### PR TITLE
More Accurate Lane Connection Arcs

### DIFF
--- a/TLM/TLM/UI/SubTools/LaneConnectorTool.cs
+++ b/TLM/TLM/UI/SubTools/LaneConnectorTool.cs
@@ -731,7 +731,7 @@ namespace TrafficManager.UI.SubTools {
             Bezier3 bezier3;
             if (start.SegmentId != target.SegmentId) {
                 Vector3 lDir = NetManager.instance.m_lanes.m_buffer[start.LaneId].m_bezier.Tangent(start.StartNode ? 0f : 1f);
-                Vector3 tDir = NetManager.instance.m_lanes.m_buffer[target.LaneId].m_bezier.Tangent(target.startNode ? 0f : 1f);
+                Vector3 tDir = NetManager.instance.m_lanes.m_buffer[target.LaneId].m_bezier.Tangent(target.StartNode ? 0f : 1f);
 
                 // TODO fix
                 // SegmentEndGeometry segmentEndGeometry = SegmentGeometry.Get(start.segmentId).GetEnd(start.startNode);


### PR DESCRIPTION
Key changes:

- greatly improved shape of lane connection. Now it should be almost equal to path of moving vehicle :wink:
- removed rendering of gray circles from all intersections (still visible on intersection with lane connection set - todo)
- improved drawing performance in edit and preview mode (little game hang when switching from preview -> edit - todo)
 
I think this could be the first new enhancement pushed to LABS first before moving to STABLE but we will see 😉 

PR set as draft for now until I'll fix those problems 😃

![lane connections](https://user-images.githubusercontent.com/19638970/56083870-dc597b80-5e2a-11e9-9869-7bebc97820bd.png)

Fixes #3