### PR TITLE
Medians

### DIFF
--- a/TLM/TLM/Manager/Impl/RoutingManager.cs
+++ b/TLM/TLM/Manager/Impl/RoutingManager.cs
@@ -16,205 +16,205 @@ using TrafficManager.Util;
 using static TrafficManager.State.Flags;
 
 namespace TrafficManager.Manager.Impl {
-	public class RoutingManager : AbstractGeometryObservingManager, IRoutingManager {
-		public static readonly RoutingManager Instance = new RoutingManager();
+    public class RoutingManager : AbstractGeometryObservingManager, IRoutingManager {
+        public static readonly RoutingManager Instance = new RoutingManager();
 
-		public const NetInfo.LaneType ROUTED_LANE_TYPES = NetInfo.LaneType.Vehicle | NetInfo.LaneType.TransportVehicle;
-		public const VehicleInfo.VehicleType ROUTED_VEHICLE_TYPES = VehicleInfo.VehicleType.Car | VehicleInfo.VehicleType.Metro | VehicleInfo.VehicleType.Train | VehicleInfo.VehicleType.Tram | VehicleInfo.VehicleType.Monorail;
-		public const VehicleInfo.VehicleType ARROW_VEHICLE_TYPES = VehicleInfo.VehicleType.Car;
+        public const NetInfo.LaneType ROUTED_LANE_TYPES = NetInfo.LaneType.Vehicle | NetInfo.LaneType.TransportVehicle;
+        public const VehicleInfo.VehicleType ROUTED_VEHICLE_TYPES = VehicleInfo.VehicleType.Car | VehicleInfo.VehicleType.Metro | VehicleInfo.VehicleType.Train | VehicleInfo.VehicleType.Tram | VehicleInfo.VehicleType.Monorail;
+        public const VehicleInfo.VehicleType ARROW_VEHICLE_TYPES = VehicleInfo.VehicleType.Car;
 
-		private const byte MAX_NUM_TRANSITIONS = 64;
+        private const byte MAX_NUM_TRANSITIONS = 64;
 
-		/// <summary>
-		/// Structs for path-finding that contain required segment-related routing data
-		/// </summary>
-		public SegmentRoutingData[] segmentRoutings = new SegmentRoutingData[NetManager.MAX_SEGMENT_COUNT];
+        /// <summary>
+        /// Structs for path-finding that contain required segment-related routing data
+        /// </summary>
+        public SegmentRoutingData[] segmentRoutings = new SegmentRoutingData[NetManager.MAX_SEGMENT_COUNT];
 
-		/// <summary>
-		/// Structs for path-finding that contain required lane-end-related backward routing data.
-		/// Index:
-		///		[0 .. NetManager.MAX_LANE_COUNT-1]: lane ends at start node
-		///		[NetManager.MAX_LANE_COUNT .. 2*NetManger.MAX_LANE_COUNT-1]: lane ends at end node
-		/// </summary>
-		public LaneEndRoutingData[] laneEndBackwardRoutings = new LaneEndRoutingData[(uint)NetManager.MAX_LANE_COUNT * 2u];
+        /// <summary>
+        /// Structs for path-finding that contain required lane-end-related backward routing data.
+        /// Index:
+        ///		[0 .. NetManager.MAX_LANE_COUNT-1]: lane ends at start node
+        ///		[NetManager.MAX_LANE_COUNT .. 2*NetManger.MAX_LANE_COUNT-1]: lane ends at end node
+        /// </summary>
+        public LaneEndRoutingData[] laneEndBackwardRoutings = new LaneEndRoutingData[(uint)NetManager.MAX_LANE_COUNT * 2u];
 
-		/// <summary>
-		/// Structs for path-finding that contain required lane-end-related forward routing data.
-		/// Index:
-		///		[0 .. NetManager.MAX_LANE_COUNT-1]: lane ends at start node
-		///		[NetManager.MAX_LANE_COUNT .. 2*NetManger.MAX_LANE_COUNT-1]: lane ends at end node
-		/// </summary>
-		public LaneEndRoutingData[] laneEndForwardRoutings = new LaneEndRoutingData[(uint)NetManager.MAX_LANE_COUNT * 2u];
+        /// <summary>
+        /// Structs for path-finding that contain required lane-end-related forward routing data.
+        /// Index:
+        ///		[0 .. NetManager.MAX_LANE_COUNT-1]: lane ends at start node
+        ///		[NetManager.MAX_LANE_COUNT .. 2*NetManger.MAX_LANE_COUNT-1]: lane ends at end node
+        /// </summary>
+        public LaneEndRoutingData[] laneEndForwardRoutings = new LaneEndRoutingData[(uint)NetManager.MAX_LANE_COUNT * 2u];
 
-		protected bool segmentsUpdated = false;
-		protected ulong[] updatedSegmentBuckets = new ulong[576];
-		protected object updateLock = new object();
+        protected bool segmentsUpdated = false;
+        protected ulong[] updatedSegmentBuckets = new ulong[576];
+        protected object updateLock = new object();
 
-		protected override void InternalPrintDebugInfo() {
-			base.InternalPrintDebugInfo();
-			String buf = $"Segment routings:\n";
-			for (int i = 0; i < segmentRoutings.Length; ++i) {
-				if (!Services.NetService.IsSegmentValid((ushort)i)) {
-					continue;
-				}
-				buf += $"Segment {i}: {segmentRoutings[i]}\n";
-			}
-			buf += $"\nLane end backward routings:\n";
-			for (uint laneId = 0; laneId < NetManager.MAX_LANE_COUNT; ++laneId) {
-				if (!Services.NetService.IsLaneValid(laneId)) {
-					continue;
-				}
-				buf += $"Lane {laneId} @ start: {laneEndBackwardRoutings[GetLaneEndRoutingIndex(laneId, true)]}\n";
-				buf += $"Lane {laneId} @ end: {laneEndBackwardRoutings[GetLaneEndRoutingIndex(laneId, false)]}\n";
-			}
-			buf += $"\nLane end forward routings:\n";
-			for (uint laneId = 0; laneId < NetManager.MAX_LANE_COUNT; ++laneId) {
-				if (!Services.NetService.IsLaneValid(laneId)) {
-					continue;
-				}
-				buf += $"Lane {laneId} @ start: {laneEndForwardRoutings[GetLaneEndRoutingIndex(laneId, true)]}\n";
-				buf += $"Lane {laneId} @ end: {laneEndForwardRoutings[GetLaneEndRoutingIndex(laneId, false)]}\n";
-			}
-			Log._Debug(buf);
-		}
+        protected override void InternalPrintDebugInfo() {
+            base.InternalPrintDebugInfo();
+            String buf = $"Segment routings:\n";
+            for (int i = 0; i < segmentRoutings.Length; ++i) {
+                if (!Services.NetService.IsSegmentValid((ushort)i)) {
+                    continue;
+                }
+                buf += $"Segment {i}: {segmentRoutings[i]}\n";
+            }
+            buf += $"\nLane end backward routings:\n";
+            for (uint laneId = 0; laneId < NetManager.MAX_LANE_COUNT; ++laneId) {
+                if (!Services.NetService.IsLaneValid(laneId)) {
+                    continue;
+                }
+                buf += $"Lane {laneId} @ start: {laneEndBackwardRoutings[GetLaneEndRoutingIndex(laneId, true)]}\n";
+                buf += $"Lane {laneId} @ end: {laneEndBackwardRoutings[GetLaneEndRoutingIndex(laneId, false)]}\n";
+            }
+            buf += $"\nLane end forward routings:\n";
+            for (uint laneId = 0; laneId < NetManager.MAX_LANE_COUNT; ++laneId) {
+                if (!Services.NetService.IsLaneValid(laneId)) {
+                    continue;
+                }
+                buf += $"Lane {laneId} @ start: {laneEndForwardRoutings[GetLaneEndRoutingIndex(laneId, true)]}\n";
+                buf += $"Lane {laneId} @ end: {laneEndForwardRoutings[GetLaneEndRoutingIndex(laneId, false)]}\n";
+            }
+            Log._Debug(buf);
+        }
 
-		private RoutingManager() {
+        private RoutingManager() {
 
-		}
+        }
 
-		public void SimulationStep() {
-			if (!segmentsUpdated || Singleton<NetManager>.instance.m_segmentsUpdated || Singleton<NetManager>.instance.m_nodesUpdated) { // TODO maybe refactor NetManager use (however this could influence performance)
-				return;
-			}
+        public void SimulationStep() {
+            if (!segmentsUpdated || Singleton<NetManager>.instance.m_segmentsUpdated || Singleton<NetManager>.instance.m_nodesUpdated) { // TODO maybe refactor NetManager use (however this could influence performance)
+                return;
+            }
 
-			try {
-				Monitor.Enter(updateLock);
-				segmentsUpdated = false;
+            try {
+                Monitor.Enter(updateLock);
+                segmentsUpdated = false;
 
-				int len = updatedSegmentBuckets.Length;
-				for (int i = 0; i < len; i++) {
-					ulong segMask = updatedSegmentBuckets[i];
-					if (segMask != 0uL) {
-						for (int m = 0; m < 64; m++) {
-							if ((segMask & 1uL << m) != 0uL) {
-								ushort segmentId = (ushort)(i << 6 | m);
-								RecalculateSegment(segmentId);
-							}
-						}
-						updatedSegmentBuckets[i] = 0;
-					}
-				}
-			} finally {
-				Monitor.Exit(updateLock);
-			}
-		}
+                int len = updatedSegmentBuckets.Length;
+                for (int i = 0; i < len; i++) {
+                    ulong segMask = updatedSegmentBuckets[i];
+                    if (segMask != 0uL) {
+                        for (int m = 0; m < 64; m++) {
+                            if ((segMask & 1uL << m) != 0uL) {
+                                ushort segmentId = (ushort)(i << 6 | m);
+                                RecalculateSegment(segmentId);
+                            }
+                        }
+                        updatedSegmentBuckets[i] = 0;
+                    }
+                }
+            } finally {
+                Monitor.Exit(updateLock);
+            }
+        }
 
-		public void RequestFullRecalculation() {
-			try {
-				Monitor.Enter(updateLock);
+        public void RequestFullRecalculation() {
+            try {
+                Monitor.Enter(updateLock);
 
-				for (uint segmentId = 0; segmentId < NetManager.MAX_SEGMENT_COUNT; ++segmentId) {
-					updatedSegmentBuckets[segmentId >> 6] |= 1uL << (int)(segmentId & 63);
-				}
-				Flags.clearHighwayLaneArrows();
-				segmentsUpdated = true;
+                for (uint segmentId = 0; segmentId < NetManager.MAX_SEGMENT_COUNT; ++segmentId) {
+                    updatedSegmentBuckets[segmentId >> 6] |= 1uL << (int)(segmentId & 63);
+                }
+                Flags.clearHighwayLaneArrows();
+                segmentsUpdated = true;
 
-				if (Services.SimulationService.SimulationPaused || Services.SimulationService.ForcedSimulationPaused) {
-					SimulationStep();
-				}
-			} finally {
-				Monitor.Exit(updateLock);
-			}
-		}
+                if (Services.SimulationService.SimulationPaused || Services.SimulationService.ForcedSimulationPaused) {
+                    SimulationStep();
+                }
+            } finally {
+                Monitor.Exit(updateLock);
+            }
+        }
 
-		public void RequestRecalculation(ushort segmentId, bool propagate = true) {
+        public void RequestRecalculation(ushort segmentId, bool propagate = true) {
 #if DEBUG
-			bool debug = GlobalConfig.Instance.Debug.Switches[1] && (GlobalConfig.Instance.Debug.SegmentId <= 0 || GlobalConfig.Instance.Debug.SegmentId == segmentId);
-			if (debug) {
-				Log._Debug($"RoutingManager.RequestRecalculation({segmentId}, {propagate}) called.");
-			}
+            bool debug = GlobalConfig.Instance.Debug.Switches[1] && (GlobalConfig.Instance.Debug.SegmentId <= 0 || GlobalConfig.Instance.Debug.SegmentId == segmentId);
+            if (debug) {
+                Log._Debug($"RoutingManager.RequestRecalculation({segmentId}, {propagate}) called.");
+            }
 #endif
 
-			try {
-				Monitor.Enter(updateLock);
+            try {
+                Monitor.Enter(updateLock);
 
-				updatedSegmentBuckets[segmentId >> 6] |= 1uL << (int)(segmentId & 63);
-				ResetIncomingHighwayLaneArrows(segmentId);
-				segmentsUpdated = true;
-			} finally {
-				Monitor.Exit(updateLock);
-			}
+                updatedSegmentBuckets[segmentId >> 6] |= 1uL << (int)(segmentId & 63);
+                ResetIncomingHighwayLaneArrows(segmentId);
+                segmentsUpdated = true;
+            } finally {
+                Monitor.Exit(updateLock);
+            }
 
-			if (propagate) {
-				SegmentGeometry segGeo = SegmentGeometry.Get(segmentId);
-				if (segGeo == null) {
-					return;
-				}
+            if (propagate) {
+                SegmentGeometry segGeo = SegmentGeometry.Get(segmentId);
+                if (segGeo == null) {
+                    return;
+                }
 
-				foreach (ushort otherSegmentId in segGeo.GetConnectedSegments(true)) {
-					if (otherSegmentId == 0) {
-						continue;
-					}
+                foreach (ushort otherSegmentId in segGeo.GetConnectedSegments(true)) {
+                    if (otherSegmentId == 0) {
+                        continue;
+                    }
 
-					RequestRecalculation(otherSegmentId, false);
-				}
+                    RequestRecalculation(otherSegmentId, false);
+                }
 
-				foreach (ushort otherSegmentId in segGeo.GetConnectedSegments(false)) {
-					if (otherSegmentId == 0) {
-						continue;
-					}
+                foreach (ushort otherSegmentId in segGeo.GetConnectedSegments(false)) {
+                    if (otherSegmentId == 0) {
+                        continue;
+                    }
 
-					RequestRecalculation(otherSegmentId, false);
-				}
-			}
-		}
+                    RequestRecalculation(otherSegmentId, false);
+                }
+            }
+        }
 
-		protected void RecalculateAll() {
+        protected void RecalculateAll() {
 #if DEBUGROUTING
 			bool debug = GlobalConfig.Instance.Debug.Switches[1];
 			Log._Debug($"RoutingManager.RecalculateAll: called");
 #endif
-			Flags.clearHighwayLaneArrows();
-			for (uint segmentId = 0; segmentId < NetManager.MAX_SEGMENT_COUNT; ++segmentId) {
-				try {
-					RecalculateSegment((ushort)segmentId);
-				} catch (Exception e) {
-					Log.Error($"An error occurred while calculating routes for segment {segmentId}: {e}");
-				}
-			}
-		}
+            Flags.clearHighwayLaneArrows();
+            for (uint segmentId = 0; segmentId < NetManager.MAX_SEGMENT_COUNT; ++segmentId) {
+                try {
+                    RecalculateSegment((ushort)segmentId);
+                } catch (Exception e) {
+                    Log.Error($"An error occurred while calculating routes for segment {segmentId}: {e}");
+                }
+            }
+        }
 
-		protected void RecalculateSegment(ushort segmentId) {
+        protected void RecalculateSegment(ushort segmentId) {
 #if DEBUGROUTING
 			bool debug = GlobalConfig.Instance.Debug.Switches[1] && (GlobalConfig.Instance.Debug.SegmentId <= 0 || GlobalConfig.Instance.Debug.SegmentId == segmentId);
 			if (debug)
 				Log._Debug($"RoutingManager.RecalculateSegment({segmentId}) called.");
 #endif
-			if (!Services.NetService.IsSegmentValid(segmentId)) {
+            if (!Services.NetService.IsSegmentValid(segmentId)) {
 #if DEBUGROUTING
 				if (debug)
 					Log._Debug($"RoutingManager.RecalculateSegment({segmentId}): Segment is invalid. Skipping recalculation");
 #endif
-				return;
-			}
+                return;
+            }
 
-			RecalculateSegmentRoutingData(segmentId);
+            RecalculateSegmentRoutingData(segmentId);
 
-			Services.NetService.IterateSegmentLanes(segmentId, delegate (uint laneId, ref NetLane lane, NetInfo.Lane laneInfo, ushort segId, ref NetSegment segment, byte laneIndex) {
-				RecalculateLaneEndRoutingData(segmentId, laneIndex, laneId, true);
-				RecalculateLaneEndRoutingData(segmentId, laneIndex, laneId, false);
+            Services.NetService.IterateSegmentLanes(segmentId, delegate (uint laneId, ref NetLane lane, NetInfo.Lane laneInfo, ushort segId, ref NetSegment segment, byte laneIndex) {
+                RecalculateLaneEndRoutingData(segmentId, laneIndex, laneId, true);
+                RecalculateLaneEndRoutingData(segmentId, laneIndex, laneId, false);
 
-				return true;
-			});
-		}
+                return true;
+            });
+        }
 
-		protected void ResetIncomingHighwayLaneArrows(ushort segmentId) {
-			ushort[] nodeIds = new ushort[2];
-			Services.NetService.ProcessSegment(segmentId, delegate (ushort segId, ref NetSegment segment) {
-				nodeIds[0] = segment.m_startNode;
-				nodeIds[1] = segment.m_endNode;
-				return true;
-			});
+        protected void ResetIncomingHighwayLaneArrows(ushort segmentId) {
+            ushort[] nodeIds = new ushort[2];
+            Services.NetService.ProcessSegment(segmentId, delegate (ushort segId, ref NetSegment segment) {
+                nodeIds[0] = segment.m_startNode;
+                nodeIds[1] = segment.m_endNode;
+                return true;
+            });
 
 #if DEBUGROUTING
 			bool debug = GlobalConfig.Instance.Debug.Switches[1] && (GlobalConfig.Instance.Debug.SegmentId <= 0 || GlobalConfig.Instance.Debug.SegmentId == segmentId);
@@ -222,52 +222,52 @@ namespace TrafficManager.Manager.Impl {
 				Log._Debug($"RoutingManager.ResetRoutingData: Identify nodes connected to {segmentId}: nodeIds={nodeIds.ArrayToString()}");
 #endif
 
-			// reset highway lane arrows on all incoming lanes
-			foreach (ushort nodeId in nodeIds) {
-				if (nodeId == 0) {
-					continue;
-				}
+            // reset highway lane arrows on all incoming lanes
+            foreach (ushort nodeId in nodeIds) {
+                if (nodeId == 0) {
+                    continue;
+                }
 
-				Services.NetService.IterateNodeSegments(nodeId, delegate (ushort segId, ref NetSegment segment) {
-					if (segId == segmentId) {
-						return true;
-					}
+                Services.NetService.IterateNodeSegments(nodeId, delegate (ushort segId, ref NetSegment segment) {
+                    if (segId == segmentId) {
+                        return true;
+                    }
 
-					Services.NetService.IterateSegmentLanes(segId, delegate (uint laneId, ref NetLane lane, NetInfo.Lane laneInfo, ushort sId, ref NetSegment seg, byte laneIndex) {
-						if (IsIncomingLane(segId, seg.m_startNode == nodeId, laneIndex)) {
-							Flags.removeHighwayLaneArrowFlags(laneId);
-						}
-						return true;
-					});
-					return true;
-				});
-			}
-		}
+                    Services.NetService.IterateSegmentLanes(segId, delegate (uint laneId, ref NetLane lane, NetInfo.Lane laneInfo, ushort sId, ref NetSegment seg, byte laneIndex) {
+                        if (IsIncomingLane(segId, seg.m_startNode == nodeId, laneIndex)) {
+                            Flags.removeHighwayLaneArrowFlags(laneId);
+                        }
+                        return true;
+                    });
+                    return true;
+                });
+            }
+        }
 
-		protected void ResetRoutingData(ushort segmentId) {
+        protected void ResetRoutingData(ushort segmentId) {
 #if DEBUGROUTING
 			bool debugBasic = GlobalConfig.Instance.Debug.Switches[1] && (GlobalConfig.Instance.Debug.SegmentId <= 0 || GlobalConfig.Instance.Debug.SegmentId == segmentId);
 			bool debugFine = GlobalConfig.Instance.Debug.Switches[8] && (GlobalConfig.Instance.Debug.SegmentId <= 0 || GlobalConfig.Instance.Debug.SegmentId == segmentId);
 			if (debugBasic)
 				Log._Debug($"RoutingManager.ResetRoutingData: called for segment {segmentId}");
 #endif
-			segmentRoutings[segmentId].Reset();
+            segmentRoutings[segmentId].Reset();
 
-			ResetIncomingHighwayLaneArrows(segmentId);
+            ResetIncomingHighwayLaneArrows(segmentId);
 
-			Services.NetService.IterateSegmentLanes(segmentId, delegate (uint laneId, ref NetLane lane, NetInfo.Lane laneInfo, ushort segId, ref NetSegment segment, byte laneIndex) {
+            Services.NetService.IterateSegmentLanes(segmentId, delegate (uint laneId, ref NetLane lane, NetInfo.Lane laneInfo, ushort segId, ref NetSegment segment, byte laneIndex) {
 #if DEBUGROUTING
 				if (debugFine)
 					Log._Debug($"RoutingManager.ResetRoutingData: Resetting lane {laneId}, idx {laneIndex} @ seg. {segmentId}");
 #endif
-				ResetLaneRoutings(laneId, true);
-				ResetLaneRoutings(laneId, false);
+                ResetLaneRoutings(laneId, true);
+                ResetLaneRoutings(laneId, false);
 
-				return true;
-			});
-		}
+                return true;
+            });
+        }
 
-		protected void RecalculateSegmentRoutingData(ushort segmentId) {
+        protected void RecalculateSegmentRoutingData(ushort segmentId) {
 #if DEBUGROUTING
 			bool debugBasic = GlobalConfig.Instance.Debug.Switches[1] && (GlobalConfig.Instance.Debug.SegmentId <= 0 || GlobalConfig.Instance.Debug.SegmentId == segmentId);
 			bool debugFine = GlobalConfig.Instance.Debug.Switches[8] && (GlobalConfig.Instance.Debug.SegmentId <= 0 || GlobalConfig.Instance.Debug.SegmentId == segmentId);
@@ -275,24 +275,24 @@ namespace TrafficManager.Manager.Impl {
 				Log._Debug($"RoutingManager.RecalculateSegmentRoutingData: called for seg. {segmentId}");
 #endif
 
-			segmentRoutings[segmentId].Reset();
+            segmentRoutings[segmentId].Reset();
 
-			SegmentGeometry segGeo = SegmentGeometry.Get(segmentId);
-			if (segGeo == null) {
-				return;
-			}
+            SegmentGeometry segGeo = SegmentGeometry.Get(segmentId);
+            if (segGeo == null) {
+                return;
+            }
 
-			segmentRoutings[segmentId].highway = segGeo.IsHighway();
-			segmentRoutings[segmentId].startNodeOutgoingOneWay = segGeo.IsOutgoingOneWay(true);
-			segmentRoutings[segmentId].endNodeOutgoingOneWay = segGeo.IsOutgoingOneWay(false);
+            segmentRoutings[segmentId].highway = segGeo.IsHighway();
+            segmentRoutings[segmentId].startNodeOutgoingOneWay = segGeo.IsOutgoingOneWay(true);
+            segmentRoutings[segmentId].endNodeOutgoingOneWay = segGeo.IsOutgoingOneWay(false);
 
 #if DEBUGROUTING
 			if (debugBasic)
 				Log._Debug($"RoutingManager.RecalculateSegmentRoutingData: Calculated routing data for segment {segmentId}: {segmentRoutings[segmentId]}");
 #endif
-		}
+        }
 
-		protected void RecalculateLaneEndRoutingData(ushort segmentId, int laneIndex, uint laneId, bool startNode) {
+        protected void RecalculateLaneEndRoutingData(ushort segmentId, int laneIndex, uint laneId, bool startNode) {
 #if DEBUGROUTING
 			bool debugBasic = GlobalConfig.Instance.Debug.Switches[1] && (GlobalConfig.Instance.Debug.SegmentId <= 0 || GlobalConfig.Instance.Debug.SegmentId == segmentId);
 			bool debugFine = GlobalConfig.Instance.Debug.Switches[8] && (GlobalConfig.Instance.Debug.SegmentId <= 0 || GlobalConfig.Instance.Debug.SegmentId == segmentId);
@@ -300,92 +300,92 @@ namespace TrafficManager.Manager.Impl {
 				Log._Debug($"RoutingManager.RecalculateLaneEndRoutingData({segmentId}, {laneIndex}, {laneId}, {startNode}) called");
 #endif
 
-			ResetLaneRoutings(laneId, startNode);
+            ResetLaneRoutings(laneId, startNode);
 
-			if (!IsOutgoingLane(segmentId, startNode, laneIndex)) {
+            if (!IsOutgoingLane(segmentId, startNode, laneIndex)) {
 #if DEBUGROUTING
 				if (debugFine)
 					Log._Debug($"RoutingManager.RecalculateLaneEndRoutingData({segmentId}, {laneIndex}, {laneId}, {startNode}): Lane is not an outgoing lane");
 #endif
-				return;
-			}
+                return;
+            }
 
-			bool prevIsMergeLane = Constants.ServiceFactory.NetService.CheckLaneFlags(laneId, NetLane.Flags.Merge);
+            bool prevIsMergeLane = Constants.ServiceFactory.NetService.CheckLaneFlags(laneId, NetLane.Flags.Merge);
 
-			NetInfo prevSegmentInfo = null;
-			bool prevSegIsInverted = false;
-			Constants.ServiceFactory.NetService.ProcessSegment(segmentId, delegate (ushort prevSegId, ref NetSegment segment) {
-				prevSegmentInfo = segment.Info;
-				prevSegIsInverted = (segment.m_flags & NetSegment.Flags.Invert) != NetSegment.Flags.None;
-				return true;
-			});
+            NetInfo prevSegmentInfo = null;
+            bool prevSegIsInverted = false;
+            Constants.ServiceFactory.NetService.ProcessSegment(segmentId, delegate (ushort prevSegId, ref NetSegment segment) {
+                prevSegmentInfo = segment.Info;
+                prevSegIsInverted = (segment.m_flags & NetSegment.Flags.Invert) != NetSegment.Flags.None;
+                return true;
+            });
 
-			bool leftHandDrive = Constants.ServiceFactory.SimulationService.LeftHandDrive;
+            bool leftHandDrive = Constants.ServiceFactory.SimulationService.LeftHandDrive;
 
-			SegmentGeometry prevSegGeo = SegmentGeometry.Get(segmentId);
-			if (prevSegGeo == null) {
+            SegmentGeometry prevSegGeo = SegmentGeometry.Get(segmentId);
+            if (prevSegGeo == null) {
 #if DEBUGROUTING
 				if (debugFine)
 					Log._Debug($"RoutingManager.RecalculateLaneEndRoutingData({segmentId}, {laneIndex}, {laneId}, {startNode}): No segment geometry found");
 #endif
-				//Log.Warning($"RoutingManager.RecalculateLaneEndRoutingData({segmentId}, {laneIndex}, {laneId}, {startNode}): prevSegGeo for segment {segmentId} is null");
-				return;
-			}
-			SegmentEndGeometry prevEndGeo = prevSegGeo.GetEnd(startNode);
-			if (prevEndGeo == null) {
+                //Log.Warning($"RoutingManager.RecalculateLaneEndRoutingData({segmentId}, {laneIndex}, {laneId}, {startNode}): prevSegGeo for segment {segmentId} is null");
+                return;
+            }
+            SegmentEndGeometry prevEndGeo = prevSegGeo.GetEnd(startNode);
+            if (prevEndGeo == null) {
 #if DEBUGROUTING
 				if (debugFine)
 					Log._Debug($"RoutingManager.RecalculateLaneEndRoutingData({segmentId}, {laneIndex}, {laneId}, {startNode}): No segment end geometry found");
 #endif
-				return;
-			}
+                return;
+            }
 
-			ushort prevSegmentId = segmentId;
-			int prevLaneIndex = laneIndex;
-			uint prevLaneId = laneId;
-			ushort nextNodeId = prevEndGeo.NodeId();
+            ushort prevSegmentId = segmentId;
+            int prevLaneIndex = laneIndex;
+            uint prevLaneId = laneId;
+            ushort nextNodeId = prevEndGeo.NodeId();
 
-			NetInfo.Lane prevLaneInfo = prevSegmentInfo.m_lanes[prevLaneIndex];
-			if (!prevLaneInfo.CheckType(ROUTED_LANE_TYPES, ROUTED_VEHICLE_TYPES)) {
-				return;
-			}
-			LaneEndRoutingData backwardRouting = new LaneEndRoutingData();
-			backwardRouting.routed = true;
+            NetInfo.Lane prevLaneInfo = prevSegmentInfo.m_lanes[prevLaneIndex];
+            if (!prevLaneInfo.CheckType(ROUTED_LANE_TYPES, ROUTED_VEHICLE_TYPES)) {
+                return;
+            }
+            LaneEndRoutingData backwardRouting = new LaneEndRoutingData();
+            backwardRouting.routed = true;
 
-			int prevSimilarLaneCount = prevLaneInfo.m_similarLaneCount;
-			int prevInnerSimilarLaneIndex = CalcInnerSimilarLaneIndex(prevSegmentId, prevLaneIndex);
-			int prevOuterSimilarLaneIndex = CalcOuterSimilarLaneIndex(prevSegmentId, prevLaneIndex);
-			bool prevHasBusLane = prevSegGeo.HasBusLane();
+            int prevSimilarLaneCount = prevLaneInfo.m_similarLaneCount;
+            int prevInnerSimilarLaneIndex = CalcInnerSimilarLaneIndex(prevSegmentId, prevLaneIndex);
+            int prevOuterSimilarLaneIndex = CalcOuterSimilarLaneIndex(prevSegmentId, prevLaneIndex);
+            bool prevHasBusLane = prevSegGeo.HasBusLane();
 
-			bool nextIsJunction = false;
-			bool nextIsTransition = false;
-			bool nextIsEndOrOneWayOut = false;
-			bool nextHasTrafficLights = false;
-			Constants.ServiceFactory.NetService.ProcessNode(nextNodeId, delegate (ushort nodeId, ref NetNode node) {
-				nextIsJunction = (node.m_flags & NetNode.Flags.Junction) != NetNode.Flags.None;
-				nextIsTransition = (node.m_flags & NetNode.Flags.Transition) != NetNode.Flags.None;
-				nextHasTrafficLights = (node.m_flags & NetNode.Flags.TrafficLights) != NetNode.Flags.None;
-				nextIsEndOrOneWayOut = (node.m_flags & (NetNode.Flags.End | NetNode.Flags.OneWayOut)) != NetNode.Flags.None;
-				return true;
-			});
+            bool nextIsJunction = false;
+            bool nextIsTransition = false;
+            bool nextIsEndOrOneWayOut = false;
+            bool nextHasTrafficLights = false;
+            Constants.ServiceFactory.NetService.ProcessNode(nextNodeId, delegate (ushort nodeId, ref NetNode node) {
+                nextIsJunction = (node.m_flags & NetNode.Flags.Junction) != NetNode.Flags.None;
+                nextIsTransition = (node.m_flags & NetNode.Flags.Transition) != NetNode.Flags.None;
+                nextHasTrafficLights = (node.m_flags & NetNode.Flags.TrafficLights) != NetNode.Flags.None;
+                nextIsEndOrOneWayOut = (node.m_flags & (NetNode.Flags.End | NetNode.Flags.OneWayOut)) != NetNode.Flags.None;
+                return true;
+            });
 
-			bool nextIsSimpleJunction = false;
-			bool nextIsSplitJunction = false;
-			if (Options.highwayRules && !nextHasTrafficLights) {
-				// determine if junction is a simple junction (highway rules only apply to simple junctions)
-				NodeGeometry nodeGeo = NodeGeometry.Get(nextNodeId);
-				nextIsSimpleJunction = nodeGeo.IsSimpleJunction;
-				nextIsSplitJunction = nodeGeo.OutgoingSegments > 1;
-			}
-			bool isNextRealJunction = prevSegGeo.CountOtherSegments(startNode) > 1;
-			bool nextAreOnlyOneWayHighways = prevEndGeo.OnlyHighways;
+            bool nextIsSimpleJunction = false;
+            bool nextIsSplitJunction = false;
+            if (Options.highwayRules && !nextHasTrafficLights) {
+                // determine if junction is a simple junction (highway rules only apply to simple junctions)
+                NodeGeometry nodeGeo = NodeGeometry.Get(nextNodeId);
+                nextIsSimpleJunction = nodeGeo.IsSimpleJunction;
+                nextIsSplitJunction = nodeGeo.OutgoingSegments > 1;
+            }
+            bool isNextRealJunction = prevSegGeo.CountOtherSegments(startNode) > 1;
+            bool nextAreOnlyOneWayHighways = prevEndGeo.OnlyHighways;
 
-			// determine if highway rules should be applied
-			bool onHighway = Options.highwayRules && nextAreOnlyOneWayHighways && prevEndGeo.OutgoingOneWay && prevSegGeo.IsHighway();
-			bool applyHighwayRules = onHighway && nextIsSimpleJunction;
-			bool applyHighwayRulesAtJunction = applyHighwayRules && isNextRealJunction;
-			bool iterateViaGeometry = applyHighwayRulesAtJunction && prevLaneInfo.CheckType(ROUTED_LANE_TYPES, ARROW_VEHICLE_TYPES);
-			ushort nextSegmentId = iterateViaGeometry ? segmentId : (ushort)0; // start with u-turns at highway junctions
+            // determine if highway rules should be applied
+            bool onHighway = Options.highwayRules && nextAreOnlyOneWayHighways && prevEndGeo.OutgoingOneWay && prevSegGeo.IsHighway();
+            bool applyHighwayRules = onHighway && nextIsSimpleJunction;
+            bool applyHighwayRulesAtJunction = applyHighwayRules && isNextRealJunction;
+            bool iterateViaGeometry = applyHighwayRulesAtJunction && prevLaneInfo.CheckType(ROUTED_LANE_TYPES, ARROW_VEHICLE_TYPES);
+            ushort nextSegmentId = iterateViaGeometry ? segmentId : (ushort)0; // start with u-turns at highway junctions
 
 #if DEBUGROUTING
 			if (debugFine) {
@@ -396,43 +396,43 @@ namespace TrafficManager.Manager.Impl {
 			}
 #endif
 
-			int totalIncomingLanes = 0; // running number of next incoming lanes (number is updated at each segment iteration)
-			int totalOutgoingLanes = 0; // running number of next outgoing lanes (number is updated at each segment iteration)
+            int totalIncomingLanes = 0; // running number of next incoming lanes (number is updated at each segment iteration)
+            int totalOutgoingLanes = 0; // running number of next outgoing lanes (number is updated at each segment iteration)
 
-			for (int k = 0; k < 8; ++k) {
-				if (!iterateViaGeometry) {
-					Constants.ServiceFactory.NetService.ProcessNode(nextNodeId, delegate (ushort nId, ref NetNode node) {
-						nextSegmentId = node.GetSegment(k);
-						return true;
-					});
+            for (int k = 0; k < 8; ++k) {
+                if (!iterateViaGeometry) {
+                    Constants.ServiceFactory.NetService.ProcessNode(nextNodeId, delegate (ushort nId, ref NetNode node) {
+                        nextSegmentId = node.GetSegment(k);
+                        return true;
+                    });
 
-					if (nextSegmentId == 0) {
-						continue;
-					}
-				}
+                    if (nextSegmentId == 0) {
+                        continue;
+                    }
+                }
 
-				int outgoingVehicleLanes = 0;
-				int incomingVehicleLanes = 0;
+                int outgoingVehicleLanes = 0;
+                int incomingVehicleLanes = 0;
 
-				bool isNextStartNodeOfNextSegment = false;
-				bool nextSegIsInverted = false;
-				NetInfo nextSegmentInfo = null;
-				uint nextFirstLaneId = 0;
-				Constants.ServiceFactory.NetService.ProcessSegment(nextSegmentId, delegate (ushort nextSegId, ref NetSegment segment) {
-					isNextStartNodeOfNextSegment = segment.m_startNode == nextNodeId;
-					/*segment.UpdateLanes(nextSegmentId, true);
+                bool isNextStartNodeOfNextSegment = false;
+                bool nextSegIsInverted = false;
+                NetInfo nextSegmentInfo = null;
+                uint nextFirstLaneId = 0;
+                Constants.ServiceFactory.NetService.ProcessSegment(nextSegmentId, delegate (ushort nextSegId, ref NetSegment segment) {
+                    isNextStartNodeOfNextSegment = segment.m_startNode == nextNodeId;
+                    /*segment.UpdateLanes(nextSegmentId, true);
 					if (isNextStartNodeOfNextSegment) {
 						segment.UpdateStartSegments(nextSegmentId);
 					} else {
 						segment.UpdateEndSegments(nextSegmentId);
 					}*/
-					nextSegmentInfo = segment.Info;
-					nextSegIsInverted = (segment.m_flags & NetSegment.Flags.Invert) != NetSegment.Flags.None;
-					nextFirstLaneId = segment.m_lanes;
-					return true;
-				});
-				bool nextIsHighway = SegmentGeometry.calculateIsHighway(nextSegmentInfo);
-				bool nextHasBusLane = SegmentGeometry.calculateHasBusLane(nextSegmentInfo);
+                    nextSegmentInfo = segment.Info;
+                    nextSegIsInverted = (segment.m_flags & NetSegment.Flags.Invert) != NetSegment.Flags.None;
+                    nextFirstLaneId = segment.m_lanes;
+                    return true;
+                });
+                bool nextIsHighway = SegmentGeometry.calculateIsHighway(nextSegmentInfo);
+                bool nextHasBusLane = SegmentGeometry.calculateHasBusLane(nextSegmentInfo);
 
 #if DEBUGROUTING
 				if (debugFine) {
@@ -441,9 +441,9 @@ namespace TrafficManager.Manager.Impl {
 				}
 #endif
 
-				// determine next segment direction by evaluating the geometry information
-				ArrowDirection nextIncomingDir = prevEndGeo.GetDirection(nextSegmentId);
-				bool isNextSegmentValid = nextIncomingDir != ArrowDirection.None;
+                // determine next segment direction by evaluating the geometry information
+                ArrowDirection nextIncomingDir = prevEndGeo.GetDirection(nextSegmentId);
+                bool isNextSegmentValid = nextIncomingDir != ArrowDirection.None;
 
 #if DEBUGROUTING
 				if (debugFine)
@@ -451,79 +451,105 @@ namespace TrafficManager.Manager.Impl {
 #endif
 
 
-				NetInfo.Direction nextDir = isNextStartNodeOfNextSegment ? NetInfo.Direction.Backward : NetInfo.Direction.Forward;
-				NetInfo.Direction nextDir2 = !nextSegIsInverted ? nextDir : NetInfo.InvertDirection(nextDir);
+                NetInfo.Direction nextDir = isNextStartNodeOfNextSegment ? NetInfo.Direction.Backward : NetInfo.Direction.Forward;
+                NetInfo.Direction nextDir2 = !nextSegIsInverted ? nextDir : NetInfo.InvertDirection(nextDir);
 
-				LaneTransitionData[] nextRelaxedTransitionDatas = null;
-				byte numNextRelaxedTransitionDatas = 0;
-				LaneTransitionData[] nextCompatibleTransitionDatas = null;
-				int[] nextCompatibleOuterSimilarIndices = null;
-				byte numNextCompatibleTransitionDatas = 0;
-				LaneTransitionData[] nextLaneConnectionTransitionDatas = null;
-				byte numNextLaneConnectionTransitionDatas = 0;
-				LaneTransitionData[] nextForcedTransitionDatas = null;
-				byte numNextForcedTransitionDatas = 0;
-				int[] nextCompatibleTransitionDataIndices = null;
-				byte numNextCompatibleTransitionDataIndices = 0;
-				int[] compatibleLaneIndexToLaneConnectionIndex = null;
+                LaneTransitionData[] nextRelaxedTransitionDatas = null;
+                byte numNextRelaxedTransitionDatas = 0;
+                LaneTransitionData[] nextCompatibleTransitionDatas = null;
+                int[] nextCompatibleOuterSimilarIndices = null;
+                byte numNextCompatibleTransitionDatas = 0;
+                LaneTransitionData[] nextLaneConnectionTransitionDatas = null;
+                byte numNextLaneConnectionTransitionDatas = 0;
+                LaneTransitionData[] nextForcedTransitionDatas = null;
+                byte numNextForcedTransitionDatas = 0;
+                int[] nextCompatibleTransitionDataIndices = null;
+                byte numNextCompatibleTransitionDataIndices = 0;
+                int[] compatibleLaneIndexToLaneConnectionIndex = null;
 
-				if (isNextSegmentValid) {
-					nextRelaxedTransitionDatas = new LaneTransitionData[MAX_NUM_TRANSITIONS];
-					nextCompatibleTransitionDatas = new LaneTransitionData[MAX_NUM_TRANSITIONS];
-					nextLaneConnectionTransitionDatas = new LaneTransitionData[MAX_NUM_TRANSITIONS];
-					nextForcedTransitionDatas = new LaneTransitionData[MAX_NUM_TRANSITIONS];
-					nextCompatibleOuterSimilarIndices = new int[MAX_NUM_TRANSITIONS];
-					nextCompatibleTransitionDataIndices = new int[MAX_NUM_TRANSITIONS];
-					compatibleLaneIndexToLaneConnectionIndex = new int[MAX_NUM_TRANSITIONS];
-				}
+                if (isNextSegmentValid) {
+                    nextRelaxedTransitionDatas = new LaneTransitionData[MAX_NUM_TRANSITIONS];
+                    nextCompatibleTransitionDatas = new LaneTransitionData[MAX_NUM_TRANSITIONS];
+                    nextLaneConnectionTransitionDatas = new LaneTransitionData[MAX_NUM_TRANSITIONS];
+                    nextForcedTransitionDatas = new LaneTransitionData[MAX_NUM_TRANSITIONS];
+                    nextCompatibleOuterSimilarIndices = new int[MAX_NUM_TRANSITIONS];
+                    nextCompatibleTransitionDataIndices = new int[MAX_NUM_TRANSITIONS];
+                    compatibleLaneIndexToLaneConnectionIndex = new int[MAX_NUM_TRANSITIONS];
+                }
 
 
-				uint nextLaneId = nextFirstLaneId;
-				byte nextLaneIndex = 0;
-				//ushort compatibleLaneIndicesMask = 0;
+                uint nextLaneId = nextFirstLaneId;
+                byte nextLaneIndex = 0;
+                //ushort compatibleLaneIndicesMask = 0;
+                int[] laneGroups = new int[nextSegmentInfo.m_lanes.Length];
+                int prevLaneGroup = 0;
+                List<NetInfo.Lane> prevSortedLanes = prevSegmentInfo.m_lanes.OrderBy(l => l.m_position).ToList();
+                List<NetInfo.Lane> sortedLanes = nextSegmentInfo.m_lanes.OrderBy(l => l.m_position).ToList();
 
-				while (nextLaneIndex < nextSegmentInfo.m_lanes.Length && nextLaneId != 0u) {
-					// determine valid lanes based on lane arrows
-					NetInfo.Lane nextLaneInfo = nextSegmentInfo.m_lanes[nextLaneIndex];
+                if (prevSegmentInfo == nextSegmentInfo) {
+                    if (!nextIsJunction) {
+
+                        int prevLaneSortedIndex = prevSortedLanes.IndexOf(prevLaneInfo);
+                        for (byte prevLaneInx = 1; prevLaneInx <= prevLaneSortedIndex && prevLaneId != 0; prevLaneInx++) {
+                            NetInfo.Lane laneInfo = prevSortedLanes[prevLaneInx];
+                            if (laneInfo.m_finalDirection != prevSortedLanes[prevLaneInx - 1].m_finalDirection || (laneInfo.m_laneType & LaneConnectionManager.LANE_TYPES) == NetInfo.LaneType.None ||
+                            (laneInfo.m_vehicleType & LaneConnectionManager.VEHICLE_TYPES) == VehicleInfo.VehicleType.None || laneInfo.m_position > (prevSortedLanes[prevLaneInx - 1].m_position + (0.5f * prevSortedLanes[prevLaneInx - 1].m_width) + (0.5f * laneInfo.m_width) + 1)) {
+                                prevLaneGroup++;
+                            }
+                        }
+
+                        for (byte nextLaneInx = 1; nextLaneInx < sortedLanes.Count && nextLaneId != 0; nextLaneInx++) {
+                            NetInfo.Lane laneInfo = sortedLanes[nextLaneInx];
+                            laneGroups[nextLaneInx] = laneGroups[nextLaneInx - 1];
+                            if (laneInfo.m_finalDirection != sortedLanes[nextLaneInx - 1].m_finalDirection || (laneInfo.m_laneType & LaneConnectionManager.LANE_TYPES) == NetInfo.LaneType.None ||
+                            (laneInfo.m_vehicleType & LaneConnectionManager.VEHICLE_TYPES) == VehicleInfo.VehicleType.None || laneInfo.m_position > (sortedLanes[nextLaneInx - 1].m_position + (0.5f * sortedLanes[nextLaneInx - 1].m_width) + (0.5f * laneInfo.m_width) + 1)) {
+                                laneGroups[nextLaneInx]++;
+                            }
+                        }
+                    }
+                }
+                while (nextLaneIndex < nextSegmentInfo.m_lanes.Length && nextLaneId != 0u) {
+                    // determine valid lanes based on lane arrows
+                    NetInfo.Lane nextLaneInfo = nextSegmentInfo.m_lanes[nextLaneIndex];
 
 #if DEBUGROUTING
 					if (debugFine)
 						Log._Debug($"RoutingManager.RecalculateLaneEndRoutingData({segmentId}, {laneIndex}, {laneId}, {startNode}): prevSegment={segmentId}. Exploring nextSegment={nextSegmentId}, lane {nextLaneId}, idx {nextLaneIndex}");
 #endif
 
-					if (nextLaneInfo.CheckType(ROUTED_LANE_TYPES, ROUTED_VEHICLE_TYPES) &&
-						(prevLaneInfo.m_vehicleType & nextLaneInfo.m_vehicleType) != VehicleInfo.VehicleType.None
-						/*(nextLaneInfo.m_vehicleType & prevLaneInfo.m_vehicleType) != VehicleInfo.VehicleType.None &&
+                    if (nextLaneInfo.CheckType(ROUTED_LANE_TYPES, ROUTED_VEHICLE_TYPES) &&
+                        (prevLaneInfo.m_vehicleType & nextLaneInfo.m_vehicleType) != VehicleInfo.VehicleType.None
+                        /*(nextLaneInfo.m_vehicleType & prevLaneInfo.m_vehicleType) != VehicleInfo.VehicleType.None &&
 						(nextLaneInfo.m_laneType & prevLaneInfo.m_laneType) != NetInfo.LaneType.None*/) { // next is compatible lane
 #if DEBUGROUTING
 						if (debugFine)
 							Log._Debug($"RoutingManager.RecalculateLaneEndRoutingData({segmentId}, {laneIndex}, {laneId}, {startNode}): vehicle type check passed for nextLaneId={nextLaneId}, idx={nextLaneIndex}");
 #endif
-						if ((nextLaneInfo.m_finalDirection & nextDir2) != NetInfo.Direction.None) { // next is incoming lane
+                        if ((nextLaneInfo.m_finalDirection & nextDir2) != NetInfo.Direction.None) { // next is incoming lane
 #if DEBUGROUTING
 							if (debugFine)
 								Log._Debug($"RoutingManager.RecalculateLaneEndRoutingData({segmentId}, {laneIndex}, {laneId}, {startNode}): lane direction check passed for nextLaneId={nextLaneId}, idx={nextLaneIndex}");
 #endif
-							++incomingVehicleLanes;
+                            ++incomingVehicleLanes;
 
 #if DEBUGROUTING
 							if (debugFine)
 								Log._Debug($"RoutingManager.RecalculateLaneEndRoutingData({segmentId}, {laneIndex}, {laneId}, {startNode}): increasing number of incoming lanes at nextLaneId={nextLaneId}, idx={nextLaneIndex}: isNextValid={isNextSegmentValid}, nextLaneInfo.m_finalDirection={nextLaneInfo.m_finalDirection}, nextDir2={nextDir2}: incomingVehicleLanes={incomingVehicleLanes}, outgoingVehicleLanes={outgoingVehicleLanes} ");
 #endif
 
-							if (isNextSegmentValid) {
-								// calculate current similar lane index starting from outer lane
-								int nextOuterSimilarLaneIndex = CalcOuterSimilarLaneIndex(nextSegmentId, nextLaneIndex);
-								//int nextInnerSimilarLaneIndex = CalcInnerSimilarLaneIndex(nextSegmentId, nextLaneIndex);
-								bool isCompatibleLane = false;
-								LaneEndTransitionType transitionType = LaneEndTransitionType.Invalid;
+                            if (isNextSegmentValid) {
+                                // calculate current similar lane index starting from outer lane
+                                int nextOuterSimilarLaneIndex = CalcOuterSimilarLaneIndex(nextSegmentId, nextLaneIndex);
+                                //int nextInnerSimilarLaneIndex = CalcInnerSimilarLaneIndex(nextSegmentId, nextLaneIndex);
+                                bool isCompatibleLane = false;
+                                LaneEndTransitionType transitionType = LaneEndTransitionType.Invalid;
 
-								// check for lane connections
-								bool nextHasOutgoingConnections = LaneConnectionManager.Instance.HasConnections(nextLaneId, isNextStartNodeOfNextSegment);
-								bool nextIsConnectedWithPrev = true;
-								if (nextHasOutgoingConnections) {
-									nextIsConnectedWithPrev = LaneConnectionManager.Instance.AreLanesConnected(prevLaneId, nextLaneId, startNode);
-								}
+                                // check for lane connections
+                                bool nextHasOutgoingConnections = LaneConnectionManager.Instance.HasConnections(nextLaneId, isNextStartNodeOfNextSegment);
+                                bool nextIsConnectedWithPrev = true;
+                                if (nextHasOutgoingConnections) {
+                                    nextIsConnectedWithPrev = LaneConnectionManager.Instance.AreLanesConnected(prevLaneId, nextLaneId, startNode);
+                                }
 
 #if DEBUGROUTING
 								if (debugFine)
@@ -536,196 +562,199 @@ namespace TrafficManager.Manager.Impl {
 									Log._Debug($"RoutingManager.RecalculateLaneEndRoutingData({segmentId}, {laneIndex}, {laneId}, {startNode}): connection information for nextLaneId={nextLaneId}, idx={nextLaneIndex}: nextOuterSimilarLaneIndex={nextOuterSimilarLaneIndex}, nextHasOutgoingConnections={nextHasOutgoingConnections}, nextIsConnectedWithPrev={nextIsConnectedWithPrev}");
 #endif
 
-								int currentLaneConnectionTransIndex = -1;
-								if (nextHasOutgoingConnections) {
-									// check for lane connections
-									if (nextIsConnectedWithPrev) {
-										// lane is connected with previous lane
-										if (numNextLaneConnectionTransitionDatas < MAX_NUM_TRANSITIONS) {
-											currentLaneConnectionTransIndex = numNextLaneConnectionTransitionDatas;
-											nextLaneConnectionTransitionDatas[numNextLaneConnectionTransitionDatas++].Set(nextLaneId, nextLaneIndex, LaneEndTransitionType.LaneConnection, nextSegmentId, isNextStartNodeOfNextSegment);
-										} else {
-											Log.Warning($"nextTransitionDatas overflow @ source lane {prevLaneId}, idx {prevLaneIndex} @ seg. {prevSegmentId}");
-										}
+                                int currentLaneConnectionTransIndex = -1;
+                                if (nextHasOutgoingConnections) {
+                                    // check for lane connections
+                                    if (nextIsConnectedWithPrev) {
+                                        // lane is connected with previous lane
+                                        if (numNextLaneConnectionTransitionDatas < MAX_NUM_TRANSITIONS) {
+                                            currentLaneConnectionTransIndex = numNextLaneConnectionTransitionDatas;
+                                            nextLaneConnectionTransitionDatas[numNextLaneConnectionTransitionDatas++].Set(nextLaneId, nextLaneIndex, LaneEndTransitionType.LaneConnection, nextSegmentId, isNextStartNodeOfNextSegment);
+                                        } else {
+                                            Log.Warning($"nextTransitionDatas overflow @ source lane {prevLaneId}, idx {prevLaneIndex} @ seg. {prevSegmentId}");
+                                        }
 #if DEBUGROUTING
 										if (debugFine)
 											Log._Debug($"RoutingManager.RecalculateLaneEndRoutingData({segmentId}, {laneIndex}, {laneId}, {startNode}): nextLaneId={nextLaneId}, idx={nextLaneIndex} has outgoing connections and is connected with previous lane. adding as lane connection lane.");
 #endif
-									} else {
+                                    } else {
 #if DEBUGROUTING
 										if (debugFine)
 											Log._Debug($"RoutingManager.RecalculateLaneEndRoutingData({segmentId}, {laneIndex}, {laneId}, {startNode}): nextLaneId={nextLaneId}, idx={nextLaneIndex} has outgoing connections but is NOT connected with previous lane");
 #endif
-									}
-								}
-
-								if (prevIsMergeLane && Constants.ServiceFactory.NetService.CheckLaneFlags(nextLaneId, NetLane.Flags.Merge)) {
+                                    }
+                                }
+                                bool laneInValidGroup = laneGroups[sortedLanes.IndexOf(nextLaneInfo)] == prevLaneGroup;
+                                if (prevIsMergeLane && Constants.ServiceFactory.NetService.CheckLaneFlags(nextLaneId, NetLane.Flags.Merge)) {
 #if DEBUGROUTING
 									if (debugFine)
 										Log._Debug($"RoutingManager.RecalculateLaneEndRoutingData({segmentId}, {laneIndex}, {laneId}, {startNode}): nextLaneId={nextLaneId}, idx={nextLaneIndex} is a merge lane, as the previous lane. adding as Default.");
 #endif
-									if (nextOuterSimilarLaneIndex == prevOuterSimilarLaneIndex) {
+                                    if (nextOuterSimilarLaneIndex == prevOuterSimilarLaneIndex) {
 #if DEBUGROUTING
 										if (debugFine)
 											Log._Debug($"RoutingManager.RecalculateLaneEndRoutingData({segmentId}, {laneIndex}, {laneId}, {startNode}): nextLaneId={nextLaneId}, idx={nextLaneIndex} is a continuous merge lane. adding as Default.");
 #endif
-										isCompatibleLane = true;
-										transitionType = LaneEndTransitionType.Default;
-									}
-								} else if (!nextIsJunction) {
+                                        isCompatibleLane = true;
+                                        transitionType = LaneEndTransitionType.Default;
+                                    }
+                                } else if (!nextIsJunction) {
 #if DEBUGROUTING
 									if (debugFine)
 										Log._Debug($"RoutingManager.RecalculateLaneEndRoutingData({segmentId}, {laneIndex}, {laneId}, {startNode}): nextLaneId={nextLaneId}, idx={nextLaneIndex} is not a junction. adding as Default.");
 #endif
-									isCompatibleLane = true;
-									transitionType = LaneEndTransitionType.Default;
-								} else if (nextLaneInfo.CheckType(ROUTED_LANE_TYPES, ARROW_VEHICLE_TYPES)) {
-									// check for lane arrows
-									LaneArrows nextLaneArrows = LaneArrowManager.Instance.GetFinalLaneArrows(nextLaneId);
-									bool hasLeftArrow = (nextLaneArrows & LaneArrows.Left) != LaneArrows.None;
-									bool hasRightArrow = (nextLaneArrows & LaneArrows.Right) != LaneArrows.None;
-									bool hasForwardArrow = (nextLaneArrows & LaneArrows.Forward) != LaneArrows.None || (nextLaneArrows & LaneArrows.LeftForwardRight) == LaneArrows.None;
+                                    isCompatibleLane = true;
+                                    transitionType = LaneEndTransitionType.Default;
+                                } else if (nextLaneInfo.CheckType(ROUTED_LANE_TYPES, ARROW_VEHICLE_TYPES)) {
+                                    // check for lane arrows
+                                    LaneArrows nextLaneArrows = LaneArrowManager.Instance.GetFinalLaneArrows(nextLaneId);
+                                    bool hasLeftArrow = (nextLaneArrows & LaneArrows.Left) != LaneArrows.None;
+                                    bool hasRightArrow = (nextLaneArrows & LaneArrows.Right) != LaneArrows.None;
+                                    bool hasForwardArrow = (nextLaneArrows & LaneArrows.Forward) != LaneArrows.None || (nextLaneArrows & LaneArrows.LeftForwardRight) == LaneArrows.None;
 
 #if DEBUGROUTING
 									if (debugFine)
 										Log._Debug($"RoutingManager.RecalculateLaneEndRoutingData({segmentId}, {laneIndex}, {laneId}, {startNode}): start lane arrow check for nextLaneId={nextLaneId}, idx={nextLaneIndex}: hasLeftArrow={hasLeftArrow}, hasForwardArrow={hasForwardArrow}, hasRightArrow={hasRightArrow}");
 #endif
 
-									if (applyHighwayRules || // highway rules enabled
-											(nextIncomingDir == ArrowDirection.Right && hasLeftArrow) || // valid incoming right
-											(nextIncomingDir == ArrowDirection.Left && hasRightArrow) || // valid incoming left
-											(nextIncomingDir == ArrowDirection.Forward && hasForwardArrow) || // valid incoming straight
-											(nextIncomingDir == ArrowDirection.Turn && (nextIsEndOrOneWayOut || ((leftHandDrive && hasRightArrow) || (!leftHandDrive && hasLeftArrow))))) { // valid turning lane
+                                    if (applyHighwayRules || // highway rules enabled
+                                            (nextIncomingDir == ArrowDirection.Right && hasLeftArrow) || // valid incoming right
+                                            (nextIncomingDir == ArrowDirection.Left && hasRightArrow) || // valid incoming left
+                                            (nextIncomingDir == ArrowDirection.Forward && hasForwardArrow) || // valid incoming straight
+                                            (nextIncomingDir == ArrowDirection.Turn && (nextIsEndOrOneWayOut || ((leftHandDrive && hasRightArrow) || (!leftHandDrive && hasLeftArrow))))) { // valid turning lane
 #if DEBUGROUTING
 										if (debugFine)
 											Log._Debug($"RoutingManager.RecalculateLaneEndRoutingData({segmentId}, {laneIndex}, {laneId}, {startNode}): lane arrow check passed for nextLaneId={nextLaneId}, idx={nextLaneIndex}. adding as default lane.");
 #endif
-										isCompatibleLane = true;
-										transitionType = LaneEndTransitionType.Default;
-									} else if (nextIsConnectedWithPrev) {
+                                        isCompatibleLane = true;
+                                        transitionType = LaneEndTransitionType.Default;
+                                    } else if (nextIsConnectedWithPrev) {
 #if DEBUGROUTING
 										if (debugFine)
 											Log._Debug($"RoutingManager.RecalculateLaneEndRoutingData({segmentId}, {laneIndex}, {laneId}, {startNode}): lane arrow check FAILED for nextLaneId={nextLaneId}, idx={nextLaneIndex}. adding as relaxed lane.");
 #endif
 
-										// lane can be used by all vehicles that may disregard lane arrows
-										transitionType = LaneEndTransitionType.Relaxed;
-										if (numNextRelaxedTransitionDatas < MAX_NUM_TRANSITIONS) {
-											nextRelaxedTransitionDatas[numNextRelaxedTransitionDatas++].Set(nextLaneId, nextLaneIndex, transitionType, nextSegmentId, isNextStartNodeOfNextSegment, GlobalConfig.Instance.PathFinding.IncompatibleLaneDistance);
-										} else {
-											Log.Warning($"nextTransitionDatas overflow @ source lane {prevLaneId}, idx {prevLaneIndex} @ seg. {prevSegmentId}");
-										}
-									}
-								} else if (!nextHasOutgoingConnections) {
+                                        // lane can be used by all vehicles that may disregard lane arrows
+                                        transitionType = LaneEndTransitionType.Relaxed;
+                                        if (numNextRelaxedTransitionDatas < MAX_NUM_TRANSITIONS) {
+                                            if (nextIsJunction || laneInValidGroup)
+                                                nextRelaxedTransitionDatas[numNextRelaxedTransitionDatas++].Set(nextLaneId, nextLaneIndex, transitionType, nextSegmentId, isNextStartNodeOfNextSegment, GlobalConfig.Instance.PathFinding.IncompatibleLaneDistance);
+                                        } else {
+                                            Log.Warning($"nextTransitionDatas overflow @ source lane {prevLaneId}, idx {prevLaneIndex} @ seg. {prevSegmentId}");
+                                        }
+                                    }
+                                } else if (!nextHasOutgoingConnections) {
 #if DEBUGROUTING
 									if (debugFine)
 										Log._Debug($"RoutingManager.RecalculateLaneEndRoutingData({segmentId}, {laneIndex}, {laneId}, {startNode}): nextLaneId={nextLaneId}, idx={nextLaneIndex} is used by vehicles that do not follow lane arrows. adding as default.");
 #endif
 
-									// routed vehicle that does not follow lane arrows (trains, trams, metros, monorails)
-									transitionType = LaneEndTransitionType.Default;
+                                    // routed vehicle that does not follow lane arrows (trains, trams, metros, monorails)
+                                    transitionType = LaneEndTransitionType.Default;
 
-									if (numNextForcedTransitionDatas < MAX_NUM_TRANSITIONS) {
-										nextForcedTransitionDatas[numNextForcedTransitionDatas].Set(nextLaneId, nextLaneIndex, transitionType, nextSegmentId, isNextStartNodeOfNextSegment);
+                                    if (numNextForcedTransitionDatas < MAX_NUM_TRANSITIONS) {
+                                        if (nextIsJunction || laneInValidGroup)
+                                            nextForcedTransitionDatas[numNextForcedTransitionDatas].Set(nextLaneId, nextLaneIndex, transitionType, nextSegmentId, isNextStartNodeOfNextSegment);
 
-										if (! isNextRealJunction) {
-											// simple forced lane transition: set lane distance
-											nextForcedTransitionDatas[numNextForcedTransitionDatas].distance = (byte)Math.Abs(prevOuterSimilarLaneIndex - nextOuterSimilarLaneIndex);
-										}
+                                        if (! isNextRealJunction) {
+                                            // simple forced lane transition: set lane distance
+                                            nextForcedTransitionDatas[numNextForcedTransitionDatas].distance = (byte)Math.Abs(prevOuterSimilarLaneIndex - nextOuterSimilarLaneIndex);
+                                        }
 
-										++numNextForcedTransitionDatas;
-									} else {
-										Log.Warning($"nextForcedTransitionDatas overflow @ source lane {prevLaneId}, idx {prevLaneIndex} @ seg. {prevSegmentId}");
-									}
-								}
+                                        ++numNextForcedTransitionDatas;
+                                    } else {
+                                        Log.Warning($"nextForcedTransitionDatas overflow @ source lane {prevLaneId}, idx {prevLaneIndex} @ seg. {prevSegmentId}");
+                                    }
+                                }
 
-								if (isCompatibleLane) {
+                                if (isCompatibleLane) {
 #if DEBUGROUTING
 									if (debugFine)
 										Log._Debug($"RoutingManager.RecalculateLaneEndRoutingData({segmentId}, {laneIndex}, {laneId}, {startNode}): adding nextLaneId={nextLaneId}, idx={nextLaneIndex} as compatible lane now.");
 #endif
 
-									if (numNextCompatibleTransitionDatas < MAX_NUM_TRANSITIONS) {
-										nextCompatibleOuterSimilarIndices[numNextCompatibleTransitionDatas] = nextOuterSimilarLaneIndex;
-										compatibleLaneIndexToLaneConnectionIndex[numNextCompatibleTransitionDatas] = currentLaneConnectionTransIndex;
-										//compatibleLaneIndicesMask |= POW2MASKS[numNextCompatibleTransitionDatas];
-										nextCompatibleTransitionDatas[numNextCompatibleTransitionDatas++].Set(nextLaneId, nextLaneIndex, transitionType, nextSegmentId, isNextStartNodeOfNextSegment);
-									} else {
-										Log.Warning($"nextCompatibleTransitionDatas overflow @ source lane {prevLaneId}, idx {prevLaneIndex} @ seg. {prevSegmentId}");
-									}
-								} else {
+                                    if (numNextCompatibleTransitionDatas < MAX_NUM_TRANSITIONS) {
+                                        nextCompatibleOuterSimilarIndices[numNextCompatibleTransitionDatas] = nextOuterSimilarLaneIndex;
+                                        compatibleLaneIndexToLaneConnectionIndex[numNextCompatibleTransitionDatas] = currentLaneConnectionTransIndex;
+                                        //compatibleLaneIndicesMask |= POW2MASKS[numNextCompatibleTransitionDatas];
+                                        if (nextIsJunction || laneInValidGroup)
+                                            nextCompatibleTransitionDatas[numNextCompatibleTransitionDatas++].Set(nextLaneId, nextLaneIndex, transitionType, nextSegmentId, isNextStartNodeOfNextSegment);
+                                    } else {
+                                        Log.Warning($"nextCompatibleTransitionDatas overflow @ source lane {prevLaneId}, idx {prevLaneIndex} @ seg. {prevSegmentId}");
+                                    }
+                                } else {
 #if DEBUGROUTING
 									if (debugFine)
 										Log._Debug($"RoutingManager.RecalculateLaneEndRoutingData({segmentId}, {laneIndex}, {laneId}, {startNode}): nextLaneId={nextLaneId}, idx={nextLaneIndex} is NOT compatible.");
 #endif
-								}
-							}
-						} else {
+                                }
+                            }
+                        } else {
 #if DEBUGROUTING
 							if (debugFine)
 								Log._Debug($"RoutingManager.RecalculateLaneEndRoutingData({segmentId}, {laneIndex}, {laneId}, {startNode}): lane direction check NOT passed for nextLaneId={nextLaneId}, idx={nextLaneIndex}: isNextValid={isNextSegmentValid}, nextLaneInfo.m_finalDirection={nextLaneInfo.m_finalDirection}, nextDir2={nextDir2}");
 #endif
-							if ((nextLaneInfo.m_finalDirection & NetInfo.InvertDirection(nextDir2)) != NetInfo.Direction.None) {
-								++outgoingVehicleLanes;
+                            if ((nextLaneInfo.m_finalDirection & NetInfo.InvertDirection(nextDir2)) != NetInfo.Direction.None) {
+                                ++outgoingVehicleLanes;
 #if DEBUGROUTING
 								if (debugFine)
 									Log._Debug($"RoutingManager.RecalculateLaneEndRoutingData({segmentId}, {laneIndex}, {laneId}, {startNode}): increasing number of outgoing lanes at nextLaneId={nextLaneId}, idx={nextLaneIndex}: isNextValid={isNextSegmentValid}, nextLaneInfo.m_finalDirection={nextLaneInfo.m_finalDirection}, nextDir2={nextDir2}: incomingVehicleLanes={incomingVehicleLanes}, outgoingVehicleLanes={outgoingVehicleLanes}");
 #endif
-							}
-						}
-					} else {
+                            }
+                        }
+                    } else {
 #if DEBUGROUTING
 						if (debugFine)
 							Log._Debug($"RoutingManager.RecalculateLaneEndRoutingData({segmentId}, {laneIndex}, {laneId}, {startNode}): vehicle type check NOT passed for nextLaneId={nextLaneId}, idx={nextLaneIndex}: prevLaneInfo.m_vehicleType={prevLaneInfo.m_vehicleType}, nextLaneInfo.m_vehicleType={nextLaneInfo.m_vehicleType}, prevLaneInfo.m_laneType={prevLaneInfo.m_laneType}, nextLaneInfo.m_laneType={nextLaneInfo.m_laneType}");
 #endif
-					}
+                    }
 
-					Constants.ServiceFactory.NetService.ProcessLane(nextLaneId, delegate (uint lId, ref NetLane lane) {
-						nextLaneId = lane.m_nextLane;
-						return true;
-					});
-					++nextLaneIndex;
-				} // foreach lane
+                    Constants.ServiceFactory.NetService.ProcessLane(nextLaneId, delegate (uint lId, ref NetLane lane) {
+                        nextLaneId = lane.m_nextLane;
+                        return true;
+                    });
+                    ++nextLaneIndex;
+                } // foreach lane
 
 
 #if DEBUGROUTING
 				if (debugFine)
 					Log._Debug($"RoutingManager.RecalculateLaneEndRoutingData({segmentId}, {laneIndex}, {laneId}, {startNode}): isNextValid={isNextSegmentValid} Compatible lanes: " + nextCompatibleTransitionDatas?.ArrayToString());
 #endif
-				if (isNextSegmentValid) {
-					bool laneChangesAllowed = Options.junctionRestrictionsEnabled && JunctionRestrictionsManager.Instance.IsLaneChangingAllowedWhenGoingStraight(nextSegmentId, isNextStartNodeOfNextSegment);
-					int nextCompatibleLaneCount = numNextCompatibleTransitionDatas;
-					if (nextCompatibleLaneCount > 0) {
-						// we found compatible lanes
+                if (isNextSegmentValid) {
+                    bool laneChangesAllowed = Options.junctionRestrictionsEnabled && JunctionRestrictionsManager.Instance.IsLaneChangingAllowedWhenGoingStraight(nextSegmentId, isNextStartNodeOfNextSegment);
+                    int nextCompatibleLaneCount = numNextCompatibleTransitionDatas;
+                    if (nextCompatibleLaneCount > 0) {
+                        // we found compatible lanes
 
-						int[] tmp = new int[nextCompatibleLaneCount];
-						Array.Copy(nextCompatibleOuterSimilarIndices, tmp, nextCompatibleLaneCount);
-						nextCompatibleOuterSimilarIndices = tmp;
+                        int[] tmp = new int[nextCompatibleLaneCount];
+                        Array.Copy(nextCompatibleOuterSimilarIndices, tmp, nextCompatibleLaneCount);
+                        nextCompatibleOuterSimilarIndices = tmp;
 
-						int[] compatibleLaneIndicesSortedByOuterSimilarIndex = nextCompatibleOuterSimilarIndices.Select((x, i) => new KeyValuePair<int, int>(x, i)).OrderBy(p => p.Key).Select(p => p.Value).ToArray();
+                        int[] compatibleLaneIndicesSortedByOuterSimilarIndex = nextCompatibleOuterSimilarIndices.Select((x, i) => new KeyValuePair<int, int>(x, i)).OrderBy(p => p.Key).Select(p => p.Value).ToArray();
 
-						// enable highway rules only at junctions or at simple lane merging/splitting points
-						int laneDiff = nextCompatibleLaneCount - prevSimilarLaneCount;
-						bool applyHighwayRulesAtSegment = applyHighwayRules && (applyHighwayRulesAtJunction || Math.Abs(laneDiff) == 1);
+                        // enable highway rules only at junctions or at simple lane merging/splitting points
+                        int laneDiff = nextCompatibleLaneCount - prevSimilarLaneCount;
+                        bool applyHighwayRulesAtSegment = applyHighwayRules && (applyHighwayRulesAtJunction || Math.Abs(laneDiff) == 1);
 
 #if DEBUGROUTING
 						if (debugFine)
 							Log._Debug($"RoutingManager.RecalculateLaneEndRoutingData({segmentId}, {laneIndex}, {laneId}, {startNode}): found compatible lanes! compatibleLaneIndicesSortedByOuterSimilarIndex={compatibleLaneIndicesSortedByOuterSimilarIndex.ArrayToString()}, laneDiff={laneDiff}, applyHighwayRulesAtSegment={applyHighwayRulesAtSegment}");
 #endif
 
-						if (applyHighwayRulesAtJunction) {
-							// we reached a highway junction where more than two segments are connected to each other
+                        if (applyHighwayRulesAtJunction) {
+                            // we reached a highway junction where more than two segments are connected to each other
 #if DEBUGROUTING
 							if (debugFine)
 								Log._Debug($"RoutingManager.RecalculateLaneEndRoutingData({segmentId}, {laneIndex}, {laneId}, {startNode}): applying highway rules at junction");
 #endif
 
-							// number of lanes that were processed in earlier segment iterations (either all incoming or all outgoing)
-							int numLanesSeen = Math.Max(totalIncomingLanes, totalOutgoingLanes);
+                            // number of lanes that were processed in earlier segment iterations (either all incoming or all outgoing)
+                            int numLanesSeen = Math.Max(totalIncomingLanes, totalOutgoingLanes);
 
-							int minNextInnerSimilarIndex = -1;
-							int maxNextInnerSimilarIndex = -1;
-							int refNextInnerSimilarIndex = -1; // this lane will be referred as the "stay" lane with zero distance
+                            int minNextInnerSimilarIndex = -1;
+                            int maxNextInnerSimilarIndex = -1;
+                            int refNextInnerSimilarIndex = -1; // this lane will be referred as the "stay" lane with zero distance
 
 #if DEBUGHWJUNCTIONROUTING
 							if (debugFine) {
@@ -735,75 +764,75 @@ namespace TrafficManager.Manager.Impl {
 							}
 #endif
 
-							if (nextIsSplitJunction) {
-								// lane splitting at junction
-								minNextInnerSimilarIndex = prevInnerSimilarLaneIndex + numLanesSeen;
+                            if (nextIsSplitJunction) {
+                                // lane splitting at junction
+                                minNextInnerSimilarIndex = prevInnerSimilarLaneIndex + numLanesSeen;
 
-								if (minNextInnerSimilarIndex >= nextCompatibleLaneCount) {
-									// there have already been explored more outgoing lanes than incoming lanes on the previous segment. Also allow vehicles to go to the current segment.
-									minNextInnerSimilarIndex = maxNextInnerSimilarIndex = refNextInnerSimilarIndex = nextCompatibleLaneCount - 1;
-								} else {
-									maxNextInnerSimilarIndex = refNextInnerSimilarIndex = minNextInnerSimilarIndex;
-									if (laneChangesAllowed) {
-										// allow lane changes at highway junctions
-										if (minNextInnerSimilarIndex > 0 && prevInnerSimilarLaneIndex > 0) {
-											--minNextInnerSimilarIndex;
-										}
-									}
-								}
+                                if (minNextInnerSimilarIndex >= nextCompatibleLaneCount) {
+                                    // there have already been explored more outgoing lanes than incoming lanes on the previous segment. Also allow vehicles to go to the current segment.
+                                    minNextInnerSimilarIndex = maxNextInnerSimilarIndex = refNextInnerSimilarIndex = nextCompatibleLaneCount - 1;
+                                } else {
+                                    maxNextInnerSimilarIndex = refNextInnerSimilarIndex = minNextInnerSimilarIndex;
+                                    if (laneChangesAllowed) {
+                                        // allow lane changes at highway junctions
+                                        if (minNextInnerSimilarIndex > 0 && prevInnerSimilarLaneIndex > 0) {
+                                            --minNextInnerSimilarIndex;
+                                        }
+                                    }
+                                }
 
 #if DEBUGHWJUNCTIONROUTING
 								if (debugFine) {
 									Log._Debug($"RoutingManager.RecalculateLaneEndRoutingData({segmentId}, {laneIndex}, {laneId}, {startNode}): highway rules at junction: lane splitting junction. minNextInnerSimilarIndex={minNextInnerSimilarIndex}, maxNextInnerSimilarIndex={maxNextInnerSimilarIndex}");
 								}
 #endif
-							} else {
-								// lane merging at junction
-								minNextInnerSimilarIndex = prevInnerSimilarLaneIndex - numLanesSeen;
+                            } else {
+                                // lane merging at junction
+                                minNextInnerSimilarIndex = prevInnerSimilarLaneIndex - numLanesSeen;
 
-								if (minNextInnerSimilarIndex < 0) {
-									if (prevInnerSimilarLaneIndex == prevSimilarLaneCount - 1) {
-										// there have already been explored more incoming lanes than outgoing lanes on the previous segment. Allow the current segment to also join the big merging party. What a fun!
-										minNextInnerSimilarIndex = 0;
-										maxNextInnerSimilarIndex = nextCompatibleLaneCount - 1;
-									} else {
-										// lanes do not connect (min/max = -1)
-									}
-								} else {
-									// allow lane changes at highway junctions
-									refNextInnerSimilarIndex = minNextInnerSimilarIndex;
-									if (laneChangesAllowed) {
-										maxNextInnerSimilarIndex = Math.Min(nextCompatibleLaneCount - 1, minNextInnerSimilarIndex + 1);
-										if (minNextInnerSimilarIndex > 0) {
-											--minNextInnerSimilarIndex;
-										}
-									} else {
-										maxNextInnerSimilarIndex = minNextInnerSimilarIndex;
-									}
+                                if (minNextInnerSimilarIndex < 0) {
+                                    if (prevInnerSimilarLaneIndex == prevSimilarLaneCount - 1) {
+                                        // there have already been explored more incoming lanes than outgoing lanes on the previous segment. Allow the current segment to also join the big merging party. What a fun!
+                                        minNextInnerSimilarIndex = 0;
+                                        maxNextInnerSimilarIndex = nextCompatibleLaneCount - 1;
+                                    } else {
+                                        // lanes do not connect (min/max = -1)
+                                    }
+                                } else {
+                                    // allow lane changes at highway junctions
+                                    refNextInnerSimilarIndex = minNextInnerSimilarIndex;
+                                    if (laneChangesAllowed) {
+                                        maxNextInnerSimilarIndex = Math.Min(nextCompatibleLaneCount - 1, minNextInnerSimilarIndex + 1);
+                                        if (minNextInnerSimilarIndex > 0) {
+                                            --minNextInnerSimilarIndex;
+                                        }
+                                    } else {
+                                        maxNextInnerSimilarIndex = minNextInnerSimilarIndex;
+                                    }
 
-									if (totalIncomingLanes > 0 && prevInnerSimilarLaneIndex == prevSimilarLaneCount - 1 && maxNextInnerSimilarIndex < nextCompatibleLaneCount - 1) {
-										// we reached the outermost lane on the previous segment but there are still lanes to go on the next segment: allow merging
-										maxNextInnerSimilarIndex = nextCompatibleLaneCount - 1;
-									}
-								}
+                                    if (totalIncomingLanes > 0 && prevInnerSimilarLaneIndex == prevSimilarLaneCount - 1 && maxNextInnerSimilarIndex < nextCompatibleLaneCount - 1) {
+                                        // we reached the outermost lane on the previous segment but there are still lanes to go on the next segment: allow merging
+                                        maxNextInnerSimilarIndex = nextCompatibleLaneCount - 1;
+                                    }
+                                }
 
 #if DEBUGHWJUNCTIONROUTING
 								if (debugFine) {
 									Log._Debug($"RoutingManager.RecalculateLaneEndRoutingData({segmentId}, {laneIndex}, {laneId}, {startNode}): highway rules at junction: lane merging/unknown junction. minNextInnerSimilarIndex={minNextInnerSimilarIndex}, maxNextInnerSimilarIndex={maxNextInnerSimilarIndex}");
 								}
 #endif
-							}
+                            }
 
-							if (minNextInnerSimilarIndex >= 0) {
+                            if (minNextInnerSimilarIndex >= 0) {
 #if DEBUGHWJUNCTIONROUTING
 								if (debugFine) {
 									Log._Debug($"RoutingManager.RecalculateLaneEndRoutingData({segmentId}, {laneIndex}, {laneId}, {startNode}): minNextInnerSimilarIndex >= 0. nextCompatibleTransitionDatas={nextCompatibleTransitionDatas.ArrayToString()}");
 								}
 #endif
 
-								// explore lanes
-								for (int nextInnerSimilarIndex = minNextInnerSimilarIndex; nextInnerSimilarIndex <= maxNextInnerSimilarIndex; ++nextInnerSimilarIndex) {
-									int nextTransitionIndex = FindLaneByInnerIndex(nextCompatibleTransitionDatas, numNextCompatibleTransitionDatas, nextSegmentId, nextInnerSimilarIndex);
+                                // explore lanes
+                                for (int nextInnerSimilarIndex = minNextInnerSimilarIndex; nextInnerSimilarIndex <= maxNextInnerSimilarIndex; ++nextInnerSimilarIndex) {
+                                    int nextTransitionIndex = FindLaneByInnerIndex(nextCompatibleTransitionDatas, numNextCompatibleTransitionDatas, nextSegmentId, nextInnerSimilarIndex);
 
 #if DEBUGHWJUNCTIONROUTING
 									if (debugFine) {
@@ -811,53 +840,53 @@ namespace TrafficManager.Manager.Impl {
 									}
 #endif
 
-									if (nextTransitionIndex < 0) {
-										continue;
-									}
+                                    if (nextTransitionIndex < 0) {
+                                        continue;
+                                    }
 
-									// calculate lane distance
-									byte compatibleLaneDist = 0;
-									if (refNextInnerSimilarIndex >= 0) {
-										compatibleLaneDist = (byte)Math.Abs(refNextInnerSimilarIndex - nextInnerSimilarIndex);
-									}
+                                    // calculate lane distance
+                                    byte compatibleLaneDist = 0;
+                                    if (refNextInnerSimilarIndex >= 0) {
+                                        compatibleLaneDist = (byte)Math.Abs(refNextInnerSimilarIndex - nextInnerSimilarIndex);
+                                    }
 
-									// skip lanes having lane connections
-									if (LaneConnectionManager.Instance.HasConnections(nextCompatibleTransitionDatas[nextTransitionIndex].laneId, isNextStartNodeOfNextSegment)) {
-										int laneConnectionTransIndex = compatibleLaneIndexToLaneConnectionIndex[nextTransitionIndex];
-										if (laneConnectionTransIndex >= 0) {
-											nextLaneConnectionTransitionDatas[laneConnectionTransIndex].distance = compatibleLaneDist;
-										}
+                                    // skip lanes having lane connections
+                                    if (LaneConnectionManager.Instance.HasConnections(nextCompatibleTransitionDatas[nextTransitionIndex].laneId, isNextStartNodeOfNextSegment)) {
+                                        int laneConnectionTransIndex = compatibleLaneIndexToLaneConnectionIndex[nextTransitionIndex];
+                                        if (laneConnectionTransIndex >= 0) {
+                                            nextLaneConnectionTransitionDatas[laneConnectionTransIndex].distance = compatibleLaneDist;
+                                        }
 #if DEBUGROUTING
 										if (debugFine)
 											Log._Debug($"RoutingManager.RecalculateLaneEndRoutingData({segmentId}, {laneIndex}, {laneId}, {startNode}): Next lane ({nextCompatibleTransitionDatas[nextTransitionIndex].laneId}) has outgoing lane connections. Skip for now but set compatibleLaneDist={compatibleLaneDist} if laneConnectionTransIndex={laneConnectionTransIndex} >= 0.");
 #endif
-										continue; // disregard lane since it has outgoing connections
-									}
+                                        continue; // disregard lane since it has outgoing connections
+                                    }
 
-									nextCompatibleTransitionDatas[nextTransitionIndex].distance = compatibleLaneDist;
+                                    nextCompatibleTransitionDatas[nextTransitionIndex].distance = compatibleLaneDist;
 #if DEBUGHWJUNCTIONROUTING
 									if (debugFine) {
 										Log._Debug($"RoutingManager.RecalculateLaneEndRoutingData({segmentId}, {laneIndex}, {laneId}, {startNode}): highway junction iteration: compatibleLaneDist={compatibleLaneDist}");
 									}
 #endif
 
-									UpdateHighwayLaneArrows(nextCompatibleTransitionDatas[nextTransitionIndex].laneId, isNextStartNodeOfNextSegment, nextIncomingDir);
+                                    UpdateHighwayLaneArrows(nextCompatibleTransitionDatas[nextTransitionIndex].laneId, isNextStartNodeOfNextSegment, nextIncomingDir);
 
-									if (numNextCompatibleTransitionDataIndices < MAX_NUM_TRANSITIONS) {
-										nextCompatibleTransitionDataIndices[numNextCompatibleTransitionDataIndices++] = nextTransitionIndex;
-									} else {
-										Log.Warning($"nextCompatibleTransitionDataIndices overflow @ source lane {prevLaneId}, idx {prevLaneIndex} @ seg. {prevSegmentId}");
-									}
-								}
+                                    if (numNextCompatibleTransitionDataIndices < MAX_NUM_TRANSITIONS) {
+                                        nextCompatibleTransitionDataIndices[numNextCompatibleTransitionDataIndices++] = nextTransitionIndex;
+                                    } else {
+                                        Log.Warning($"nextCompatibleTransitionDataIndices overflow @ source lane {prevLaneId}, idx {prevLaneIndex} @ seg. {prevSegmentId}");
+                                    }
+                                }
 
 #if DEBUGHWJUNCTIONROUTING
 								if (debugFine) {
 									Log._Debug($"RoutingManager.RecalculateLaneEndRoutingData({segmentId}, {laneIndex}, {laneId}, {startNode}): highway junction iterations finished: nextCompatibleTransitionDataIndices={nextCompatibleTransitionDataIndices.ArrayToString()}");
 								}
 #endif
-							}
-						} else {
-							/*
+                            }
+                        } else {
+                            /*
 							 * This is
 							 *    1. a highway lane splitting/merging point,
 							 *    2. a city or highway lane continuation point (simple transition with equal number of lanes or flagged city transition), or
@@ -870,432 +899,432 @@ namespace TrafficManager.Manager.Impl {
 								Log._Debug($"RoutingManager.RecalculateLaneEndRoutingData({segmentId}, {laneIndex}, {laneId}, {startNode}): regular node");
 #endif
 
-							// min/max compatible outer similar lane indices
-							int minNextCompatibleOuterSimilarIndex = -1;
-							int maxNextCompatibleOuterSimilarIndex = -1;
-							if (nextIncomingDir == ArrowDirection.Turn) {
-								minNextCompatibleOuterSimilarIndex = 0;
-								maxNextCompatibleOuterSimilarIndex = nextCompatibleLaneCount - 1;
+                            // min/max compatible outer similar lane indices
+                            int minNextCompatibleOuterSimilarIndex = -1;
+                            int maxNextCompatibleOuterSimilarIndex = -1;
+                            if (nextIncomingDir == ArrowDirection.Turn) {
+                                minNextCompatibleOuterSimilarIndex = 0;
+                                maxNextCompatibleOuterSimilarIndex = nextCompatibleLaneCount - 1;
 #if DEBUGROUTING
 								if (debugFine)
 									Log._Debug($"RoutingManager.RecalculateLaneEndRoutingData({segmentId}, {laneIndex}, {laneId}, {startNode}): u-turn: minNextCompatibleOuterSimilarIndex={minNextCompatibleOuterSimilarIndex}, maxNextCompatibleOuterSimilarIndex={maxNextCompatibleOuterSimilarIndex}");
 #endif
-							} else if (isNextRealJunction) {
+                            } else if (isNextRealJunction) {
 #if DEBUGROUTING
 								if (debugFine)
 									Log._Debug($"RoutingManager.RecalculateLaneEndRoutingData({segmentId}, {laneIndex}, {laneId}, {startNode}): next is real junction");
 #endif
 
-								// at junctions: try to match distinct lanes
-								if (nextCompatibleLaneCount > prevSimilarLaneCount && prevOuterSimilarLaneIndex == prevSimilarLaneCount - 1) {
-									// merge inner lanes
-									minNextCompatibleOuterSimilarIndex = prevOuterSimilarLaneIndex;
-									maxNextCompatibleOuterSimilarIndex = nextCompatibleLaneCount - 1;
+                                // at junctions: try to match distinct lanes
+                                if (nextCompatibleLaneCount > prevSimilarLaneCount && prevOuterSimilarLaneIndex == prevSimilarLaneCount - 1) {
+                                    // merge inner lanes
+                                    minNextCompatibleOuterSimilarIndex = prevOuterSimilarLaneIndex;
+                                    maxNextCompatibleOuterSimilarIndex = nextCompatibleLaneCount - 1;
 #if DEBUGROUTING
 									if (debugFine)
 										Log._Debug($"RoutingManager.RecalculateLaneEndRoutingData({segmentId}, {laneIndex}, {laneId}, {startNode}): merge inner lanes: minNextCompatibleOuterSimilarIndex={minNextCompatibleOuterSimilarIndex}, maxNextCompatibleOuterSimilarIndex={maxNextCompatibleOuterSimilarIndex}");
 #endif
-								} else if (nextCompatibleLaneCount < prevSimilarLaneCount && prevSimilarLaneCount % nextCompatibleLaneCount == 0) {
-									// symmetric split
-									int splitFactor = prevSimilarLaneCount / nextCompatibleLaneCount;
-									minNextCompatibleOuterSimilarIndex = maxNextCompatibleOuterSimilarIndex = prevOuterSimilarLaneIndex / splitFactor;
+                                } else if (nextCompatibleLaneCount < prevSimilarLaneCount && prevSimilarLaneCount % nextCompatibleLaneCount == 0) {
+                                    // symmetric split
+                                    int splitFactor = prevSimilarLaneCount / nextCompatibleLaneCount;
+                                    minNextCompatibleOuterSimilarIndex = maxNextCompatibleOuterSimilarIndex = prevOuterSimilarLaneIndex / splitFactor;
 #if DEBUGROUTING
 									if (debugFine)
 										Log._Debug($"RoutingManager.RecalculateLaneEndRoutingData({segmentId}, {laneIndex}, {laneId}, {startNode}): symmetric split: minNextCompatibleOuterSimilarIndex={minNextCompatibleOuterSimilarIndex}, maxNextCompatibleOuterSimilarIndex={maxNextCompatibleOuterSimilarIndex}");
 #endif
-								} else {
-									// 1-to-n (split inner lane) or 1-to-1 (direct lane matching)
-									minNextCompatibleOuterSimilarIndex = prevOuterSimilarLaneIndex;
-									maxNextCompatibleOuterSimilarIndex = prevOuterSimilarLaneIndex;
+                                } else {
+                                    // 1-to-n (split inner lane) or 1-to-1 (direct lane matching)
+                                    minNextCompatibleOuterSimilarIndex = prevOuterSimilarLaneIndex;
+                                    maxNextCompatibleOuterSimilarIndex = prevOuterSimilarLaneIndex;
 #if DEBUGROUTING
 									if (debugFine)
 										Log._Debug($"RoutingManager.RecalculateLaneEndRoutingData({segmentId}, {laneIndex}, {laneId}, {startNode}): 1-to-n (split inner lane) or 1-to-1 (direct lane matching): minNextCompatibleOuterSimilarIndex={minNextCompatibleOuterSimilarIndex}, maxNextCompatibleOuterSimilarIndex={maxNextCompatibleOuterSimilarIndex}");
 #endif
-								}
+                                }
 
-								bool straightLaneChangesAllowed = nextIncomingDir == ArrowDirection.Forward && laneChangesAllowed;
+                                bool straightLaneChangesAllowed = nextIncomingDir == ArrowDirection.Forward && laneChangesAllowed;
 
 #if DEBUGROUTING
 								if (debugFine)
 									Log._Debug($"RoutingManager.RecalculateLaneEndRoutingData({segmentId}, {laneIndex}, {laneId}, {startNode}): laneChangesAllowed={laneChangesAllowed} straightLaneChangesAllowed={straightLaneChangesAllowed}");
 #endif
 
-								if (!straightLaneChangesAllowed) {
-									if (nextHasBusLane && !prevHasBusLane) {
-										// allow vehicles on the bus lane AND on the next lane to merge on this lane
-										maxNextCompatibleOuterSimilarIndex = Math.Min(nextCompatibleLaneCount - 1, maxNextCompatibleOuterSimilarIndex + 1);
+                                if (!straightLaneChangesAllowed) {
+                                    if (nextHasBusLane && !prevHasBusLane) {
+                                        // allow vehicles on the bus lane AND on the next lane to merge on this lane
+                                        maxNextCompatibleOuterSimilarIndex = Math.Min(nextCompatibleLaneCount - 1, maxNextCompatibleOuterSimilarIndex + 1);
 #if DEBUGROUTING
 										if (debugFine)
 											Log._Debug($"RoutingManager.RecalculateLaneEndRoutingData({segmentId}, {laneIndex}, {laneId}, {startNode}): allow vehicles on the bus lane AND on the next lane to merge on this lane: minNextCompatibleOuterSimilarIndex={minNextCompatibleOuterSimilarIndex}, maxNextCompatibleOuterSimilarIndex={maxNextCompatibleOuterSimilarIndex}");
 #endif
-									} else if (!nextHasBusLane && prevHasBusLane) {
-										// allow vehicles to enter the bus lane
-										minNextCompatibleOuterSimilarIndex = Math.Max(0, minNextCompatibleOuterSimilarIndex - 1);
+                                    } else if (!nextHasBusLane && prevHasBusLane) {
+                                        // allow vehicles to enter the bus lane
+                                        minNextCompatibleOuterSimilarIndex = Math.Max(0, minNextCompatibleOuterSimilarIndex - 1);
 #if DEBUGROUTING
 										if (debugFine)
 											Log._Debug($"RoutingManager.RecalculateLaneEndRoutingData({segmentId}, {laneIndex}, {laneId}, {startNode}): allow vehicles to enter the bus lane: minNextCompatibleOuterSimilarIndex={minNextCompatibleOuterSimilarIndex}, maxNextCompatibleOuterSimilarIndex={maxNextCompatibleOuterSimilarIndex}");
 #endif
-									}
-								} else {
-									// vehicles may change lanes when going straight
-									minNextCompatibleOuterSimilarIndex = minNextCompatibleOuterSimilarIndex - 1;
-									maxNextCompatibleOuterSimilarIndex = maxNextCompatibleOuterSimilarIndex + 1;
+                                    }
+                                } else {
+                                    // vehicles may change lanes when going straight
+                                    minNextCompatibleOuterSimilarIndex = minNextCompatibleOuterSimilarIndex - 1;
+                                    maxNextCompatibleOuterSimilarIndex = maxNextCompatibleOuterSimilarIndex + 1;
 #if DEBUGROUTING
 									if (debugFine)
 										Log._Debug($"RoutingManager.RecalculateLaneEndRoutingData({segmentId}, {laneIndex}, {laneId}, {startNode}): vehicles may change lanes when going straight: minNextCompatibleOuterSimilarIndex={minNextCompatibleOuterSimilarIndex}, maxNextCompatibleOuterSimilarIndex={maxNextCompatibleOuterSimilarIndex}");
 #endif
-								}
-							} else if (prevSimilarLaneCount == nextCompatibleLaneCount) {
-								// equal lane count: consider all available lanes
-								minNextCompatibleOuterSimilarIndex = 0;
-								maxNextCompatibleOuterSimilarIndex = nextCompatibleLaneCount - 1;
+                                }
+                            } else if (prevSimilarLaneCount == nextCompatibleLaneCount) {
+                                // equal lane count: consider all available lanes
+                                minNextCompatibleOuterSimilarIndex = 0;
+                                maxNextCompatibleOuterSimilarIndex = nextCompatibleLaneCount - 1;
 #if DEBUGROUTING
 								if (debugFine)
 									Log._Debug($"RoutingManager.RecalculateLaneEndRoutingData({segmentId}, {laneIndex}, {laneId}, {startNode}): equal lane count: minNextCompatibleOuterSimilarIndex={minNextCompatibleOuterSimilarIndex}, maxNextCompatibleOuterSimilarIndex={maxNextCompatibleOuterSimilarIndex}");
 #endif
-							} else {
-								// lane continuation point: lane merging/splitting
+                            } else {
+                                // lane continuation point: lane merging/splitting
 
 #if DEBUGROUTING
 								if (debugFine)
 									Log._Debug($"RoutingManager.RecalculateLaneEndRoutingData({segmentId}, {laneIndex}, {laneId}, {startNode}): lane continuation point: lane merging/splitting");
 #endif
 
-								bool sym1 = (prevSimilarLaneCount & 1) == 0; // mod 2 == 0
-								bool sym2 = (nextCompatibleLaneCount & 1) == 0; // mod 2 == 0
+                                bool sym1 = (prevSimilarLaneCount & 1) == 0; // mod 2 == 0
+                                bool sym2 = (nextCompatibleLaneCount & 1) == 0; // mod 2 == 0
 #if DEBUGROUTING
 								if (debugFine)
 									Log._Debug($"RoutingManager.RecalculateLaneEndRoutingData({segmentId}, {laneIndex}, {laneId}, {startNode}): sym1={sym1}, sym2={sym2}");
 #endif
-								if (prevSimilarLaneCount < nextCompatibleLaneCount) {
+                                if (prevSimilarLaneCount < nextCompatibleLaneCount) {
 #if DEBUGROUTING
 									if (debugFine)
 										Log._Debug($"RoutingManager.RecalculateLaneEndRoutingData({segmentId}, {laneIndex}, {laneId}, {startNode}): lane merging (prevSimilarLaneCount={prevSimilarLaneCount} < nextCompatibleLaneCount={nextCompatibleLaneCount})");
 #endif
 
-									// lane merging
-									if (sym1 == sym2) {
-										// merge outer lanes
-										int a = (nextCompatibleLaneCount - prevSimilarLaneCount) >> 1; // nextCompatibleLaneCount - prevSimilarLaneCount is always > 0
+                                    // lane merging
+                                    if (sym1 == sym2) {
+                                        // merge outer lanes
+                                        int a = (nextCompatibleLaneCount - prevSimilarLaneCount) >> 1; // nextCompatibleLaneCount - prevSimilarLaneCount is always > 0
 #if DEBUGROUTING
 										if (debugFine)
 											Log._Debug($"RoutingManager.RecalculateLaneEndRoutingData({segmentId}, {laneIndex}, {laneId}, {startNode}): merge outer lanes. a={a}");
 #endif
-										if (prevSimilarLaneCount == 1) {
-											minNextCompatibleOuterSimilarIndex = 0;
-											maxNextCompatibleOuterSimilarIndex = nextCompatibleLaneCount - 1; // always >=0
+                                        if (prevSimilarLaneCount == 1) {
+                                            minNextCompatibleOuterSimilarIndex = 0;
+                                            maxNextCompatibleOuterSimilarIndex = nextCompatibleLaneCount - 1; // always >=0
 #if DEBUGROUTING
 											if (debugFine)
 												Log._Debug($"RoutingManager.RecalculateLaneEndRoutingData({segmentId}, {laneIndex}, {laneId}, {startNode}): prevSimilarLaneCount == 1: minNextCompatibleOuterSimilarIndex={minNextCompatibleOuterSimilarIndex}, maxNextCompatibleOuterSimilarIndex={maxNextCompatibleOuterSimilarIndex}");
 #endif
-										} else if (prevOuterSimilarLaneIndex == 0) {
-											minNextCompatibleOuterSimilarIndex = 0;
-											maxNextCompatibleOuterSimilarIndex = a;
+                                        } else if (prevOuterSimilarLaneIndex == 0) {
+                                            minNextCompatibleOuterSimilarIndex = 0;
+                                            maxNextCompatibleOuterSimilarIndex = a;
 #if DEBUGROUTING
 											if (debugFine)
 												Log._Debug($"RoutingManager.RecalculateLaneEndRoutingData({segmentId}, {laneIndex}, {laneId}, {startNode}): prevOuterSimilarLaneIndex == 0: minNextCompatibleOuterSimilarIndex={minNextCompatibleOuterSimilarIndex}, maxNextCompatibleOuterSimilarIndex={maxNextCompatibleOuterSimilarIndex}");
 #endif
-										} else if (prevOuterSimilarLaneIndex == prevSimilarLaneCount - 1) {
-											minNextCompatibleOuterSimilarIndex = prevOuterSimilarLaneIndex + a;
-											maxNextCompatibleOuterSimilarIndex = nextCompatibleLaneCount - 1; // always >=0
+                                        } else if (prevOuterSimilarLaneIndex == prevSimilarLaneCount - 1) {
+                                            minNextCompatibleOuterSimilarIndex = prevOuterSimilarLaneIndex + a;
+                                            maxNextCompatibleOuterSimilarIndex = nextCompatibleLaneCount - 1; // always >=0
 #if DEBUGROUTING
 											if (debugFine)
 												Log._Debug($"RoutingManager.RecalculateLaneEndRoutingData({segmentId}, {laneIndex}, {laneId}, {startNode}): prevOuterSimilarLaneIndex == prevSimilarLaneCount - 1: minNextCompatibleOuterSimilarIndex={minNextCompatibleOuterSimilarIndex}, maxNextCompatibleOuterSimilarIndex={maxNextCompatibleOuterSimilarIndex}");
 #endif
-										} else {
-											minNextCompatibleOuterSimilarIndex = maxNextCompatibleOuterSimilarIndex = prevOuterSimilarLaneIndex + a;
+                                        } else {
+                                            minNextCompatibleOuterSimilarIndex = maxNextCompatibleOuterSimilarIndex = prevOuterSimilarLaneIndex + a;
 #if DEBUGROUTING
 											if (debugFine)
 												Log._Debug($"RoutingManager.RecalculateLaneEndRoutingData({segmentId}, {laneIndex}, {laneId}, {startNode}): default case: minNextCompatibleOuterSimilarIndex={minNextCompatibleOuterSimilarIndex}, maxNextCompatibleOuterSimilarIndex={maxNextCompatibleOuterSimilarIndex}");
 #endif
-										}
-									} else {
-										// criss-cross merge
-										int a = (nextCompatibleLaneCount - prevSimilarLaneCount - 1) >> 1; // nextCompatibleLaneCount - prevSimilarLaneCount - 1 is always >= 0
-										int b = (nextCompatibleLaneCount - prevSimilarLaneCount + 1) >> 1; // nextCompatibleLaneCount - prevSimilarLaneCount + 1 is always >= 2
+                                        }
+                                    } else {
+                                        // criss-cross merge
+                                        int a = (nextCompatibleLaneCount - prevSimilarLaneCount - 1) >> 1; // nextCompatibleLaneCount - prevSimilarLaneCount - 1 is always >= 0
+                                        int b = (nextCompatibleLaneCount - prevSimilarLaneCount + 1) >> 1; // nextCompatibleLaneCount - prevSimilarLaneCount + 1 is always >= 2
 #if DEBUGROUTING
 										if (debugFine)
 											Log._Debug($"RoutingManager.RecalculateLaneEndRoutingData({segmentId}, {laneIndex}, {laneId}, {startNode}): criss-cross merge: a={a}, b={b}");
 #endif
-										if (prevSimilarLaneCount == 1) {
-											minNextCompatibleOuterSimilarIndex = 0;
-											maxNextCompatibleOuterSimilarIndex = nextCompatibleLaneCount - 1; // always >=0
+                                        if (prevSimilarLaneCount == 1) {
+                                            minNextCompatibleOuterSimilarIndex = 0;
+                                            maxNextCompatibleOuterSimilarIndex = nextCompatibleLaneCount - 1; // always >=0
 #if DEBUGROUTING
 											if (debugFine)
 												Log._Debug($"RoutingManager.RecalculateLaneEndRoutingData({segmentId}, {laneIndex}, {laneId}, {startNode}): prevSimilarLaneCount == 1: minNextCompatibleOuterSimilarIndex={minNextCompatibleOuterSimilarIndex}, maxNextCompatibleOuterSimilarIndex={maxNextCompatibleOuterSimilarIndex}");
 #endif
-										} else if (prevOuterSimilarLaneIndex == 0) {
-											minNextCompatibleOuterSimilarIndex = 0;
-											maxNextCompatibleOuterSimilarIndex = b;
+                                        } else if (prevOuterSimilarLaneIndex == 0) {
+                                            minNextCompatibleOuterSimilarIndex = 0;
+                                            maxNextCompatibleOuterSimilarIndex = b;
 #if DEBUGROUTING
 											if (debugFine)
 												Log._Debug($"RoutingManager.RecalculateLaneEndRoutingData({segmentId}, {laneIndex}, {laneId}, {startNode}): prevOuterSimilarLaneIndex == 0: minNextCompatibleOuterSimilarIndex={minNextCompatibleOuterSimilarIndex}, maxNextCompatibleOuterSimilarIndex={maxNextCompatibleOuterSimilarIndex}");
 #endif
-										} else if (prevOuterSimilarLaneIndex == prevSimilarLaneCount - 1) {
-											minNextCompatibleOuterSimilarIndex = prevOuterSimilarLaneIndex + a;
-											maxNextCompatibleOuterSimilarIndex = nextCompatibleLaneCount - 1; // always >=0
+                                        } else if (prevOuterSimilarLaneIndex == prevSimilarLaneCount - 1) {
+                                            minNextCompatibleOuterSimilarIndex = prevOuterSimilarLaneIndex + a;
+                                            maxNextCompatibleOuterSimilarIndex = nextCompatibleLaneCount - 1; // always >=0
 #if DEBUGROUTING
 											if (debugFine)
 												Log._Debug($"RoutingManager.RecalculateLaneEndRoutingData({segmentId}, {laneIndex}, {laneId}, {startNode}): prevOuterSimilarLaneIndex == prevSimilarLaneCount - 1: minNextCompatibleOuterSimilarIndex={minNextCompatibleOuterSimilarIndex}, maxNextCompatibleOuterSimilarIndex={maxNextCompatibleOuterSimilarIndex}");
 #endif
-										} else {
-											minNextCompatibleOuterSimilarIndex = prevOuterSimilarLaneIndex + a;
-											maxNextCompatibleOuterSimilarIndex = prevOuterSimilarLaneIndex + b;
+                                        } else {
+                                            minNextCompatibleOuterSimilarIndex = prevOuterSimilarLaneIndex + a;
+                                            maxNextCompatibleOuterSimilarIndex = prevOuterSimilarLaneIndex + b;
 #if DEBUGROUTING
 											if (debugFine)
 												Log._Debug($"RoutingManager.RecalculateLaneEndRoutingData({segmentId}, {laneIndex}, {laneId}, {startNode}): default criss-cross case: minNextCompatibleOuterSimilarIndex={minNextCompatibleOuterSimilarIndex}, maxNextCompatibleOuterSimilarIndex={maxNextCompatibleOuterSimilarIndex}");
 #endif
-										}
-									}
-								} else {
-									// at lane splits: distribute traffic evenly (1-to-n, n-to-n)										
-									// prevOuterSimilarIndex is always > nextCompatibleLaneCount
+                                        }
+                                    }
+                                } else {
+                                    // at lane splits: distribute traffic evenly (1-to-n, n-to-n)										
+                                    // prevOuterSimilarIndex is always > nextCompatibleLaneCount
 #if DEBUGROUTING
 									if (debugFine)
 										Log._Debug($"RoutingManager.RecalculateLaneEndRoutingData({segmentId}, {laneIndex}, {laneId}, {startNode}): at lane splits: distribute traffic evenly (1-to-n, n-to-n)");
 #endif
-									if (sym1 == sym2) {
-										// split outer lanes
-										int a = (prevSimilarLaneCount - nextCompatibleLaneCount) >> 1; // prevSimilarLaneCount - nextCompatibleLaneCount is always > 0
-										minNextCompatibleOuterSimilarIndex = maxNextCompatibleOuterSimilarIndex = prevOuterSimilarLaneIndex - a; // a is always <= prevSimilarLaneCount
+                                    if (sym1 == sym2) {
+                                        // split outer lanes
+                                        int a = (prevSimilarLaneCount - nextCompatibleLaneCount) >> 1; // prevSimilarLaneCount - nextCompatibleLaneCount is always > 0
+                                        minNextCompatibleOuterSimilarIndex = maxNextCompatibleOuterSimilarIndex = prevOuterSimilarLaneIndex - a; // a is always <= prevSimilarLaneCount
 #if DEBUGROUTING
 										if (debugFine)
 											Log._Debug($"RoutingManager.RecalculateLaneEndRoutingData({segmentId}, {laneIndex}, {laneId}, {startNode}): split outer lanes: minNextCompatibleOuterSimilarIndex={minNextCompatibleOuterSimilarIndex}, maxNextCompatibleOuterSimilarIndex={maxNextCompatibleOuterSimilarIndex}");
 #endif
-									} else {
-										// split outer lanes, criss-cross inner lanes 
-										int a = (prevSimilarLaneCount - nextCompatibleLaneCount - 1) >> 1; // prevSimilarLaneCount - nextCompatibleLaneCount - 1 is always >= 0
+                                    } else {
+                                        // split outer lanes, criss-cross inner lanes 
+                                        int a = (prevSimilarLaneCount - nextCompatibleLaneCount - 1) >> 1; // prevSimilarLaneCount - nextCompatibleLaneCount - 1 is always >= 0
 
-										minNextCompatibleOuterSimilarIndex = (a - 1 >= prevOuterSimilarLaneIndex) ? 0 : prevOuterSimilarLaneIndex - a - 1;
-										maxNextCompatibleOuterSimilarIndex = (a >= prevOuterSimilarLaneIndex) ? 0 : prevOuterSimilarLaneIndex - a;
+                                        minNextCompatibleOuterSimilarIndex = (a - 1 >= prevOuterSimilarLaneIndex) ? 0 : prevOuterSimilarLaneIndex - a - 1;
+                                        maxNextCompatibleOuterSimilarIndex = (a >= prevOuterSimilarLaneIndex) ? 0 : prevOuterSimilarLaneIndex - a;
 #if DEBUGROUTING
 										if (debugFine)
 											Log._Debug($"RoutingManager.RecalculateLaneEndRoutingData({segmentId}, {laneIndex}, {laneId}, {startNode}): split outer lanes, criss-cross inner lanes: minNextCompatibleOuterSimilarIndex={minNextCompatibleOuterSimilarIndex}, maxNextCompatibleOuterSimilarIndex={maxNextCompatibleOuterSimilarIndex}");
 #endif
-									}
-								}
-							}
+                                    }
+                                }
+                            }
 
 #if DEBUGROUTING
 							if (debugFine)
 								Log._Debug($"RoutingManager.RecalculateLaneEndRoutingData({segmentId}, {laneIndex}, {laneId}, {startNode}): pre-final bounds: minNextCompatibleOuterSimilarIndex={minNextCompatibleOuterSimilarIndex}, maxNextCompatibleOuterSimilarIndex={maxNextCompatibleOuterSimilarIndex}");
 #endif
 
-							minNextCompatibleOuterSimilarIndex = Math.Max(0, Math.Min(minNextCompatibleOuterSimilarIndex, nextCompatibleLaneCount - 1));
-							maxNextCompatibleOuterSimilarIndex = Math.Max(0, Math.Min(maxNextCompatibleOuterSimilarIndex, nextCompatibleLaneCount - 1));
+                            minNextCompatibleOuterSimilarIndex = Math.Max(0, Math.Min(minNextCompatibleOuterSimilarIndex, nextCompatibleLaneCount - 1));
+                            maxNextCompatibleOuterSimilarIndex = Math.Max(0, Math.Min(maxNextCompatibleOuterSimilarIndex, nextCompatibleLaneCount - 1));
 
-							if (minNextCompatibleOuterSimilarIndex > maxNextCompatibleOuterSimilarIndex) {
-								minNextCompatibleOuterSimilarIndex = maxNextCompatibleOuterSimilarIndex;
-							}
+                            if (minNextCompatibleOuterSimilarIndex > maxNextCompatibleOuterSimilarIndex) {
+                                minNextCompatibleOuterSimilarIndex = maxNextCompatibleOuterSimilarIndex;
+                            }
 
 #if DEBUGROUTING
 							if (debugFine)
 								Log._Debug($"RoutingManager.RecalculateLaneEndRoutingData({segmentId}, {laneIndex}, {laneId}, {startNode}): final bounds: minNextCompatibleOuterSimilarIndex={minNextCompatibleOuterSimilarIndex}, maxNextCompatibleOuterSimilarIndex={maxNextCompatibleOuterSimilarIndex}");
 #endif
 
-							// find best matching lane(s)
-							for (int nextCompatibleOuterSimilarIndex = minNextCompatibleOuterSimilarIndex; nextCompatibleOuterSimilarIndex <= maxNextCompatibleOuterSimilarIndex; ++nextCompatibleOuterSimilarIndex) {
-								int nextTransitionIndex = FindLaneWithMaxOuterIndex(compatibleLaneIndicesSortedByOuterSimilarIndex, nextCompatibleOuterSimilarIndex);
+                            // find best matching lane(s)
+                            for (int nextCompatibleOuterSimilarIndex = minNextCompatibleOuterSimilarIndex; nextCompatibleOuterSimilarIndex <= maxNextCompatibleOuterSimilarIndex; ++nextCompatibleOuterSimilarIndex) {
+                                int nextTransitionIndex = FindLaneWithMaxOuterIndex(compatibleLaneIndicesSortedByOuterSimilarIndex, nextCompatibleOuterSimilarIndex);
 
 #if DEBUGROUTING
 								if (debugFine)
 									Log._Debug($"RoutingManager.RecalculateLaneEndRoutingData({segmentId}, {laneIndex}, {laneId}, {startNode}): best matching lane iteration -- nextCompatibleOuterSimilarIndex={nextCompatibleOuterSimilarIndex} => nextTransitionIndex={nextTransitionIndex}");
 #endif
 
-								if (nextTransitionIndex < 0) {
-									continue;
-								}
+                                if (nextTransitionIndex < 0) {
+                                    continue;
+                                }
 
-								// calculate lane distance
-								byte compatibleLaneDist = 0;
-								if (nextIncomingDir == ArrowDirection.Turn) {
-									compatibleLaneDist = (byte)GlobalConfig.Instance.PathFinding.UturnLaneDistance;
-								} else if (!isNextRealJunction && ((!nextIsJunction && !nextIsTransition) || nextCompatibleLaneCount == prevSimilarLaneCount)) {
-									int relLaneDist = nextCompatibleOuterSimilarIndices[nextTransitionIndex] - prevOuterSimilarLaneIndex; // relative lane distance (positive: change to more outer lane, negative: change to more inner lane)
-									compatibleLaneDist = (byte)Math.Abs(relLaneDist);
-								}
+                                // calculate lane distance
+                                byte compatibleLaneDist = 0;
+                                if (nextIncomingDir == ArrowDirection.Turn) {
+                                    compatibleLaneDist = (byte)GlobalConfig.Instance.PathFinding.UturnLaneDistance;
+                                } else if (!isNextRealJunction && ((!nextIsJunction && !nextIsTransition) || nextCompatibleLaneCount == prevSimilarLaneCount)) {
+                                    int relLaneDist = nextCompatibleOuterSimilarIndices[nextTransitionIndex] - prevOuterSimilarLaneIndex; // relative lane distance (positive: change to more outer lane, negative: change to more inner lane)
+                                    compatibleLaneDist = (byte)Math.Abs(relLaneDist);
+                                }
 
-								// skip lanes having lane connections
-								if (LaneConnectionManager.Instance.HasConnections(nextCompatibleTransitionDatas[nextTransitionIndex].laneId, isNextStartNodeOfNextSegment)) {
-									int laneConnectionTransIndex = compatibleLaneIndexToLaneConnectionIndex[nextTransitionIndex];
-									if (laneConnectionTransIndex >= 0) {
-										nextLaneConnectionTransitionDatas[laneConnectionTransIndex].distance = compatibleLaneDist;
-									}
+                                // skip lanes having lane connections
+                                if (LaneConnectionManager.Instance.HasConnections(nextCompatibleTransitionDatas[nextTransitionIndex].laneId, isNextStartNodeOfNextSegment)) {
+                                    int laneConnectionTransIndex = compatibleLaneIndexToLaneConnectionIndex[nextTransitionIndex];
+                                    if (laneConnectionTransIndex >= 0) {
+                                        nextLaneConnectionTransitionDatas[laneConnectionTransIndex].distance = compatibleLaneDist;
+                                    }
 #if DEBUGROUTING
 									if (debugFine)
 										Log._Debug($"RoutingManager.RecalculateLaneEndRoutingData({segmentId}, {laneIndex}, {laneId}, {startNode}): Next lane ({nextCompatibleTransitionDatas[nextTransitionIndex].laneId}) has outgoing lane connections. Skip for now but set compatibleLaneDist={compatibleLaneDist} if laneConnectionTransIndex={laneConnectionTransIndex} >= 0.");
 #endif
-									continue; // disregard lane since it has outgoing connections
-								}
+                                    continue; // disregard lane since it has outgoing connections
+                                }
 
-								if (
-									nextIncomingDir == ArrowDirection.Turn && // u-turn
-									!nextIsEndOrOneWayOut && // not a dead end
-									nextCompatibleOuterSimilarIndex != maxNextCompatibleOuterSimilarIndex // incoming lane is not innermost lane
-								) {
-									// force u-turns to happen on the innermost lane
-									++compatibleLaneDist;
-									nextCompatibleTransitionDatas[nextTransitionIndex].type = LaneEndTransitionType.Relaxed;
+                                if (
+                                    nextIncomingDir == ArrowDirection.Turn && // u-turn
+                                    !nextIsEndOrOneWayOut && // not a dead end
+                                    nextCompatibleOuterSimilarIndex != maxNextCompatibleOuterSimilarIndex // incoming lane is not innermost lane
+                                ) {
+                                    // force u-turns to happen on the innermost lane
+                                    ++compatibleLaneDist;
+                                    nextCompatibleTransitionDatas[nextTransitionIndex].type = LaneEndTransitionType.Relaxed;
 #if DEBUGROUTING
 									if (debugFine)
 										Log._Debug($"RoutingManager.RecalculateLaneEndRoutingData({segmentId}, {laneIndex}, {laneId}, {startNode}): Next lane ({nextCompatibleTransitionDatas[nextTransitionIndex].laneId}) is avoided u-turn. Incrementing compatible lane distance to {compatibleLaneDist}");
 #endif
-								}
+                                }
 
 #if DEBUGROUTING
 								if (debugFine)
 									Log._Debug($"RoutingManager.RecalculateLaneEndRoutingData({segmentId}, {laneIndex}, {laneId}, {startNode}): -> compatibleLaneDist={compatibleLaneDist}");
 #endif
 
-								nextCompatibleTransitionDatas[nextTransitionIndex].distance = compatibleLaneDist;
-								if (onHighway && !isNextRealJunction && compatibleLaneDist > 1) {
-									// under normal circumstances vehicles should not change more than one lane on highways at one time
-									nextCompatibleTransitionDatas[nextTransitionIndex].type = LaneEndTransitionType.Relaxed;
+                                nextCompatibleTransitionDatas[nextTransitionIndex].distance = compatibleLaneDist;
+                                if (onHighway && !isNextRealJunction && compatibleLaneDist > 1) {
+                                    // under normal circumstances vehicles should not change more than one lane on highways at one time
+                                    nextCompatibleTransitionDatas[nextTransitionIndex].type = LaneEndTransitionType.Relaxed;
 #if DEBUGROUTING
 									if (debugFine)
 										Log._Debug($"RoutingManager.RecalculateLaneEndRoutingData({segmentId}, {laneIndex}, {laneId}, {startNode}): -> under normal circumstances vehicles should not change more than one lane on highways at one time: setting type to Relaxed");
 #endif
-								} else if (applyHighwayRulesAtSegment) {
-									UpdateHighwayLaneArrows(nextCompatibleTransitionDatas[nextTransitionIndex].laneId, isNextStartNodeOfNextSegment, nextIncomingDir);
-								}
+                                } else if (applyHighwayRulesAtSegment) {
+                                    UpdateHighwayLaneArrows(nextCompatibleTransitionDatas[nextTransitionIndex].laneId, isNextStartNodeOfNextSegment, nextIncomingDir);
+                                }
 
-								if (numNextCompatibleTransitionDataIndices < MAX_NUM_TRANSITIONS) {
-									nextCompatibleTransitionDataIndices[numNextCompatibleTransitionDataIndices++] = nextTransitionIndex;
-								} else {
-									Log.Warning($"nextCompatibleTransitionDataIndices overflow @ source lane {prevLaneId}, idx {prevLaneIndex} @ seg. {prevSegmentId}");
-								}
-							} // foreach lane
-						} // highway/city rules if/else
-					} // compatible lanes found
+                                if (numNextCompatibleTransitionDataIndices < MAX_NUM_TRANSITIONS) {
+                                    nextCompatibleTransitionDataIndices[numNextCompatibleTransitionDataIndices++] = nextTransitionIndex;
+                                } else {
+                                    Log.Warning($"nextCompatibleTransitionDataIndices overflow @ source lane {prevLaneId}, idx {prevLaneIndex} @ seg. {prevSegmentId}");
+                                }
+                            } // foreach lane
+                        } // highway/city rules if/else
+                    } // compatible lanes found
 
-					// build final array
-					LaneTransitionData[] nextTransitionDatas = new LaneTransitionData[numNextRelaxedTransitionDatas + numNextCompatibleTransitionDataIndices + numNextLaneConnectionTransitionDatas + numNextForcedTransitionDatas];
-					int j = 0;
-					for (int i = 0; i < numNextCompatibleTransitionDataIndices; ++i) {
-						nextTransitionDatas[j++] = nextCompatibleTransitionDatas[nextCompatibleTransitionDataIndices[i]];
-					}
+                    // build final array
+                    LaneTransitionData[] nextTransitionDatas = new LaneTransitionData[numNextRelaxedTransitionDatas + numNextCompatibleTransitionDataIndices + numNextLaneConnectionTransitionDatas + numNextForcedTransitionDatas];
+                    int j = 0;
+                    for (int i = 0; i < numNextCompatibleTransitionDataIndices; ++i) {
+                        nextTransitionDatas[j++] = nextCompatibleTransitionDatas[nextCompatibleTransitionDataIndices[i]];
+                    }
 
-					for (int i = 0; i < numNextLaneConnectionTransitionDatas; ++i) {
-						nextTransitionDatas[j++] = nextLaneConnectionTransitionDatas[i];
-					}
+                    for (int i = 0; i < numNextLaneConnectionTransitionDatas; ++i) {
+                        nextTransitionDatas[j++] = nextLaneConnectionTransitionDatas[i];
+                    }
 
-					for (int i = 0; i < numNextRelaxedTransitionDatas; ++i) {
-						nextTransitionDatas[j++] = nextRelaxedTransitionDatas[i];
-					}
+                    for (int i = 0; i < numNextRelaxedTransitionDatas; ++i) {
+                        nextTransitionDatas[j++] = nextRelaxedTransitionDatas[i];
+                    }
 
-					for (int i = 0; i < numNextForcedTransitionDatas; ++i) {
-						nextTransitionDatas[j++] = nextForcedTransitionDatas[i];
-					}
+                    for (int i = 0; i < numNextForcedTransitionDatas; ++i) {
+                        nextTransitionDatas[j++] = nextForcedTransitionDatas[i];
+                    }
 
 #if DEBUGROUTING
 					if (debugFine)
 						Log._Debug($"RoutingManager.RecalculateLaneEndRoutingData({segmentId}, {laneIndex}, {laneId}, {startNode}): build array for nextSegment={nextSegmentId}: nextTransitionDatas={nextTransitionDatas.ArrayToString()}");
 #endif
 
-					backwardRouting.AddTransitions(nextTransitionDatas);
+                    backwardRouting.AddTransitions(nextTransitionDatas);
 
 #if DEBUGROUTING
 					if (debugFine)
 						Log._Debug($"RoutingManager.RecalculateLaneEndRoutingData({segmentId}, {laneIndex}, {laneId}, {startNode}): updated incoming/outgoing lanes for next segment iteration: totalIncomingLanes={totalIncomingLanes}, totalOutgoingLanes={totalOutgoingLanes}");
 #endif
-				} // valid segment
+                } // valid segment
 
-				if (nextSegmentId != prevSegmentId) {
-					totalIncomingLanes += incomingVehicleLanes;
-					totalOutgoingLanes += outgoingVehicleLanes;
-				}
+                if (nextSegmentId != prevSegmentId) {
+                    totalIncomingLanes += incomingVehicleLanes;
+                    totalOutgoingLanes += outgoingVehicleLanes;
+                }
 
-				if (iterateViaGeometry) {
-					Constants.ServiceFactory.NetService.ProcessSegment(nextSegmentId, delegate (ushort nextSegId, ref NetSegment segment) {
-						if (Constants.ServiceFactory.SimulationService.LeftHandDrive) {
-							nextSegmentId = segment.GetLeftSegment(nextNodeId);
-						} else {
-							nextSegmentId = segment.GetRightSegment(nextNodeId);
-						}
-						return true;
-					});
+                if (iterateViaGeometry) {
+                    Constants.ServiceFactory.NetService.ProcessSegment(nextSegmentId, delegate (ushort nextSegId, ref NetSegment segment) {
+                        if (Constants.ServiceFactory.SimulationService.LeftHandDrive) {
+                            nextSegmentId = segment.GetLeftSegment(nextNodeId);
+                        } else {
+                            nextSegmentId = segment.GetRightSegment(nextNodeId);
+                        }
+                        return true;
+                    });
 
-					if (nextSegmentId == prevSegmentId || nextSegmentId == 0) {
-						// we reached the first segment again
-						break;
-					}
-				}
-			} // foreach segment
+                    if (nextSegmentId == prevSegmentId || nextSegmentId == 0) {
+                        // we reached the first segment again
+                        break;
+                    }
+                }
+            } // foreach segment
 
-			// update backward routing
-			laneEndBackwardRoutings[GetLaneEndRoutingIndex(laneId, startNode)] = backwardRouting;
+            // update backward routing
+            laneEndBackwardRoutings[GetLaneEndRoutingIndex(laneId, startNode)] = backwardRouting;
 
-			// update forward routing
-			LaneTransitionData[] newTransitions = backwardRouting.transitions;
-			if (newTransitions != null) {
-				for (int i = 0; i < newTransitions.Length; ++i) {
-					uint sourceIndex = GetLaneEndRoutingIndex(newTransitions[i].laneId, newTransitions[i].startNode);
+            // update forward routing
+            LaneTransitionData[] newTransitions = backwardRouting.transitions;
+            if (newTransitions != null) {
+                for (int i = 0; i < newTransitions.Length; ++i) {
+                    uint sourceIndex = GetLaneEndRoutingIndex(newTransitions[i].laneId, newTransitions[i].startNode);
 
-					LaneTransitionData forwardTransition = new LaneTransitionData();
-					forwardTransition.laneId = laneId;
-					forwardTransition.laneIndex = (byte)laneIndex;
-					forwardTransition.type = newTransitions[i].type;
-					forwardTransition.distance = newTransitions[i].distance;
-					forwardTransition.segmentId = segmentId;
-					forwardTransition.startNode = startNode;
+                    LaneTransitionData forwardTransition = new LaneTransitionData();
+                    forwardTransition.laneId = laneId;
+                    forwardTransition.laneIndex = (byte)laneIndex;
+                    forwardTransition.type = newTransitions[i].type;
+                    forwardTransition.distance = newTransitions[i].distance;
+                    forwardTransition.segmentId = segmentId;
+                    forwardTransition.startNode = startNode;
 
-					laneEndForwardRoutings[sourceIndex].AddTransition(forwardTransition);
+                    laneEndForwardRoutings[sourceIndex].AddTransition(forwardTransition);
 
 #if DEBUGROUTING
 					if (debugFine)
 						Log._Debug($"RoutingManager.RecalculateLaneEndRoutingData({segmentId}, {laneIndex}, {laneId}, {startNode}): adding transition to forward routing of laneId={laneId}, idx={laneIndex} @ seg. {newTransitions[i].segmentId} @ node {newTransitions[i].startNode} (sourceIndex={sourceIndex}): {forwardTransition.ToString()}\n\nNew forward routing:\n{laneEndForwardRoutings[sourceIndex].ToString()}");
 #endif
-				}
-			}
+                }
+            }
 
 #if DEBUGROUTING
 			if (debugBasic)
 				Log._Debug($"RoutingManager.RecalculateLaneEndRoutingData({segmentId}, {laneIndex}, {laneId}, {startNode}): FINISHED calculating routing data for array index {GetLaneEndRoutingIndex(laneId, startNode)}: {backwardRouting}");
 #endif
-		}
+        }
 
-		/// <summary>
-		/// remove all backward routings from this lane and forward routings pointing to this lane
-		/// </summary>
-		/// <param name="laneId"></param>
-		/// <param name="startNode"></param>
-		protected void ResetLaneRoutings(uint laneId, bool startNode) {
-			uint index = GetLaneEndRoutingIndex(laneId, startNode);
+        /// <summary>
+        /// remove all backward routings from this lane and forward routings pointing to this lane
+        /// </summary>
+        /// <param name="laneId"></param>
+        /// <param name="startNode"></param>
+        protected void ResetLaneRoutings(uint laneId, bool startNode) {
+            uint index = GetLaneEndRoutingIndex(laneId, startNode);
 
-			LaneTransitionData[] oldBackwardTransitions = laneEndBackwardRoutings[index].transitions;
-			if (oldBackwardTransitions != null) {
-				for (int i = 0; i < oldBackwardTransitions.Length; ++i) {
-					uint sourceIndex = GetLaneEndRoutingIndex(oldBackwardTransitions[i].laneId, oldBackwardTransitions[i].startNode);
-					laneEndForwardRoutings[sourceIndex].RemoveTransition(laneId);
-				}
-			}
+            LaneTransitionData[] oldBackwardTransitions = laneEndBackwardRoutings[index].transitions;
+            if (oldBackwardTransitions != null) {
+                for (int i = 0; i < oldBackwardTransitions.Length; ++i) {
+                    uint sourceIndex = GetLaneEndRoutingIndex(oldBackwardTransitions[i].laneId, oldBackwardTransitions[i].startNode);
+                    laneEndForwardRoutings[sourceIndex].RemoveTransition(laneId);
+                }
+            }
 
-			laneEndBackwardRoutings[index].Reset();
-		}
+            laneEndBackwardRoutings[index].Reset();
+        }
 
-		private void UpdateHighwayLaneArrows(uint laneId, bool startNode, ArrowDirection dir) {
+        private void UpdateHighwayLaneArrows(uint laneId, bool startNode, ArrowDirection dir) {
 
-			Flags.LaneArrows? prevHighwayArrows = Flags.getHighwayLaneArrowFlags(laneId);
-			Flags.LaneArrows newHighwayArrows = Flags.LaneArrows.None;
-			if (prevHighwayArrows != null)
-				newHighwayArrows = (Flags.LaneArrows)prevHighwayArrows;
-			if (dir == ArrowDirection.Right)
-				newHighwayArrows |= Flags.LaneArrows.Left;
-			else if (dir == ArrowDirection.Left)
-				newHighwayArrows |= Flags.LaneArrows.Right;
-			else if (dir == ArrowDirection.Forward)
-				newHighwayArrows |= Flags.LaneArrows.Forward;
+            Flags.LaneArrows? prevHighwayArrows = Flags.getHighwayLaneArrowFlags(laneId);
+            Flags.LaneArrows newHighwayArrows = Flags.LaneArrows.None;
+            if (prevHighwayArrows != null)
+                newHighwayArrows = (Flags.LaneArrows)prevHighwayArrows;
+            if (dir == ArrowDirection.Right)
+                newHighwayArrows |= Flags.LaneArrows.Left;
+            else if (dir == ArrowDirection.Left)
+                newHighwayArrows |= Flags.LaneArrows.Right;
+            else if (dir == ArrowDirection.Forward)
+                newHighwayArrows |= Flags.LaneArrows.Forward;
 
 #if DEBUGROUTING
 			//Log._Debug($"RoutingManager.RecalculateLaneEndRoutingData: highway rules -- next lane {laneId} obeys highway rules. Setting highway lane arrows to {newHighwayArrows}. prevHighwayArrows={prevHighwayArrows}");
 #endif
 
-			if (newHighwayArrows != prevHighwayArrows && newHighwayArrows != Flags.LaneArrows.None) {
-				Flags.setHighwayLaneArrowFlags(laneId, newHighwayArrows, false);
-			}
-		}
+            if (newHighwayArrows != prevHighwayArrows && newHighwayArrows != Flags.LaneArrows.None) {
+                Flags.setHighwayLaneArrowFlags(laneId, newHighwayArrows, false);
+            }
+        }
 
-		/*private int GetSegmentNodeIndex(ushort nodeId, ushort segmentId) {
+        /*private int GetSegmentNodeIndex(ushort nodeId, ushort segmentId) {
 			int i = -1;
 			Services.NetService.IterateNodeSegments(nodeId, delegate (ushort segId, ref NetSegment segment) {
 				++i;
@@ -1307,117 +1336,117 @@ namespace TrafficManager.Manager.Impl {
 			return i;
 		}*/
 
-		internal uint GetLaneEndRoutingIndex(uint laneId, bool startNode) {
-			return (uint)(laneId + (startNode ? 0u : (uint)NetManager.MAX_LANE_COUNT));
-		}
+        internal uint GetLaneEndRoutingIndex(uint laneId, bool startNode) {
+            return (uint)(laneId + (startNode ? 0u : (uint)NetManager.MAX_LANE_COUNT));
+        }
 
-		public int CalcInnerSimilarLaneIndex(ushort segmentId, int laneIndex) {
-			int ret = -1;
-			Constants.ServiceFactory.NetService.ProcessSegment(segmentId, delegate (ushort segId, ref NetSegment segment) {
-				ret = CalcInnerSimilarLaneIndex(segment.Info.m_lanes[laneIndex]);
-				return true;
-			});
+        public int CalcInnerSimilarLaneIndex(ushort segmentId, int laneIndex) {
+            int ret = -1;
+            Constants.ServiceFactory.NetService.ProcessSegment(segmentId, delegate (ushort segId, ref NetSegment segment) {
+                ret = CalcInnerSimilarLaneIndex(segment.Info.m_lanes[laneIndex]);
+                return true;
+            });
 
-			return ret;
-		}
+            return ret;
+        }
 
-		public int CalcInnerSimilarLaneIndex(NetInfo.Lane laneInfo) {
-			// note: m_direction is correct here
-			return (byte)(laneInfo.m_direction & NetInfo.Direction.Forward) != 0 ? laneInfo.m_similarLaneIndex : laneInfo.m_similarLaneCount - laneInfo.m_similarLaneIndex - 1;
-		}
+        public int CalcInnerSimilarLaneIndex(NetInfo.Lane laneInfo) {
+            // note: m_direction is correct here
+            return (byte)(laneInfo.m_direction & NetInfo.Direction.Forward) != 0 ? laneInfo.m_similarLaneIndex : laneInfo.m_similarLaneCount - laneInfo.m_similarLaneIndex - 1;
+        }
 
-		public int CalcOuterSimilarLaneIndex(ushort segmentId, int laneIndex) {
-			int ret = -1;
-			Constants.ServiceFactory.NetService.ProcessSegment(segmentId, delegate (ushort segId, ref NetSegment segment) {
-				ret = CalcOuterSimilarLaneIndex(segment.Info.m_lanes[laneIndex]);
-				return true;
-			});
+        public int CalcOuterSimilarLaneIndex(ushort segmentId, int laneIndex) {
+            int ret = -1;
+            Constants.ServiceFactory.NetService.ProcessSegment(segmentId, delegate (ushort segId, ref NetSegment segment) {
+                ret = CalcOuterSimilarLaneIndex(segment.Info.m_lanes[laneIndex]);
+                return true;
+            });
 
-			return ret;
-		}
+            return ret;
+        }
 
-		public int CalcOuterSimilarLaneIndex(NetInfo.Lane laneInfo) {
-			// note: m_direction is correct here
-			return (byte)(laneInfo.m_direction & NetInfo.Direction.Forward) != 0 ? laneInfo.m_similarLaneCount - laneInfo.m_similarLaneIndex - 1 : laneInfo.m_similarLaneIndex;
-		}
+        public int CalcOuterSimilarLaneIndex(NetInfo.Lane laneInfo) {
+            // note: m_direction is correct here
+            return (byte)(laneInfo.m_direction & NetInfo.Direction.Forward) != 0 ? laneInfo.m_similarLaneCount - laneInfo.m_similarLaneIndex - 1 : laneInfo.m_similarLaneIndex;
+        }
 
-		protected int FindLaneWithMaxOuterIndex(int[] indicesSortedByOuterIndex, int targetOuterLaneIndex) {
-			return indicesSortedByOuterIndex[Math.Max(0, Math.Min(targetOuterLaneIndex, indicesSortedByOuterIndex.Length - 1))];
-		}
+        protected int FindLaneWithMaxOuterIndex(int[] indicesSortedByOuterIndex, int targetOuterLaneIndex) {
+            return indicesSortedByOuterIndex[Math.Max(0, Math.Min(targetOuterLaneIndex, indicesSortedByOuterIndex.Length - 1))];
+        }
 
-		protected int FindLaneByOuterIndex(LaneTransitionData[] laneTransitions, int num, ushort segmentId, int targetOuterLaneIndex) {
-			for (int i = 0; i < num; ++i) {
-				int outerIndex = CalcOuterSimilarLaneIndex(segmentId, laneTransitions[i].laneIndex);
-				if (outerIndex == targetOuterLaneIndex) {
-					return i;
-				}
-			}
-			return -1;
-		}
+        protected int FindLaneByOuterIndex(LaneTransitionData[] laneTransitions, int num, ushort segmentId, int targetOuterLaneIndex) {
+            for (int i = 0; i < num; ++i) {
+                int outerIndex = CalcOuterSimilarLaneIndex(segmentId, laneTransitions[i].laneIndex);
+                if (outerIndex == targetOuterLaneIndex) {
+                    return i;
+                }
+            }
+            return -1;
+        }
 
-		protected int FindLaneByInnerIndex(LaneTransitionData[] laneTransitions, int num, ushort segmentId, int targetInnerLaneIndex) {
-			for (int i = 0; i < num; ++i) {
-				int innerIndex = CalcInnerSimilarLaneIndex(segmentId, laneTransitions[i].laneIndex);
-				if (innerIndex == targetInnerLaneIndex) {
-					return i;
-				}
-			}
-			return -1;
-		}
+        protected int FindLaneByInnerIndex(LaneTransitionData[] laneTransitions, int num, ushort segmentId, int targetInnerLaneIndex) {
+            for (int i = 0; i < num; ++i) {
+                int innerIndex = CalcInnerSimilarLaneIndex(segmentId, laneTransitions[i].laneIndex);
+                if (innerIndex == targetInnerLaneIndex) {
+                    return i;
+                }
+            }
+            return -1;
+        }
 
-		protected bool IsOutgoingLane(ushort segmentId, bool startNode, int laneIndex) {
-			return IsIncomingOutgoingLane(segmentId, startNode, laneIndex, false);
-		}
+        protected bool IsOutgoingLane(ushort segmentId, bool startNode, int laneIndex) {
+            return IsIncomingOutgoingLane(segmentId, startNode, laneIndex, false);
+        }
 
-		protected bool IsIncomingLane(ushort segmentId, bool startNode, int laneIndex) {
-			return IsIncomingOutgoingLane(segmentId, startNode, laneIndex, true);
-		}
+        protected bool IsIncomingLane(ushort segmentId, bool startNode, int laneIndex) {
+            return IsIncomingOutgoingLane(segmentId, startNode, laneIndex, true);
+        }
 
-		protected bool IsIncomingOutgoingLane(ushort segmentId, bool startNode, int laneIndex, bool incoming) {
-			bool segIsInverted = false;
-			Constants.ServiceFactory.NetService.ProcessSegment(segmentId, delegate (ushort segId, ref NetSegment segment) {
-				segIsInverted = (segment.m_flags & NetSegment.Flags.Invert) != NetSegment.Flags.None;
-				return true;
-			});
+        protected bool IsIncomingOutgoingLane(ushort segmentId, bool startNode, int laneIndex, bool incoming) {
+            bool segIsInverted = false;
+            Constants.ServiceFactory.NetService.ProcessSegment(segmentId, delegate (ushort segId, ref NetSegment segment) {
+                segIsInverted = (segment.m_flags & NetSegment.Flags.Invert) != NetSegment.Flags.None;
+                return true;
+            });
 
-			NetInfo.Direction dir = startNode ? NetInfo.Direction.Forward : NetInfo.Direction.Backward;
-			dir = incoming ^ segIsInverted ? NetInfo.InvertDirection(dir) : dir;
+            NetInfo.Direction dir = startNode ? NetInfo.Direction.Forward : NetInfo.Direction.Backward;
+            dir = incoming ^ segIsInverted ? NetInfo.InvertDirection(dir) : dir;
 
-			NetInfo.Direction finalDir = NetInfo.Direction.None;
-			Constants.ServiceFactory.NetService.ProcessSegment(segmentId, delegate (ushort segId, ref NetSegment segment) {
-				finalDir = segment.Info.m_lanes[laneIndex].m_finalDirection;
-				return true;
-			});
+            NetInfo.Direction finalDir = NetInfo.Direction.None;
+            Constants.ServiceFactory.NetService.ProcessSegment(segmentId, delegate (ushort segId, ref NetSegment segment) {
+                finalDir = segment.Info.m_lanes[laneIndex].m_finalDirection;
+                return true;
+            });
 
-			return (finalDir & dir) != NetInfo.Direction.None;
-		}
+            return (finalDir & dir) != NetInfo.Direction.None;
+        }
 
-		protected override void HandleInvalidSegment(SegmentGeometry geometry) {
+        protected override void HandleInvalidSegment(SegmentGeometry geometry) {
 #if DEBUG
-			bool debug = GlobalConfig.Instance.Debug.Switches[1] && (GlobalConfig.Instance.Debug.SegmentId <= 0 || GlobalConfig.Instance.Debug.SegmentId == geometry.SegmentId);
-			if (debug) {
-				Log._Debug($"RoutingManager.HandleInvalidSegment({geometry.SegmentId}) called.");
-			}
+            bool debug = GlobalConfig.Instance.Debug.Switches[1] && (GlobalConfig.Instance.Debug.SegmentId <= 0 || GlobalConfig.Instance.Debug.SegmentId == geometry.SegmentId);
+            if (debug) {
+                Log._Debug($"RoutingManager.HandleInvalidSegment({geometry.SegmentId}) called.");
+            }
 #endif
-			Flags.removeHighwayLaneArrowFlagsAtSegment(geometry.SegmentId);
-			ResetRoutingData(geometry.SegmentId);
-		}
+            Flags.removeHighwayLaneArrowFlagsAtSegment(geometry.SegmentId);
+            ResetRoutingData(geometry.SegmentId);
+        }
 
-		protected override void HandleValidSegment(SegmentGeometry geometry) {
+        protected override void HandleValidSegment(SegmentGeometry geometry) {
 #if DEBUG
-			bool debug = GlobalConfig.Instance.Debug.Switches[1] && (GlobalConfig.Instance.Debug.SegmentId <= 0 || GlobalConfig.Instance.Debug.SegmentId == geometry.SegmentId);
-			if (debug) {
-				Log._Debug($"RoutingManager.HandleValidSegment({geometry.SegmentId}) called.");
-			}
+            bool debug = GlobalConfig.Instance.Debug.Switches[1] && (GlobalConfig.Instance.Debug.SegmentId <= 0 || GlobalConfig.Instance.Debug.SegmentId == geometry.SegmentId);
+            if (debug) {
+                Log._Debug($"RoutingManager.HandleValidSegment({geometry.SegmentId}) called.");
+            }
 #endif
-			ResetRoutingData(geometry.SegmentId);
-			RequestRecalculation(geometry.SegmentId);
-		}
+            ResetRoutingData(geometry.SegmentId);
+            RequestRecalculation(geometry.SegmentId);
+        }
 
-		public override void OnAfterLoadData() {
-			base.OnAfterLoadData();
+        public override void OnAfterLoadData() {
+            base.OnAfterLoadData();
 
-			RecalculateAll();
-		}
-	}
+            RecalculateAll();
+        }
+    }
 }

--- a/TLM/TLM/UI/SubTools/LaneConnectorTool.cs
+++ b/TLM/TLM/UI/SubTools/LaneConnectorTool.cs
@@ -15,626 +15,642 @@ using CSUtil.Commons;
 using TrafficManager.Manager.Impl;
 
 namespace TrafficManager.UI.SubTools {
-	public class LaneConnectorTool : SubTool {
-		enum MarkerSelectionMode {
-			None,
-			SelectSource,
-			SelectTarget
-		}
+    public class LaneConnectorTool : SubTool {
+        enum MarkerSelectionMode {
+            None,
+            SelectSource,
+            SelectTarget
+        }
 
-		enum StayInLaneMode {
-			None,
-			Both,
-			Forward,
-			Backward
-		}
+        enum StayInLaneMode {
+            None,
+            Both,
+            Forward,
+            Backward
+        }
 
-		private static readonly Color DefaultNodeMarkerColor = new Color(1f, 1f, 1f, 0.4f);
-		private NodeLaneMarker selectedMarker = null;
-		private NodeLaneMarker hoveredMarker = null;
-		private Dictionary<ushort, List<NodeLaneMarker>> currentNodeMarkers;
-		private StayInLaneMode stayInLaneMode = StayInLaneMode.None;
-		//private bool initDone = false;
+        private static readonly Color DefaultNodeMarkerColor = new Color(1f, 1f, 1f, 0.4f);
+        private NodeLaneMarker selectedMarker = null;
+        private NodeLaneMarker hoveredMarker = null;
+        private Dictionary<ushort, List<NodeLaneMarker>> currentNodeMarkers;
+        private StayInLaneMode stayInLaneMode = StayInLaneMode.None;
+        //private bool initDone = false;
 
-		class NodeLaneMarker {
-			internal ushort segmentId;
-			internal ushort nodeId;
-			internal bool startNode;
-			internal Vector3 position;
-			internal Vector3 secondaryPosition;
-			internal bool isSource;
-			internal bool isTarget;
-			internal uint laneId;
-			internal int innerSimilarLaneIndex;
-			internal int segmentIndex;
-			internal float radius = 1f;
-			internal Color color;
-			internal List<NodeLaneMarker> connectedMarkers = new List<NodeLaneMarker>();
-			internal NetInfo.LaneType laneType;
-			internal VehicleInfo.VehicleType vehicleType;
-		}
+        class NodeLaneMarker {
+            internal ushort segmentId;
+            internal ushort nodeId;
+            internal bool startNode;
+            internal Vector3 position;
+            internal Vector3 secondaryPosition;
+            internal bool isSource;
+            internal bool isTarget;
+            internal uint laneId;
+            internal int innerSimilarLaneIndex;
+            internal int segmentIndex;
+            internal float radius = 1f;
+            internal Color color;
+            internal int laneGroup;
+            internal List<NodeLaneMarker> connectedMarkers = new List<NodeLaneMarker>();
+            internal NetInfo.LaneType laneType;
+            internal VehicleInfo.VehicleType vehicleType;
+        }
 
-		public LaneConnectorTool(TrafficManagerTool mainTool) : base(mainTool) {
-			//Log._Debug($"TppLaneConnectorTool: Constructor called");
-			currentNodeMarkers = new Dictionary<ushort, List<NodeLaneMarker>>();
-		}
+        public LaneConnectorTool(TrafficManagerTool mainTool) : base(mainTool) {
+            //Log._Debug($"TppLaneConnectorTool: Constructor called");
+            currentNodeMarkers = new Dictionary<ushort, List<NodeLaneMarker>>();
+        }
 
-		public override void OnToolGUI(Event e) {
-			//Log._Debug($"TppLaneConnectorTool: OnToolGUI. SelectedNodeId={SelectedNodeId} SelectedSegmentId={SelectedSegmentId} HoveredNodeId={HoveredNodeId} HoveredSegmentId={HoveredSegmentId} IsInsideUI={MainTool.GetToolController().IsInsideUI}");
-		}
+        public override void OnToolGUI(Event e) {
+            //Log._Debug($"TppLaneConnectorTool: OnToolGUI. SelectedNodeId={SelectedNodeId} SelectedSegmentId={SelectedSegmentId} HoveredNodeId={HoveredNodeId} HoveredSegmentId={HoveredSegmentId} IsInsideUI={MainTool.GetToolController().IsInsideUI}");
+        }
 
-		public override void RenderInfoOverlay(RenderManager.CameraInfo cameraInfo) {
-			ShowOverlay(true, cameraInfo);
-		}
+        public override void RenderInfoOverlay(RenderManager.CameraInfo cameraInfo) {
+            ShowOverlay(true, cameraInfo);
+        }
 
-		private void ShowOverlay(bool viewOnly, RenderManager.CameraInfo cameraInfo) {
-			if (viewOnly && !Options.connectedLanesOverlay)
-				return;
+        private void ShowOverlay(bool viewOnly, RenderManager.CameraInfo cameraInfo) {
+            if (viewOnly && !Options.connectedLanesOverlay)
+                return;
 
-			NetManager netManager = Singleton<NetManager>.instance;
+            NetManager netManager = Singleton<NetManager>.instance;
 
-			var camPos = Singleton<SimulationManager>.instance.m_simulationView.m_position;
-			//Bounds bounds = new Bounds(Vector3.zero, Vector3.one);
-			Ray mouseRay = Camera.main.ScreenPointToRay(Input.mousePosition);
+            var camPos = Singleton<SimulationManager>.instance.m_simulationView.m_position;
+            //Bounds bounds = new Bounds(Vector3.zero, Vector3.one);
+            Ray mouseRay = Camera.main.ScreenPointToRay(Input.mousePosition);
 
-			for (uint nodeId = 1; nodeId < NetManager.MAX_NODE_COUNT; ++nodeId) {
-				if (!Constants.ServiceFactory.NetService.IsNodeValid((ushort)nodeId)) {
-					continue;
-				}
+            for (uint nodeId = 1; nodeId < NetManager.MAX_NODE_COUNT; ++nodeId) {
+                if (!Constants.ServiceFactory.NetService.IsNodeValid((ushort)nodeId)) {
+                    continue;
+                }
 
-				// TODO refactor connection class check
-				ItemClass connectionClass = NetManager.instance.m_nodes.m_buffer[nodeId].Info.GetConnectionClass();
-				if (connectionClass == null ||
-					!(connectionClass.m_service == ItemClass.Service.Road || (connectionClass.m_service == ItemClass.Service.PublicTransport &&
-					(connectionClass.m_subService == ItemClass.SubService.PublicTransportTrain ||
-					connectionClass.m_subService == ItemClass.SubService.PublicTransportMetro ||
-					connectionClass.m_subService == ItemClass.SubService.PublicTransportMonorail)))) {
-					continue;
-				}
+                // TODO refactor connection class check
+                ItemClass connectionClass = NetManager.instance.m_nodes.m_buffer[nodeId].Info.GetConnectionClass();
+                if (connectionClass == null ||
+                    !(connectionClass.m_service == ItemClass.Service.Road || (connectionClass.m_service == ItemClass.Service.PublicTransport &&
+                    (connectionClass.m_subService == ItemClass.SubService.PublicTransportTrain ||
+                    connectionClass.m_subService == ItemClass.SubService.PublicTransportMetro ||
+                    connectionClass.m_subService == ItemClass.SubService.PublicTransportMonorail)))) {
+                    continue;
+                }
 
-				var diff = NetManager.instance.m_nodes.m_buffer[nodeId].m_position - camPos;
-				if (diff.magnitude > TrafficManagerTool.MaxOverlayDistance)
-					continue; // do not draw if too distant
+                var diff = NetManager.instance.m_nodes.m_buffer[nodeId].m_position - camPos;
+                if (diff.magnitude > TrafficManagerTool.MaxOverlayDistance)
+                    continue; // do not draw if too distant
 
-				List<NodeLaneMarker> nodeMarkers;
-				bool hasMarkers = currentNodeMarkers.TryGetValue((ushort)nodeId, out nodeMarkers);
+                List<NodeLaneMarker> nodeMarkers;
+                bool hasMarkers = currentNodeMarkers.TryGetValue((ushort)nodeId, out nodeMarkers);
 
-				if (!viewOnly && GetMarkerSelectionMode() == MarkerSelectionMode.None) {
-					MainTool.DrawNodeCircle(cameraInfo, (ushort)nodeId, DefaultNodeMarkerColor, true);
-				}
+                if (!viewOnly && GetMarkerSelectionMode() == MarkerSelectionMode.None) {
+                    MainTool.DrawNodeCircle(cameraInfo, (ushort)nodeId, DefaultNodeMarkerColor, true);
+                }
 
-				if (hasMarkers) {
-					foreach (NodeLaneMarker laneMarker in nodeMarkers) {
-						if (!Constants.ServiceFactory.NetService.IsLaneValid(laneMarker.laneId)) {
-							continue;
-						}
+                if (hasMarkers) {
+                    foreach (NodeLaneMarker laneMarker in nodeMarkers) {
+                        if (!Constants.ServiceFactory.NetService.IsLaneValid(laneMarker.laneId)) {
+                            continue;
+                        }
 
-						foreach (NodeLaneMarker targetLaneMarker in laneMarker.connectedMarkers) {
-							// render lane connection from laneMarker to targetLaneMarker
-							if (!Constants.ServiceFactory.NetService.IsLaneValid(targetLaneMarker.laneId)) {
-								continue;
-							}
-							RenderLane(cameraInfo, laneMarker.position, targetLaneMarker.position, NetManager.instance.m_nodes.m_buffer[nodeId].m_position, laneMarker.color);
-						}
+                        foreach (NodeLaneMarker targetLaneMarker in laneMarker.connectedMarkers) {
+                            // render lane connection from laneMarker to targetLaneMarker
+                            if (!Constants.ServiceFactory.NetService.IsLaneValid(targetLaneMarker.laneId)) {
+                                continue;
+                            }
+                            RenderLane(cameraInfo, laneMarker.position, targetLaneMarker.position, NetManager.instance.m_nodes.m_buffer[nodeId].m_position, laneMarker.color);
+                        }
 
-						if (!viewOnly && nodeId == SelectedNodeId) {
-							//bounds.center = laneMarker.position;
-							bool markerIsHovered = IsLaneMarkerHovered(laneMarker, ref mouseRay);// bounds.IntersectRay(mouseRay);
+                        if (!viewOnly && nodeId == SelectedNodeId) {
+                            //bounds.center = laneMarker.position;
+                            bool markerIsHovered = IsLaneMarkerHovered(laneMarker, ref mouseRay);// bounds.IntersectRay(mouseRay);
 
-							// draw source marker in source selection mode,
-							// draw target marker (if segment turning angles are within bounds) and selected source marker in target selection mode
-							bool drawMarker = (GetMarkerSelectionMode() == MarkerSelectionMode.SelectSource && laneMarker.isSource) ||
-								(GetMarkerSelectionMode() == MarkerSelectionMode.SelectTarget && (
-								(laneMarker.isTarget &&
-								(laneMarker.vehicleType & selectedMarker.vehicleType) != VehicleInfo.VehicleType.None &&
-								CheckSegmentsTurningAngle(selectedMarker.segmentId, ref netManager.m_segments.m_buffer[selectedMarker.segmentId], selectedMarker.startNode, laneMarker.segmentId, ref netManager.m_segments.m_buffer[laneMarker.segmentId], laneMarker.startNode)
-								) || laneMarker == selectedMarker));
-							// highlight hovered marker and selected marker
-							bool highlightMarker = drawMarker && (laneMarker == selectedMarker || markerIsHovered);
+                            // draw source marker in source selection mode,
+                            // draw target marker (if segment turning angles are within bounds) and selected source marker in target selection mode
+                            bool drawMarker = (GetMarkerSelectionMode() == MarkerSelectionMode.SelectSource && laneMarker.isSource) ||
+                                (GetMarkerSelectionMode() == MarkerSelectionMode.SelectTarget && (
+                                (laneMarker.isTarget &&
+                                (laneMarker.vehicleType & selectedMarker.vehicleType) != VehicleInfo.VehicleType.None &&
+                                (laneMarker.laneGroup == selectedMarker.laneGroup) &&
+                                CheckSegmentsTurningAngle(selectedMarker.segmentId, ref netManager.m_segments.m_buffer[selectedMarker.segmentId], selectedMarker.startNode, laneMarker.segmentId, ref netManager.m_segments.m_buffer[laneMarker.segmentId], laneMarker.startNode)
+                                ) || laneMarker == selectedMarker));
+                            // highlight hovered marker and selected marker
+                            bool highlightMarker = drawMarker && (laneMarker == selectedMarker || markerIsHovered);
 
-							if (drawMarker) {
-								if (highlightMarker) {
-									laneMarker.radius = 2f;
-								} else
-									laneMarker.radius = 1f;
-							} else {
-								markerIsHovered = false;
-							}
+                            if (drawMarker) {
+                                if (highlightMarker) {
+                                    laneMarker.radius = 2f;
+                                } else
+                                    laneMarker.radius = 1f;
+                            } else {
+                                markerIsHovered = false;
+                            }
 
-							if (markerIsHovered) {
-								/*if (hoveredMarker != sourceLaneMarker)
+                            if (markerIsHovered) {
+                                /*if (hoveredMarker != sourceLaneMarker)
 									Log._Debug($"Marker @ lane {sourceLaneMarker.laneId} hovered");*/
-								hoveredMarker = laneMarker;
-							}
+                                hoveredMarker = laneMarker;
+                            }
 
-							if (drawMarker) {
-								//DrawLaneMarker(laneMarker, cameraInfo);
-								RenderManager.instance.OverlayEffect.DrawCircle(cameraInfo, laneMarker.color, laneMarker.position, laneMarker.radius, laneMarker.position.y - 100f, laneMarker.position.y + 100f, false, true);
-							}
-						}
-					}
-				}
-			}
-		}
+                            if (drawMarker) {
+                                //DrawLaneMarker(laneMarker, cameraInfo);
+                                RenderManager.instance.OverlayEffect.DrawCircle(cameraInfo, laneMarker.color, laneMarker.position, laneMarker.radius, laneMarker.position.y - 100f, laneMarker.position.y + 100f, false, true);
+                            }
+                        }
+                    }
+                }
+            }
+        }
 
-		private bool IsLaneMarkerHovered(NodeLaneMarker laneMarker, ref Ray mouseRay) {
-			Bounds bounds = new Bounds(Vector3.zero, Vector3.one);
-			bounds.center = laneMarker.position;
-			if (bounds.IntersectRay(mouseRay))
-				return true;
+        private bool IsLaneMarkerHovered(NodeLaneMarker laneMarker, ref Ray mouseRay) {
+            Bounds bounds = new Bounds(Vector3.zero, Vector3.one);
+            bounds.center = laneMarker.position;
+            if (bounds.IntersectRay(mouseRay))
+                return true;
 
-			bounds = new Bounds(Vector3.zero, Vector3.one);
-			bounds.center = laneMarker.secondaryPosition;
-			return bounds.IntersectRay(mouseRay);
-		}
+            bounds = new Bounds(Vector3.zero, Vector3.one);
+            bounds.center = laneMarker.secondaryPosition;
+            return bounds.IntersectRay(mouseRay);
+        }
 
-		public override void RenderOverlay(RenderManager.CameraInfo cameraInfo) {
-			//Log._Debug($"TppLaneConnectorTool: RenderOverlay. SelectedNodeId={SelectedNodeId} SelectedSegmentId={SelectedSegmentId} HoveredNodeId={HoveredNodeId} HoveredSegmentId={HoveredSegmentId} IsInsideUI={MainTool.GetToolController().IsInsideUI}");
-			// draw lane markers and connections
+        public override void RenderOverlay(RenderManager.CameraInfo cameraInfo) {
+            //Log._Debug($"TppLaneConnectorTool: RenderOverlay. SelectedNodeId={SelectedNodeId} SelectedSegmentId={SelectedSegmentId} HoveredNodeId={HoveredNodeId} HoveredSegmentId={HoveredSegmentId} IsInsideUI={MainTool.GetToolController().IsInsideUI}");
+            // draw lane markers and connections
 
-			hoveredMarker = null;
+            hoveredMarker = null;
 
-			ShowOverlay(false, cameraInfo);
+            ShowOverlay(false, cameraInfo);
 
-			// draw bezier from source marker to mouse position in target marker selection 
-			if (SelectedNodeId != 0) {
-				if (GetMarkerSelectionMode() == MarkerSelectionMode.SelectTarget) {
-					Vector3 selNodePos = NetManager.instance.m_nodes.m_buffer[SelectedNodeId].m_position;
+            // draw bezier from source marker to mouse position in target marker selection 
+            if (SelectedNodeId != 0) {
+                if (GetMarkerSelectionMode() == MarkerSelectionMode.SelectTarget) {
+                    Vector3 selNodePos = NetManager.instance.m_nodes.m_buffer[SelectedNodeId].m_position;
 
-					ToolBase.RaycastOutput output;
-					if (RayCastSegmentAndNode(out output)) {
-						RenderLane(cameraInfo, selectedMarker.position, output.m_hitPos, selNodePos, selectedMarker.color);
-					}
-				}
+                    ToolBase.RaycastOutput output;
+                    if (RayCastSegmentAndNode(out output)) {
+                        RenderLane(cameraInfo, selectedMarker.position, output.m_hitPos, selNodePos, selectedMarker.color);
+                    }
+                }
 
-				bool deleteAll = Input.GetKeyDown(KeyCode.Delete) || Input.GetKeyDown(KeyCode.Backspace);
-				bool stayInLane = Input.GetKeyDown(KeyCode.S) && (Input.GetKey(KeyCode.LeftShift) || Input.GetKey(KeyCode.RightShift)) && Singleton<NetManager>.instance.m_nodes.m_buffer[SelectedNodeId].CountSegments() == 2;
-				if (stayInLane)
-					deleteAll = true;
+                bool deleteAll = Input.GetKeyDown(KeyCode.Delete) || Input.GetKeyDown(KeyCode.Backspace);
+                bool stayInLane = Input.GetKeyDown(KeyCode.S) && (Input.GetKey(KeyCode.LeftShift) || Input.GetKey(KeyCode.RightShift)) && Singleton<NetManager>.instance.m_nodes.m_buffer[SelectedNodeId].CountSegments() == 2;
+                if (stayInLane)
+                    deleteAll = true;
 
-				if (deleteAll) {
-					// remove all connections at selected node
-					LaneConnectionManager.Instance.RemoveLaneConnectionsFromNode(SelectedNodeId);
-					RefreshCurrentNodeMarkers(SelectedNodeId);
-				}
+                if (deleteAll) {
+                    // remove all connections at selected node
+                    LaneConnectionManager.Instance.RemoveLaneConnectionsFromNode(SelectedNodeId);
+                    RefreshCurrentNodeMarkers(SelectedNodeId);
+                }
 
-				if (stayInLane) {
-					// "stay in lane"
-					switch (stayInLaneMode) {
-						case StayInLaneMode.None:
-							stayInLaneMode = StayInLaneMode.Both;
-							break;
-						case StayInLaneMode.Both:
-							stayInLaneMode = StayInLaneMode.Forward;
-							break;
-						case StayInLaneMode.Forward:
-							stayInLaneMode = StayInLaneMode.Backward;
-							break;
-						case StayInLaneMode.Backward:
-							stayInLaneMode = StayInLaneMode.None;
-							break;
-					}
+                if (stayInLane) {
+                    // "stay in lane"
+                    switch (stayInLaneMode) {
+                        case StayInLaneMode.None:
+                            stayInLaneMode = StayInLaneMode.Both;
+                            break;
+                        case StayInLaneMode.Both:
+                            stayInLaneMode = StayInLaneMode.Forward;
+                            break;
+                        case StayInLaneMode.Forward:
+                            stayInLaneMode = StayInLaneMode.Backward;
+                            break;
+                        case StayInLaneMode.Backward:
+                            stayInLaneMode = StayInLaneMode.None;
+                            break;
+                    }
 
-					if (stayInLaneMode != StayInLaneMode.None) {
-						List<NodeLaneMarker> nodeMarkers = GetNodeMarkers(SelectedNodeId, ref Singleton<NetManager>.instance.m_nodes.m_buffer[SelectedNodeId]);
-						if (nodeMarkers != null) {
-							selectedMarker = null;
-							foreach (NodeLaneMarker sourceLaneMarker in nodeMarkers) {
-								if (!sourceLaneMarker.isSource)
-									continue;
+                    if (stayInLaneMode != StayInLaneMode.None) {
+                        List<NodeLaneMarker> nodeMarkers = GetNodeMarkers(SelectedNodeId, ref Singleton<NetManager>.instance.m_nodes.m_buffer[SelectedNodeId]);
+                        if (nodeMarkers != null) {
+                            selectedMarker = null;
+                            foreach (NodeLaneMarker sourceLaneMarker in nodeMarkers) {
+                                if (!sourceLaneMarker.isSource)
+                                    continue;
 
-								if (stayInLaneMode == StayInLaneMode.Forward || stayInLaneMode == StayInLaneMode.Backward) {
-									if (sourceLaneMarker.segmentIndex == 0 ^ stayInLaneMode == StayInLaneMode.Backward) {
-										continue;
-									}
-								}
+                                if (stayInLaneMode == StayInLaneMode.Forward || stayInLaneMode == StayInLaneMode.Backward) {
+                                    if (sourceLaneMarker.segmentIndex == 0 ^ stayInLaneMode == StayInLaneMode.Backward) {
+                                        continue;
+                                    }
+                                }
 
-								foreach (NodeLaneMarker targetLaneMarker in nodeMarkers) {
-									if (!targetLaneMarker.isTarget || targetLaneMarker.segmentId == sourceLaneMarker.segmentId)
-										continue;
+                                foreach (NodeLaneMarker targetLaneMarker in nodeMarkers) {
+                                    if (!targetLaneMarker.isTarget || targetLaneMarker.segmentId == sourceLaneMarker.segmentId)
+                                        continue;
 
-									if (targetLaneMarker.innerSimilarLaneIndex == sourceLaneMarker.innerSimilarLaneIndex) {
-										Log._Debug($"Adding lane connection {sourceLaneMarker.laneId} -> {targetLaneMarker.laneId}");
-										LaneConnectionManager.Instance.AddLaneConnection(sourceLaneMarker.laneId, targetLaneMarker.laneId, sourceLaneMarker.startNode);
-									}
-								}
-							}
-						}
-						RefreshCurrentNodeMarkers(SelectedNodeId);
-					}
-				}
-			}
+                                    if (targetLaneMarker.innerSimilarLaneIndex == sourceLaneMarker.innerSimilarLaneIndex) {
+                                        Log._Debug($"Adding lane connection {sourceLaneMarker.laneId} -> {targetLaneMarker.laneId}");
+                                        LaneConnectionManager.Instance.AddLaneConnection(sourceLaneMarker.laneId, targetLaneMarker.laneId, sourceLaneMarker.startNode);
+                                    }
+                                }
+                            }
+                        }
+                        RefreshCurrentNodeMarkers(SelectedNodeId);
+                    }
+                }
+            }
 
-			if (GetMarkerSelectionMode() == MarkerSelectionMode.None && HoveredNodeId != 0) {
-				// draw hovered node
-				MainTool.DrawNodeCircle(cameraInfo, HoveredNodeId, Input.GetMouseButton(0));
-			}
-		}
+            if (GetMarkerSelectionMode() == MarkerSelectionMode.None && HoveredNodeId != 0) {
+                // draw hovered node
+                MainTool.DrawNodeCircle(cameraInfo, HoveredNodeId, Input.GetMouseButton(0));
+            }
+        }
 
-		public override void OnPrimaryClickOverlay() {
+        public override void OnPrimaryClickOverlay() {
 #if DEBUGCONN
 			bool debug = GlobalConfig.Instance.Debug.Switches[23];
 			if (debug)
 				Log._Debug($"TppLaneConnectorTool: OnPrimaryClickOverlay. SelectedNodeId={SelectedNodeId} SelectedSegmentId={SelectedSegmentId} HoveredNodeId={HoveredNodeId} HoveredSegmentId={HoveredSegmentId}");
 #endif
 
-			if (IsCursorInPanel())
-				return;
+            if (IsCursorInPanel())
+                return;
 
-			if (GetMarkerSelectionMode() == MarkerSelectionMode.None) {
-				if (HoveredNodeId != 0) {
+            if (GetMarkerSelectionMode() == MarkerSelectionMode.None) {
+                if (HoveredNodeId != 0) {
 #if DEBUGCONN
 					if (debug)
 						Log._Debug($"TppLaneConnectorTool: HoveredNode != 0");
 #endif
 
-					if (NetManager.instance.m_nodes.m_buffer[HoveredNodeId].CountSegments() < 2) {
-						// this node cannot be configured (dead end)
+                    if (NetManager.instance.m_nodes.m_buffer[HoveredNodeId].CountSegments() < 2) {
+                        // this node cannot be configured (dead end)
 #if DEBUGCONN
 						if (debug)
 							Log._Debug($"TppLaneConnectorTool: Node is a dead end");
 #endif
-						SelectedNodeId = 0;
-						selectedMarker = null;
-						stayInLaneMode = StayInLaneMode.None;
-						return;
-					}
+                        SelectedNodeId = 0;
+                        selectedMarker = null;
+                        stayInLaneMode = StayInLaneMode.None;
+                        return;
+                    }
 
-					if (SelectedNodeId != HoveredNodeId) {
+                    if (SelectedNodeId != HoveredNodeId) {
 #if DEBUGCONN
 						if (debug)
 							Log._Debug($"Node {HoveredNodeId} has been selected. Creating markers.");
 #endif
 
-						// selected node has changed. create markers
-						List<NodeLaneMarker> markers = GetNodeMarkers(HoveredNodeId, ref Singleton<NetManager>.instance.m_nodes.m_buffer[HoveredNodeId]);
-						if (markers != null) {
-							SelectedNodeId = HoveredNodeId;
-							selectedMarker = null;
-							stayInLaneMode = StayInLaneMode.None;
+                        // selected node has changed. create markers
+                        List<NodeLaneMarker> markers = GetNodeMarkers(HoveredNodeId, ref Singleton<NetManager>.instance.m_nodes.m_buffer[HoveredNodeId]);
+                        if (markers != null) {
+                            SelectedNodeId = HoveredNodeId;
+                            selectedMarker = null;
+                            stayInLaneMode = StayInLaneMode.None;
 
-							currentNodeMarkers[SelectedNodeId] = markers;
-						}
-						//this.allNodeMarkers[SelectedNodeId] = GetNodeMarkers(SelectedNodeId);
-					}
-				} else {
+                            currentNodeMarkers[SelectedNodeId] = markers;
+                        }
+                        //this.allNodeMarkers[SelectedNodeId] = GetNodeMarkers(SelectedNodeId);
+                    }
+                } else {
 #if DEBUGCONN
 					if (debug)
 						Log._Debug($"TppLaneConnectorTool: Node {SelectedNodeId} has been deselected.");
 #endif
 
-					// click on free spot. deselect node
-					SelectedNodeId = 0;
-					selectedMarker = null;
-					stayInLaneMode = StayInLaneMode.None;
-					return;
-				}
-			}
+                    // click on free spot. deselect node
+                    SelectedNodeId = 0;
+                    selectedMarker = null;
+                    stayInLaneMode = StayInLaneMode.None;
+                    return;
+                }
+            }
 
-			if (hoveredMarker != null) {
-				stayInLaneMode = StayInLaneMode.None;
+            if (hoveredMarker != null) {
+                stayInLaneMode = StayInLaneMode.None;
 
 #if DEBUGCONN
 				if (debug)
 					Log._Debug($"TppLaneConnectorTool: hoveredMarker != null. selMode={GetMarkerSelectionMode()}");
 #endif
 
-				// hovered marker has been clicked
-				if (GetMarkerSelectionMode() == MarkerSelectionMode.SelectSource) {
-					// select source marker
-					selectedMarker = hoveredMarker;
+                // hovered marker has been clicked
+                if (GetMarkerSelectionMode() == MarkerSelectionMode.SelectSource) {
+                    // select source marker
+                    selectedMarker = hoveredMarker;
 #if DEBUGCONN
 					if (debug)
 						Log._Debug($"TppLaneConnectorTool: set selected marker");
 #endif
-				} else if (GetMarkerSelectionMode() == MarkerSelectionMode.SelectTarget) {
-					// select target marker
-					//bool success = false;
-					if (LaneConnectionManager.Instance.RemoveLaneConnection(selectedMarker.laneId, hoveredMarker.laneId, selectedMarker.startNode)) { // try to remove connection
-						selectedMarker.connectedMarkers.Remove(hoveredMarker);
+                } else if (GetMarkerSelectionMode() == MarkerSelectionMode.SelectTarget) {
+                    // select target marker
+                    //bool success = false;
+                    if (LaneConnectionManager.Instance.RemoveLaneConnection(selectedMarker.laneId, hoveredMarker.laneId, selectedMarker.startNode)) { // try to remove connection
+                        selectedMarker.connectedMarkers.Remove(hoveredMarker);
 #if DEBUGCONN
 						if (debug)
 							Log._Debug($"TppLaneConnectorTool: removed lane connection: {selectedMarker.laneId}, {hoveredMarker.laneId}");
 #endif
-						//success = true;
-					} else if (LaneConnectionManager.Instance.AddLaneConnection(selectedMarker.laneId, hoveredMarker.laneId, selectedMarker.startNode)) { // try to add connection
-						selectedMarker.connectedMarkers.Add(hoveredMarker);
+                        //success = true;
+                    } else if (LaneConnectionManager.Instance.AddLaneConnection(selectedMarker.laneId, hoveredMarker.laneId, selectedMarker.startNode)) { // try to add connection
+                        selectedMarker.connectedMarkers.Add(hoveredMarker);
 #if DEBUGCONN
 						if (debug)
 							Log._Debug($"TppLaneConnectorTool: added lane connection: {selectedMarker.laneId}, {hoveredMarker.laneId}");
 #endif
-						//success = true;
-					}
+                        //success = true;
+                    }
 
-					/*if (success) {
+                    /*if (success) {
 						// connection has been modified. switch back to source marker selection
 						Log._Debug($"TppLaneConnectorTool: switch back to source marker selection");
 						selectedMarker = null;
 						selMode = MarkerSelectionMode.SelectSource;
 					}*/
-				}
-			}
-		}
+                }
+            }
+        }
 
-		public override void OnSecondaryClickOverlay() {
+        public override void OnSecondaryClickOverlay() {
 #if DEBUGCONN
 			bool debug = GlobalConfig.Instance.Debug.Switches[23];
 #endif
 
-			if (IsCursorInPanel())
-				return;
+            if (IsCursorInPanel())
+                return;
 
-			switch (GetMarkerSelectionMode()) {
-				case MarkerSelectionMode.None:
-				default:
+            switch (GetMarkerSelectionMode()) {
+                case MarkerSelectionMode.None:
+                default:
 #if DEBUGCONN
 					if (debug)
 						Log._Debug($"TppLaneConnectorTool: OnSecondaryClickOverlay: nothing to do");
 #endif
-					stayInLaneMode = StayInLaneMode.None;
-					break;
-				case MarkerSelectionMode.SelectSource:
-					// deselect node
+                    stayInLaneMode = StayInLaneMode.None;
+                    break;
+                case MarkerSelectionMode.SelectSource:
+                    // deselect node
 #if DEBUGCONN
 					if (debug)
 						Log._Debug($"TppLaneConnectorTool: OnSecondaryClickOverlay: selected node id = 0");
 #endif
-					SelectedNodeId = 0;
-					break;
-				case MarkerSelectionMode.SelectTarget:
-					// deselect source marker
+                    SelectedNodeId = 0;
+                    break;
+                case MarkerSelectionMode.SelectTarget:
+                    // deselect source marker
 #if DEBUGCONN
 					if (debug)
 						Log._Debug($"TppLaneConnectorTool: OnSecondaryClickOverlay: switch to selected source mode");
 #endif
-					selectedMarker = null;
-					break;
-			}
-		}
+                    selectedMarker = null;
+                    break;
+            }
+        }
 
-		public override void OnActivate() {
+        public override void OnActivate() {
 #if DEBUGCONN
 			bool debug = GlobalConfig.Instance.Debug.Switches[23];
 			if (debug)
 				Log._Debug("TppLaneConnectorTool: OnActivate");
 #endif
-			SelectedNodeId = 0;
-			selectedMarker = null;
-			hoveredMarker = null;
-			stayInLaneMode = StayInLaneMode.None;
-			RefreshCurrentNodeMarkers();
-		}
+            SelectedNodeId = 0;
+            selectedMarker = null;
+            hoveredMarker = null;
+            stayInLaneMode = StayInLaneMode.None;
+            RefreshCurrentNodeMarkers();
+        }
 
-		private void RefreshCurrentNodeMarkers(ushort forceNodeId=0) {
-			if (forceNodeId == 0) {
-				currentNodeMarkers.Clear();
-			} else {
-				currentNodeMarkers.Remove(forceNodeId);
-			}
+        private void RefreshCurrentNodeMarkers(ushort forceNodeId=0) {
+            if (forceNodeId == 0) {
+                currentNodeMarkers.Clear();
+            } else {
+                currentNodeMarkers.Remove(forceNodeId);
+            }
 
-			for (uint nodeId = (forceNodeId == 0 ? 1u : forceNodeId); nodeId <= (forceNodeId == 0 ? NetManager.MAX_NODE_COUNT-1 : forceNodeId); ++nodeId) {
-				if (!Constants.ServiceFactory.NetService.IsNodeValid((ushort)nodeId)) {
-					continue;
-				}
+            for (uint nodeId = (forceNodeId == 0 ? 1u : forceNodeId); nodeId <= (forceNodeId == 0 ? NetManager.MAX_NODE_COUNT - 1 : forceNodeId); ++nodeId) {
+                if (!Constants.ServiceFactory.NetService.IsNodeValid((ushort)nodeId)) {
+                    continue;
+                }
 
-				if (! LaneConnectionManager.Instance.HasNodeConnections((ushort)nodeId)) {
-					continue;
-				}
+                if (!LaneConnectionManager.Instance.HasNodeConnections((ushort)nodeId)) {
+                    continue;
+                }
 
-				List<NodeLaneMarker> nodeMarkers = GetNodeMarkers((ushort)nodeId, ref Singleton<NetManager>.instance.m_nodes.m_buffer[nodeId]);
-				if (nodeMarkers == null)
-					continue;
-				currentNodeMarkers[(ushort)nodeId] = nodeMarkers;
-			}
-		}
+                List<NodeLaneMarker> nodeMarkers = GetNodeMarkers((ushort)nodeId, ref Singleton<NetManager>.instance.m_nodes.m_buffer[nodeId]);
+                if (nodeMarkers == null)
+                    continue;
+                currentNodeMarkers[(ushort)nodeId] = nodeMarkers;
+            }
+        }
 
-		private MarkerSelectionMode GetMarkerSelectionMode() {
-			if (SelectedNodeId == 0)
-				return MarkerSelectionMode.None;
-			if (selectedMarker == null)
-				return MarkerSelectionMode.SelectSource;
-			return MarkerSelectionMode.SelectTarget;
-		}
+        private MarkerSelectionMode GetMarkerSelectionMode() {
+            if (SelectedNodeId == 0)
+                return MarkerSelectionMode.None;
+            if (selectedMarker == null)
+                return MarkerSelectionMode.SelectSource;
+            return MarkerSelectionMode.SelectTarget;
+        }
 
-		public override void Cleanup() {
-			
-		}
+        public override void Cleanup() {
 
-		public override void Initialize() {
-			base.Initialize();
-			Cleanup();
-			if (Options.connectedLanesOverlay) {
-				RefreshCurrentNodeMarkers();
-			} else {
-				currentNodeMarkers.Clear();
-			}
-		}
+        }
 
-		private List<NodeLaneMarker> GetNodeMarkers(ushort nodeId, ref NetNode node) {
-			if (nodeId == 0)
-				return null;
-			if ((node.m_flags & NetNode.Flags.Created) == NetNode.Flags.None)
-				return null;
+        public override void Initialize() {
+            base.Initialize();
+            Cleanup();
+            if (Options.connectedLanesOverlay) {
+                RefreshCurrentNodeMarkers();
+            } else {
+                currentNodeMarkers.Clear();
+            }
+        }
 
-			List<NodeLaneMarker> nodeMarkers = new List<NodeLaneMarker>();
-			LaneConnectionManager connManager = LaneConnectionManager.Instance;
+        private List<NodeLaneMarker> GetNodeMarkers(ushort nodeId, ref NetNode node) {
+            if (nodeId == 0)
+                return null;
+            if ((node.m_flags & NetNode.Flags.Created) == NetNode.Flags.None)
+                return null;
 
-			int offsetMultiplier = node.CountSegments() <= 2 ? 3 : 1;
-			for (int i = 0; i < 8; i++) {
-				ushort segmentId = node.GetSegment(i);
-				if (segmentId == 0)
-					continue;
+            List<NodeLaneMarker> nodeMarkers = new List<NodeLaneMarker>();
+            LaneConnectionManager connManager = LaneConnectionManager.Instance;
 
-				bool isEndNode = NetManager.instance.m_segments.m_buffer[segmentId].m_endNode == nodeId;
-				Vector3 offset = NetManager.instance.m_segments.m_buffer[segmentId].FindDirection(segmentId, nodeId) * offsetMultiplier;
-				NetInfo.Lane[] lanes = NetManager.instance.m_segments.m_buffer[segmentId].Info.m_lanes;
-				uint laneId = NetManager.instance.m_segments.m_buffer[segmentId].m_lanes;
-				for (byte laneIndex = 0; laneIndex < lanes.Length && laneId != 0; laneIndex++) {
-					NetInfo.Lane laneInfo = lanes[laneIndex];
-					if ((laneInfo.m_laneType & LaneConnectionManager.LANE_TYPES) != NetInfo.LaneType.None &&
-						(laneInfo.m_vehicleType & LaneConnectionManager.VEHICLE_TYPES) != VehicleInfo.VehicleType.None) {
+            int offsetMultiplier = node.CountSegments() <= 2 ? 3 : 1;
+            for (int i = 0; i < 8; i++) {
+                ushort segmentId = node.GetSegment(i);
+                if (segmentId == 0)
+                    continue;
+                bool isEndNode = NetManager.instance.m_segments.m_buffer[segmentId].m_endNode == nodeId;
+                Vector3 offset = NetManager.instance.m_segments.m_buffer[segmentId].FindDirection(segmentId, nodeId) * offsetMultiplier;
+                NetInfo.Lane[] lanes = NetManager.instance.m_segments.m_buffer[segmentId].Info.m_lanes;
+                uint laneId = NetManager.instance.m_segments.m_buffer[segmentId].m_lanes;
+                NetInfo info = NetManager.instance.m_segments.m_buffer[segmentId].Info;
+                int[] laneGroups = new int[lanes.Length];
+                List<NetInfo.Lane> sortedLanes = lanes.OrderBy(l => l.m_position).ToList();
+                if ((node.m_flags & NetNode.Flags.Junction) == NetNode.Flags.None) {
+                    for (byte laneIndex = 1; laneIndex < sortedLanes.Count && laneId != 0; laneIndex++) {
+                        NetInfo.Lane laneInfo = sortedLanes[laneIndex];
+                        laneGroups[laneIndex] = laneGroups[laneIndex - 1];
+                        if (laneInfo.m_finalDirection != sortedLanes[laneIndex - 1].m_finalDirection || (laneInfo.m_laneType & LaneConnectionManager.LANE_TYPES) == NetInfo.LaneType.None ||
+                        (laneInfo.m_vehicleType & LaneConnectionManager.VEHICLE_TYPES) == VehicleInfo.VehicleType.None || laneInfo.m_position > sortedLanes[laneIndex - 1].m_position + (0.5f * sortedLanes[laneIndex - 1].m_width) + (0.5f * laneInfo.m_width) + 1) {
+                            laneGroups[laneIndex]++;
+                        }
+                    }
+                }
+                for (byte laneIndex = 0; laneIndex < lanes.Length && laneId != 0; laneIndex++) {
+                    NetInfo.Lane laneInfo = lanes[laneIndex];
+                    if ((laneInfo.m_laneType & LaneConnectionManager.LANE_TYPES) != NetInfo.LaneType.None &&
+                        (laneInfo.m_vehicleType & LaneConnectionManager.VEHICLE_TYPES) != VehicleInfo.VehicleType.None) {
 
-						Vector3? pos = null;
-						bool isSource = false;
-						bool isTarget = false;
-						if (connManager.GetLaneEndPoint(segmentId, !isEndNode, laneIndex, laneId, laneInfo, out isSource, out isTarget, out pos)) {
+                        Vector3? pos = null;
+                        bool isSource = false;
+                        bool isTarget = false;
+                        if (connManager.GetLaneEndPoint(segmentId, !isEndNode, laneIndex, laneId, laneInfo, out isSource, out isTarget, out pos)) {
+                            int sortedLaneIndex = sortedLanes.IndexOf(laneInfo);
+                            pos = (Vector3)pos + offset;
+                            float terrainY = Singleton<TerrainManager>.instance.SampleDetailHeightSmooth(((Vector3)pos));
+                            Vector3 finalPos = new Vector3(((Vector3)pos).x, terrainY, ((Vector3)pos).z);
 
-							pos = (Vector3)pos + offset;
-							float terrainY = Singleton<TerrainManager>.instance.SampleDetailHeightSmooth(((Vector3)pos));
-							Vector3 finalPos = new Vector3(((Vector3)pos).x, terrainY, ((Vector3)pos).z);
+                            nodeMarkers.Add(new NodeLaneMarker() {
+                                segmentId = segmentId,
+                                laneId = laneId,
+                                nodeId = nodeId,
+                                startNode = !isEndNode,
+                                position = finalPos,
+                                secondaryPosition = (Vector3)pos,
+                                color = colors[nodeMarkers.Count % colors.Length],
+                                isSource = isSource,
+                                isTarget = isTarget,
+                                laneType = laneInfo.m_laneType,
+                                vehicleType = laneInfo.m_vehicleType,
+                                laneGroup = laneGroups[sortedLaneIndex],
+                                innerSimilarLaneIndex = ((byte)(laneInfo.m_direction & NetInfo.Direction.Forward) != 0) ? laneInfo.m_similarLaneIndex : laneInfo.m_similarLaneCount - laneInfo.m_similarLaneIndex - 1,
+                                segmentIndex = i
+                            });
+                        }
+                    }
 
-							nodeMarkers.Add(new NodeLaneMarker() {
-								segmentId = segmentId,
-								laneId = laneId,
-								nodeId = nodeId,
-								startNode = !isEndNode,
-								position = finalPos,
-								secondaryPosition = (Vector3)pos,
-								color = colors[nodeMarkers.Count % colors.Length],
-								isSource = isSource,
-								isTarget = isTarget,
-								laneType = laneInfo.m_laneType,
-								vehicleType = laneInfo.m_vehicleType,
-								innerSimilarLaneIndex = ((byte)(laneInfo.m_direction & NetInfo.Direction.Forward) != 0) ? laneInfo.m_similarLaneIndex : laneInfo.m_similarLaneCount - laneInfo.m_similarLaneIndex - 1,
-								segmentIndex = i
-							});
-						}
-					}
+                    laneId = NetManager.instance.m_lanes.m_buffer[laneId].m_nextLane;
+                }
+            }
 
-					laneId = NetManager.instance.m_lanes.m_buffer[laneId].m_nextLane;
-				}
-			}
+            if (nodeMarkers.Count == 0)
+                return null;
 
-			if (nodeMarkers.Count == 0)
-				return null;
+            foreach (NodeLaneMarker laneMarker1 in nodeMarkers) {
+                if (!laneMarker1.isSource)
+                    continue;
 
-			foreach (NodeLaneMarker laneMarker1 in nodeMarkers) {
-				if (!laneMarker1.isSource)
-					continue;
+                uint[] connections = LaneConnectionManager.Instance.GetLaneConnections(laneMarker1.laneId, laneMarker1.startNode);
+                if (connections == null || connections.Length == 0)
+                    continue;
 
-				uint[] connections = LaneConnectionManager.Instance.GetLaneConnections(laneMarker1.laneId, laneMarker1.startNode);
-				if (connections == null || connections.Length == 0)
-					continue;
+                foreach (NodeLaneMarker laneMarker2 in nodeMarkers) {
+                    if (!laneMarker2.isTarget)
+                        continue;
+                    if (laneMarker1.laneGroup != laneMarker2.laneGroup)
+                        continue;
+                    if (connections.Contains(laneMarker2.laneId))
+                        laneMarker1.connectedMarkers.Add(laneMarker2);
+                }
+            }
 
-				foreach (NodeLaneMarker laneMarker2 in nodeMarkers) {
-					if (!laneMarker2.isTarget)
-						continue;
+            return nodeMarkers;
+        }
 
-					if (connections.Contains(laneMarker2.laneId))
-						laneMarker1.connectedMarkers.Add(laneMarker2);
-				}
-			}
+        /// <summary>
+        /// Checks if the turning angle between two segments at the given node is within bounds.
+        /// </summary>
+        /// <param name="sourceSegmentId"></param>
+        /// <param name="sourceSegment"></param>
+        /// <param name="sourceStartNode"></param>
+        /// <param name="targetSegmentId"></param>
+        /// <param name="targetSegment"></param>
+        /// <param name="targetStartNode"></param>
+        /// <returns></returns>
+        private bool CheckSegmentsTurningAngle(ushort sourceSegmentId, ref NetSegment sourceSegment, bool sourceStartNode, ushort targetSegmentId, ref NetSegment targetSegment, bool targetStartNode) {
+            NetManager netManager = Singleton<NetManager>.instance;
 
-			return nodeMarkers;
-		}
+            NetInfo sourceSegmentInfo = netManager.m_segments.m_buffer[sourceSegmentId].Info;
+            NetInfo targetSegmentInfo = netManager.m_segments.m_buffer[targetSegmentId].Info;
 
-		/// <summary>
-		/// Checks if the turning angle between two segments at the given node is within bounds.
-		/// </summary>
-		/// <param name="sourceSegmentId"></param>
-		/// <param name="sourceSegment"></param>
-		/// <param name="sourceStartNode"></param>
-		/// <param name="targetSegmentId"></param>
-		/// <param name="targetSegment"></param>
-		/// <param name="targetStartNode"></param>
-		/// <returns></returns>
-		private bool CheckSegmentsTurningAngle(ushort sourceSegmentId, ref NetSegment sourceSegment, bool sourceStartNode, ushort targetSegmentId, ref NetSegment targetSegment, bool targetStartNode) {
-			NetManager netManager = Singleton<NetManager>.instance;
+            float turningAngle = 0.01f - Mathf.Min(sourceSegmentInfo.m_maxTurnAngleCos, targetSegmentInfo.m_maxTurnAngleCos);
+            if (turningAngle < 1f) {
+                Vector3 sourceDirection;
+                if (sourceStartNode) {
+                    sourceDirection = sourceSegment.m_startDirection;
+                } else {
+                    sourceDirection = sourceSegment.m_endDirection;
+                }
 
-			NetInfo sourceSegmentInfo = netManager.m_segments.m_buffer[sourceSegmentId].Info;
-			NetInfo targetSegmentInfo = netManager.m_segments.m_buffer[targetSegmentId].Info;
+                Vector3 targetDirection;
+                if (targetStartNode) {
+                    targetDirection = targetSegment.m_startDirection;
+                } else {
+                    targetDirection = targetSegment.m_endDirection;
+                }
+                float dirDotProd = sourceDirection.x * targetDirection.x + sourceDirection.z * targetDirection.z;
+                return dirDotProd < turningAngle;
+            }
+            return true;
+        }
 
-			float turningAngle = 0.01f - Mathf.Min(sourceSegmentInfo.m_maxTurnAngleCos, targetSegmentInfo.m_maxTurnAngleCos);
-			if (turningAngle < 1f) {
-				Vector3 sourceDirection;
-				if (sourceStartNode) {
-					sourceDirection = sourceSegment.m_startDirection;
-				} else {
-					sourceDirection = sourceSegment.m_endDirection;
-				}
+        private void RenderLane(RenderManager.CameraInfo cameraInfo, Vector3 start, Vector3 end, Vector3 middlePoint, Color color, float size = 0.1f) {
+            Bezier3 bezier;
+            bezier.a = start;
+            bezier.d = end;
+            NetSegment.CalculateMiddlePoints(bezier.a, (middlePoint - bezier.a).normalized, bezier.d, (middlePoint - bezier.d).normalized, false, false, out bezier.b, out bezier.c);
 
-				Vector3 targetDirection;
-				if (targetStartNode) {
-					targetDirection = targetSegment.m_startDirection;
-				} else {
-					targetDirection = targetSegment.m_endDirection;
-				}
-				float dirDotProd = sourceDirection.x * targetDirection.x + sourceDirection.z * targetDirection.z;
-				return dirDotProd < turningAngle;
-			}
-			return true;
-		}
+            RenderManager.instance.OverlayEffect.DrawBezier(cameraInfo, color, bezier, size, 0, 0, -1f, 1280f, false, true);
+        }
 
-		private void RenderLane(RenderManager.CameraInfo cameraInfo, Vector3 start, Vector3 end, Vector3 middlePoint, Color color, float size = 0.1f) {
-			Bezier3 bezier;
-			bezier.a = start;
-			bezier.d = end;
-			NetSegment.CalculateMiddlePoints(bezier.a, (middlePoint - bezier.a).normalized, bezier.d, (middlePoint - bezier.d).normalized, false, false, out bezier.b, out bezier.c);
+        private bool RayCastSegmentAndNode(out ToolBase.RaycastOutput output) {
+            ToolBase.RaycastInput input = new ToolBase.RaycastInput(Camera.main.ScreenPointToRay(Input.mousePosition), Camera.main.farClipPlane);
+            input.m_netService.m_service = ItemClass.Service.Road;
+            input.m_netService.m_itemLayers = ItemClass.Layer.Default | ItemClass.Layer.MetroTunnels;
+            input.m_ignoreSegmentFlags = NetSegment.Flags.None;
+            input.m_ignoreNodeFlags = NetNode.Flags.None;
+            input.m_ignoreTerrain = true;
 
-			RenderManager.instance.OverlayEffect.DrawBezier(cameraInfo, color, bezier, size, 0, 0, -1f, 1280f, false, true);
-		}
+            return MainTool.DoRayCast(input, out output);
+        }
 
-		private bool RayCastSegmentAndNode(out ToolBase.RaycastOutput output) {
-			ToolBase.RaycastInput input = new ToolBase.RaycastInput(Camera.main.ScreenPointToRay(Input.mousePosition), Camera.main.farClipPlane);
-			input.m_netService.m_service = ItemClass.Service.Road;
-			input.m_netService.m_itemLayers = ItemClass.Layer.Default | ItemClass.Layer.MetroTunnels;
-			input.m_ignoreSegmentFlags = NetSegment.Flags.None;
-			input.m_ignoreNodeFlags = NetNode.Flags.None;
-			input.m_ignoreTerrain = true;
-
-			return MainTool.DoRayCast(input, out output);
-		}
-
-		private static readonly Color32[] colors = new Color32[]
-		{
-			new Color32(161, 64, 206, 255),
-			new Color32(79, 251, 8, 255),
-			new Color32(243, 96, 44, 255),
-			new Color32(45, 106, 105, 255),
-			new Color32(253, 165, 187, 255),
-			new Color32(90, 131, 14, 255),
-			new Color32(58, 20, 70, 255),
-			new Color32(248, 246, 183, 255),
-			new Color32(255, 205, 29, 255),
-			new Color32(91, 50, 18, 255),
-			new Color32(76, 239, 155, 255),
-			new Color32(241, 25, 130, 255),
-			new Color32(125, 197, 240, 255),
-			new Color32(57, 102, 187, 255),
-			new Color32(160, 27, 61, 255),
-			new Color32(167, 251, 107, 255),
-			new Color32(165, 94, 3, 255),
-			new Color32(204, 18, 161, 255),
-			new Color32(208, 136, 237, 255),
-			new Color32(232, 211, 202, 255),
-			new Color32(45, 182, 15, 255),
-			new Color32(8, 40, 47, 255),
-			new Color32(249, 172, 142, 255),
-			new Color32(248, 99, 101, 255),
-			new Color32(180, 250, 208, 255),
-			new Color32(126, 25, 77, 255),
-			new Color32(243, 170, 55, 255),
-			new Color32(47, 69, 126, 255),
-			new Color32(50, 105, 70, 255),
-			new Color32(156, 49, 1, 255),
-			new Color32(233, 231, 255, 255),
-			new Color32(107, 146, 253, 255),
-			new Color32(127, 35, 26, 255),
-			new Color32(240, 94, 222, 255),
-			new Color32(58, 28, 24, 255),
-			new Color32(165, 179, 240, 255),
-			new Color32(239, 93, 145, 255),
-			new Color32(47, 110, 138, 255),
-			new Color32(57, 195, 101, 255),
-			new Color32(124, 88, 213, 255),
-			new Color32(252, 220, 144, 255),
-			new Color32(48, 106, 224, 255),
-			new Color32(90, 109, 28, 255),
-			new Color32(56, 179, 208, 255),
-			new Color32(239, 73, 177, 255),
-			new Color32(84, 60, 2, 255),
-			new Color32(169, 104, 238, 255),
-			new Color32(97, 201, 238, 255),
-		};
-	}
+        private static readonly Color32[] colors = new Color32[]
+        {
+            new Color32(161, 64, 206, 255),
+            new Color32(79, 251, 8, 255),
+            new Color32(243, 96, 44, 255),
+            new Color32(45, 106, 105, 255),
+            new Color32(253, 165, 187, 255),
+            new Color32(90, 131, 14, 255),
+            new Color32(58, 20, 70, 255),
+            new Color32(248, 246, 183, 255),
+            new Color32(255, 205, 29, 255),
+            new Color32(91, 50, 18, 255),
+            new Color32(76, 239, 155, 255),
+            new Color32(241, 25, 130, 255),
+            new Color32(125, 197, 240, 255),
+            new Color32(57, 102, 187, 255),
+            new Color32(160, 27, 61, 255),
+            new Color32(167, 251, 107, 255),
+            new Color32(165, 94, 3, 255),
+            new Color32(204, 18, 161, 255),
+            new Color32(208, 136, 237, 255),
+            new Color32(232, 211, 202, 255),
+            new Color32(45, 182, 15, 255),
+            new Color32(8, 40, 47, 255),
+            new Color32(249, 172, 142, 255),
+            new Color32(248, 99, 101, 255),
+            new Color32(180, 250, 208, 255),
+            new Color32(126, 25, 77, 255),
+            new Color32(243, 170, 55, 255),
+            new Color32(47, 69, 126, 255),
+            new Color32(50, 105, 70, 255),
+            new Color32(156, 49, 1, 255),
+            new Color32(233, 231, 255, 255),
+            new Color32(107, 146, 253, 255),
+            new Color32(127, 35, 26, 255),
+            new Color32(240, 94, 222, 255),
+            new Color32(58, 28, 24, 255),
+            new Color32(165, 179, 240, 255),
+            new Color32(239, 93, 145, 255),
+            new Color32(47, 110, 138, 255),
+            new Color32(57, 195, 101, 255),
+            new Color32(124, 88, 213, 255),
+            new Color32(252, 220, 144, 255),
+            new Color32(48, 106, 224, 255),
+            new Color32(90, 109, 28, 255),
+            new Color32(56, 179, 208, 255),
+            new Color32(239, 73, 177, 255),
+            new Color32(84, 60, 2, 255),
+            new Color32(169, 104, 238, 255),
+            new Color32(97, 201, 238, 255),
+        };
+    }
 }


### PR DESCRIPTION
So I'm not sure if I am doing this request in the right place but I have modified LaneConnectorTool and RouteManager to restrict crossing over medians to change lanes.  Essentially groups of lanes separated by space (over 1m) or a median will be grouped together.  I also made it so that trains cannot change lanes outside of junctions.  This is just a first draft so it is subject to some additions.

Fixes #89 