### PR TITLE
On Screen Display with Help and Keyboard Hints

### DIFF
--- a/TLM/TLM/Resources/lang.txt
+++ b/TLM/TLM/Resources/lang.txt
@@ -255,3 +255,10 @@ Road_signs_theme_mph Theme for MPH road signs
 theme_Square_US US signs
 theme_Round_UK British signs
 theme_Round_German German signs
+Toggle_OSD_panel_visible Hide OSD panel, now visible
+Toggle_OSD_panel_hidden Show OSD panel, now hidden
+OSD_Lane_Connection__Select Lane Connection: Select a node
+OSD_Exit_tool Exit tool
+OSD_Lane_Connection__Link Now link incoming lanes to outgoing
+OSD_Lane_Connection_Stay_in_lane Stay in lane (both, forward or back)
+OSD_Lane_Connection_Clear Clear

--- a/TLM/TLM/State/ConfigData/Main.cs
+++ b/TLM/TLM/State/ConfigData/Main.cs
@@ -21,6 +21,10 @@ namespace TrafficManager.State.ConfigData {
 		public int MainMenuY = MainMenuPanel.DEFAULT_MENU_Y;
 		public bool MainMenuPosLocked = false;
 
+		public int OSDPanelX = MainMenuPanel.DEFAULT_MENU_X;
+		public int OSDPanelY = MainMenuPanel.DEFAULT_MENU_Y - 32;
+		public bool OSDPanelVisible = true;
+
 		/// <summary>
 		/// Already displayed tutorial messages
 		/// </summary>

--- a/TLM/TLM/State/Keybinds/KeybindSettingsBase.cs
+++ b/TLM/TLM/State/Keybinds/KeybindSettingsBase.cs
@@ -19,7 +19,7 @@ namespace TrafficManager.State.Keybinds {
         /// <value>
         /// This input key can not be changed and is not checked, instead it is display only
         /// </value>
-        protected static KeybindSetting ToolCancelViewOnly = new KeybindSetting(
+        public static KeybindSetting ToolCancelViewOnly = new KeybindSetting(
             "Global",
             "Key_ExitSubtool",
             SavedInputKey.Encode(KeyCode.Escape, false, false, false));

--- a/TLM/TLM/State/Keybinds/KeybindUI.cs
+++ b/TLM/TLM/State/Keybinds/KeybindUI.cs
@@ -7,6 +7,7 @@ namespace TrafficManager.State.Keybinds {
     using ColossalFramework.UI;
     using CSUtil.Commons;
     using UI;
+    using UI.MainMenu;
     using UnityEngine;
 
     /// <summary>
@@ -219,6 +220,9 @@ namespace TrafficManager.State.Keybinds {
                     } else {
                         editedBinding.Value.TargetKey.value = inputKey;
                         editedBinding.Value.Target.NotifyKeyChanged();
+
+                        // Refresh OSD keybinds
+                        LoadingExtension.BaseUI.MainMenu.OsdPanel.Update();
                     }
                 }
 
@@ -256,6 +260,9 @@ namespace TrafficManager.State.Keybinds {
                 } else {
                     editedBinding.Value.TargetKey.value = inputKey;
                     editedBinding.Value.Target.NotifyKeyChanged();
+
+                    // Refresh OSD keybinds
+                    LoadingExtension.BaseUI.MainMenu.OsdPanel.Update();
                 }
 
                 keybindButton.buttonsMask = UIMouseButton.Left;

--- a/TLM/TLM/TLM.csproj
+++ b/TLM/TLM/TLM.csproj
@@ -231,6 +231,10 @@
     <Compile Include="LoadingExtension.cs" />
     <Compile Include="UI\CustomKeyHandler.cs" />
     <Compile Include="UI\IncompatibleModsPanel.cs" />
+    <Compile Include="UI\MainMenu\OSD\OnScreenDisplayPanel.cs" />
+    <Compile Include="UI\MainMenu\OSD\OsdItem.cs" />
+    <Compile Include="UI\MainMenu\OSD\OsdItem_Shortcut.cs" />
+    <Compile Include="UI\MainMenu\OSD\OsdItem_Text.cs" />
     <Compile Include="UI\RemoveCitizenInstanceButtonExtender.cs" />
     <Compile Include="UI\RemoveVehicleButtonExtender.cs" />
     <Compile Include="UI\MainMenu\LaneConnectorButton.cs" />

--- a/TLM/TLM/TLM.csproj
+++ b/TLM/TLM/TLM.csproj
@@ -235,6 +235,7 @@
     <Compile Include="UI\MainMenu\OSD\OsdItem.cs" />
     <Compile Include="UI\MainMenu\OSD\OsdItem_Shortcut.cs" />
     <Compile Include="UI\MainMenu\OSD\OsdItem_Text.cs" />
+    <Compile Include="UI\MainMenu\OSD\OsdUIPanel.cs" />
     <Compile Include="UI\RemoveCitizenInstanceButtonExtender.cs" />
     <Compile Include="UI\RemoveVehicleButtonExtender.cs" />
     <Compile Include="UI\MainMenu\LaneConnectorButton.cs" />

--- a/TLM/TLM/UI/MainMenu/MainMenuPanel.cs
+++ b/TLM/TLM/UI/MainMenu/MainMenuPanel.cs
@@ -84,7 +84,15 @@ namespace TrafficManager.UI.MainMenu {
         private SizeProfile activeProfile = null;
         private bool started = false;
 
-        public OnScreenDisplayPanel OsdPanel;
+        /// <summary>
+        /// OSD Panel with help and keybind tips
+        /// </summary>
+        public OnScreenDisplayPanel OsdPanel { get; private set; }
+
+        /// <summary>
+        /// Toggle button for OSD panel visibility
+        /// </summary>
+        public UIButton OsdButton { get; private set; }
 
         public override void Start() {
             GlobalConfig conf = GlobalConfig.Instance;
@@ -113,15 +121,22 @@ namespace TrafficManager.UI.MainMenu {
             Drag = dragHandler.AddComponent<UIDragHandle>();
             Drag.enabled = !GlobalConfig.Instance.Main.MainMenuPosLocked;
 
-            // Attach On-Screen Display panel (invisible)
-            OsdPanel = new OnScreenDisplayPanel(this);
-
             UpdateAllSizes();
+
+            // Attach On-Screen Display panel (invisible)
+            // This reads main menu panel size, so goes after Update(All)Sizes
+            try {
+                OsdPanel = new OnScreenDisplayPanel(UIView.GetAView(), this);
+                OsdButton = OsdPanel.CreateOsdButton(VersionLabel);
+            }
+            catch (Exception e) {
+                Log.Error($"Error creating OSD panel: {e}");
+            }
+
             started = true;
         }
 
         public override void OnDestroy() {
-            OsdPanel = null; // break the reference loop
             confDisposable?.Dispose();
         }
 
@@ -141,8 +156,6 @@ namespace TrafficManager.UI.MainMenu {
                 config.Main.MainMenuY = (int)absolutePosition.y;
 
                 GlobalConfig.WriteConfig();
-
-                OsdPanel?.UpdatePosition();
             }
 
             base.OnPositionChanged();

--- a/TLM/TLM/UI/MainMenu/MainMenuPanel.cs
+++ b/TLM/TLM/UI/MainMenu/MainMenuPanel.cs
@@ -1,40 +1,33 @@
 #define QUEUEDSTATSx
 
-using System;
-using System.Linq;
-using ColossalFramework;
-using ColossalFramework.UI;
-using TrafficManager.Geometry;
-using TrafficManager.TrafficLight;
-using UnityEngine;
-using TrafficManager.State;
-using TrafficManager.Custom.PathFinding;
-using System.Collections.Generic;
-using TrafficManager.Manager;
-using CSUtil.Commons;
-using TrafficManager.State.Keybinds;
-using TrafficManager.UI.SubTools;
-using TrafficManager.Util;
-
 namespace TrafficManager.UI.MainMenu {
+    using System;
+    using ColossalFramework.UI;
+    using CSUtil.Commons;
+    using OSD;
+    using State;
+    using State.Keybinds;
+    using UnityEngine;
+    using Util;
+
     public class MainMenuPanel : UIPanel, IObserver<GlobalConfig> {
         private static readonly Type[] MENU_BUTTON_TYPES
             = {
-                  // first row
-                  typeof(ToggleTrafficLightsButton),
-                  typeof(ManualTrafficLightsButton),
-                  typeof(LaneArrowsButton),
-                  typeof(LaneConnectorButton),
-                  typeof(DespawnButton),
-                  typeof(ClearTrafficButton),
-                  // second row
-                  typeof(PrioritySignsButton),
-                  typeof(TimedTrafficLightsButton),
-                  typeof(JunctionRestrictionsButton),
-                  typeof(SpeedLimitsButton),
-                  typeof(VehicleRestrictionsButton),
-                  typeof(ParkingRestrictionsButton),
-              };
+                // first row
+                typeof(ToggleTrafficLightsButton),
+                typeof(ManualTrafficLightsButton),
+                typeof(LaneArrowsButton),
+                typeof(LaneConnectorButton),
+                typeof(DespawnButton),
+                typeof(ClearTrafficButton),
+                // second row
+                typeof(PrioritySignsButton),
+                typeof(TimedTrafficLightsButton),
+                typeof(JunctionRestrictionsButton),
+                typeof(SpeedLimitsButton),
+                typeof(VehicleRestrictionsButton),
+                typeof(ParkingRestrictionsButton),
+            };
 
         public class SizeProfile {
             public int NUM_BUTTONS_PER_ROW { get; set; }
@@ -51,31 +44,31 @@ namespace TrafficManager.UI.MainMenu {
 
         public static readonly SizeProfile[] SIZE_PROFILES
             = {
-                  new SizeProfile {
-                                        NUM_BUTTONS_PER_ROW = 6,
-                                        NUM_ROWS = 2,
+                new SizeProfile {
+                    NUM_BUTTONS_PER_ROW = 6,
+                    NUM_ROWS = 2,
 
-                                        VSPACING = 5,
-                                        HSPACING = 5,
-                                        TOP_BORDER = 25,
-                                        BUTTON_SIZE = 30,
+                    VSPACING = 5,
+                    HSPACING = 5,
+                    TOP_BORDER = 25,
+                    BUTTON_SIZE = 30,
 
-                                        MENU_WIDTH = 215,
-                                        MENU_HEIGHT = 95
-                                    },
-                  new SizeProfile {
-                                        NUM_BUTTONS_PER_ROW = 6,
-                                        NUM_ROWS = 2,
+                    MENU_WIDTH = 215,
+                    MENU_HEIGHT = 95
+                },
+                new SizeProfile {
+                    NUM_BUTTONS_PER_ROW = 6,
+                    NUM_ROWS = 2,
 
-                                        VSPACING = 5,
-                                        HSPACING = 5,
-                                        TOP_BORDER = 25,
-                                        BUTTON_SIZE = 50,
+                    VSPACING = 5,
+                    HSPACING = 5,
+                    TOP_BORDER = 25,
+                    BUTTON_SIZE = 50,
 
-                                        MENU_WIDTH = 335,
-                                        MENU_HEIGHT = 135
-                                    }
-              };
+                    MENU_WIDTH = 335,
+                    MENU_HEIGHT = 135
+                }
+            };
 
         public const int DEFAULT_MENU_X = 85;
         public const int DEFAULT_MENU_Y = 60;
@@ -91,7 +84,7 @@ namespace TrafficManager.UI.MainMenu {
         private SizeProfile activeProfile = null;
         private bool started = false;
 
-        //private UILabel optionsLabel;
+        public OnScreenDisplayPanel OsdPanel;
 
         public override void Start() {
             GlobalConfig conf = GlobalConfig.Instance;
@@ -120,14 +113,16 @@ namespace TrafficManager.UI.MainMenu {
             Drag = dragHandler.AddComponent<UIDragHandle>();
             Drag.enabled = !GlobalConfig.Instance.Main.MainMenuPosLocked;
 
+            // Attach On-Screen Display panel (invisible)
+            OsdPanel = new OnScreenDisplayPanel(this);
+
             UpdateAllSizes();
             started = true;
         }
 
         public override void OnDestroy() {
-            if (confDisposable != null) {
-                confDisposable.Dispose();
-            }
+            OsdPanel = null; // break the reference loop
+            confDisposable?.Dispose();
         }
 
         internal void SetPosLock(bool lck) {
@@ -208,6 +203,9 @@ namespace TrafficManager.UI.MainMenu {
             VectorUtil.ClampRectToScreen(ref rect, resolution);
             Log.Info($"Setting main menu position to [{pos.x},{pos.y}]");
             absolutePosition = rect.position;
+
+            OsdPanel?.UpdatePosition();
+
             Invalidate();
         }
 
@@ -244,5 +242,6 @@ namespace TrafficManager.UI.MainMenu {
                 }
             }
         }
+
     }
 }

--- a/TLM/TLM/UI/MainMenu/MainMenuPanel.cs
+++ b/TLM/TLM/UI/MainMenu/MainMenuPanel.cs
@@ -141,7 +141,10 @@ namespace TrafficManager.UI.MainMenu {
                 config.Main.MainMenuY = (int)absolutePosition.y;
 
                 GlobalConfig.WriteConfig();
+
+                OsdPanel?.UpdatePosition();
             }
+
             base.OnPositionChanged();
         }
 
@@ -203,8 +206,6 @@ namespace TrafficManager.UI.MainMenu {
             VectorUtil.ClampRectToScreen(ref rect, resolution);
             Log.Info($"Setting main menu position to [{pos.x},{pos.y}]");
             absolutePosition = rect.position;
-
-            OsdPanel?.UpdatePosition();
 
             Invalidate();
         }

--- a/TLM/TLM/UI/MainMenu/OSD/OnScreenDisplayPanel.cs
+++ b/TLM/TLM/UI/MainMenu/OSD/OnScreenDisplayPanel.cs
@@ -1,0 +1,135 @@
+namespace TrafficManager.UI.MainMenu.OSD {
+    using System.Collections.Generic;
+    using ColossalFramework.UI;
+    using State.Keybinds;
+    using UnityEngine;
+
+    public class OnScreenDisplayPanel {
+        public class Configurator {
+            private OnScreenDisplayPanel panel_;
+
+            public Configurator(OnScreenDisplayPanel panel) {
+                panel_ = panel;
+                panel_.items_.Clear();
+            }
+
+            public Configurator Title(string text) {
+                panel_.Title = text;
+                return this;
+            }
+
+            public Configurator Shortcut(string text, KeybindSetting setting) {
+                panel_.items_.Add(new OsdItem_Shortcut(text, setting));
+                return this;
+            }
+
+            public void Show() {
+                panel_.Update();
+                panel_ = null;
+            }
+        }
+
+        public string Title { get; set; }
+
+        /// <summary>
+        /// White. Text color for simple messages.
+        /// </summary>
+        public static readonly Color PALETTE_TEXT = new Color(1f, 1f, 1f, 1f);
+
+        /// <summary>
+        /// Silver gray. Text color for shortcut description.
+        /// </summary>
+        public static readonly Color PALETTE_SHORTCUT_TEXT = new Color(.75f, .75f, .75f, 1f);
+
+        /// <summary>
+        /// Sand yellow. Shortcut text.
+        /// </summary>
+        public static readonly Color PALETTE_SHORTCUT = new Color(.8f, .6f, .3f, 1f);
+        // public static readonly Color PALETTE_SHORTCUT = Color.black;
+
+        /// <summary>
+        /// Text line with 8px paddings above and below
+        /// </summary>
+        public const float LABEL_HEIGHT = 16f;
+
+        /// <summary>
+        /// 2 text lines with 8px paddings above, below and between
+        /// </summary>
+        public const float PANEL_HEIGHT = (LABEL_HEIGHT * 2) + (3 * PADDING);
+
+        /// <summary>
+        /// Distance between panel elements (2x PADDING)
+        /// </summary>
+        public const float PADDING = 8f;
+
+        private readonly UIPanel thisPanel_;
+
+        private readonly List<OsdItem> items_;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OnScreenDisplayPanel"/> class.
+        /// Constructs the empty OSD panel and hides it.
+        /// </summary>
+        /// <param name="mainPanel">The parent panel to attach to</param>
+        public OnScreenDisplayPanel(UIPanel mainPanel) {
+            items_ = new List<OsdItem>();
+
+            thisPanel_ = mainPanel.AddUIComponent<UIPanel>();
+            thisPanel_.width = 10f;
+            thisPanel_.height = PANEL_HEIGHT;
+            thisPanel_.backgroundSprite = "GenericPanel";
+            thisPanel_.color = new Color32(64, 64, 64, 240);
+            Update();
+        }
+
+        public Configurator Setup() {
+            return new Configurator(this);
+        }
+
+        public void Clear() {
+            items_.Clear();
+            Update();
+        }
+
+        public void Update() {
+            UpdatePosition();
+            thisPanel_.isVisible = items_.Count > 0;
+            UpdatePanelItems();
+        }
+
+        private void UpdatePanelItems() {
+            ClearPanelItems();
+
+            var titleLabel = thisPanel_.AddUIComponent<UILabel>();
+            titleLabel.textColor = PALETTE_TEXT;
+            titleLabel.text = Title;
+            titleLabel.relativePosition = new Vector3(PADDING, PADDING);
+
+            // Add items to the panel. Resize the panel to fit everything.
+            var position = new Vector2(0, LABEL_HEIGHT + (PADDING * 2));
+
+            foreach (var item in items_) {
+                position = item.AddTo(thisPanel_, position);
+            }
+
+            thisPanel_.width = Mathf.Max(position.x, titleLabel.width + 2 * PADDING);
+        }
+
+        private void ClearPanelItems() {
+            foreach (var c in thisPanel_.components) {
+                UnityEngine.Object.Destroy(c);
+            }
+        }
+
+        public void UpdatePosition() {
+            var parent = (UIPanel) thisPanel_.parent;
+            if (parent.relativePosition.y < Screen.height / 2f) {
+                // Lower part of the screen, place above the TM:PE panel, with 1px margin
+                thisPanel_.position = new Vector3(0f, -parent.height - 1f, 0f);
+            } else {
+                // Upper part of the screen, place below the TM:PE panel, with 1px margin
+                thisPanel_.position = new Vector3(0f, thisPanel_.height + 1f, 0f);
+            }
+        }
+    }
+}

--- a/TLM/TLM/UI/MainMenu/OSD/OnScreenDisplayPanel.cs
+++ b/TLM/TLM/UI/MainMenu/OSD/OnScreenDisplayPanel.cs
@@ -124,11 +124,11 @@ namespace TrafficManager.UI.MainMenu.OSD {
         public void UpdatePosition() {
             var parent = (UIPanel) thisPanel_.parent;
             if (parent.relativePosition.y < Screen.height / 2f) {
-                // Lower part of the screen, place above the TM:PE panel, with 1px margin
-                thisPanel_.position = new Vector3(0f, -parent.height - 1f, 0f);
-            } else {
                 // Upper part of the screen, place below the TM:PE panel, with 1px margin
-                thisPanel_.position = new Vector3(0f, thisPanel_.height + 1f, 0f);
+                thisPanel_.relativePosition = new Vector3(0f, parent.height + 1f, 0f);
+            } else {
+                // Lower part of the screen, place above the TM:PE panel, with 1px margin
+                thisPanel_.relativePosition = new Vector3(0f, -thisPanel_.height - 1f, 0f);
             }
         }
     }

--- a/TLM/TLM/UI/MainMenu/OSD/OsdItem.cs
+++ b/TLM/TLM/UI/MainMenu/OSD/OsdItem.cs
@@ -1,0 +1,17 @@
+namespace TrafficManager.UI.MainMenu.OSD {
+    using ColossalFramework.UI;
+    using UnityEngine;
+
+    /// <summary>
+    /// An object in OSD panel, text label, or keyboard shortcut, etc.
+    /// </summary>
+    public abstract class OsdItem {
+        /// <summary>
+        /// Add required objects to the parent panel, return new horizontal offset
+        /// </summary>
+        /// <param name="parent">Where to add</param>
+        /// <param name="position">Horizontal (X) offset</param>
+        /// <returns>New offset after items were added</returns>
+        public abstract Vector2 AddTo(UIPanel parent, Vector2 position);
+    }
+}

--- a/TLM/TLM/UI/MainMenu/OSD/OsdItem_Shortcut.cs
+++ b/TLM/TLM/UI/MainMenu/OSD/OsdItem_Shortcut.cs
@@ -1,0 +1,48 @@
+namespace TrafficManager.UI.MainMenu.OSD {
+    using ColossalFramework.UI;
+    using State.Keybinds;
+    using UnityEngine;
+
+    public class OsdItem_Shortcut : OsdItem {
+        private readonly string text_;
+        private readonly KeybindSetting keySetting_;
+
+        public OsdItem_Shortcut(string text, KeybindSetting keySetting) {
+            text_ = text;
+            keySetting_ = keySetting;
+        }
+
+        public override Vector2 AddTo(UIPanel parent, Vector2 position) {
+            position.x += OnScreenDisplayPanel.PADDING;
+
+            var keyLabel = AddShortcutText(parent, position);
+            position.x += keyLabel.width + OnScreenDisplayPanel.PADDING;
+
+            var label = AddShortcutDescriptionText(parent, position);
+            position.x += label.width + OnScreenDisplayPanel.PADDING;
+
+            return position;
+        }
+
+        private UILabel AddShortcutDescriptionText(UIPanel parent, Vector2 position) {
+            var label = parent.AddUIComponent<UILabel>();
+            label.textColor = OnScreenDisplayPanel.PALETTE_SHORTCUT_TEXT;
+            label.text = text_;
+            label.autoHeight = true;
+            label.relativePosition = position;
+            return label;
+        }
+
+        private UILabel AddShortcutText(UIPanel parent, Vector2 position) {
+            var keyLabel = parent.AddUIComponent<UILabel>();
+            keyLabel.backgroundSprite = string.Empty;
+            keyLabel.backgroundSprite = "GenericPanelDark";
+            keyLabel.textColor = OnScreenDisplayPanel.PALETTE_SHORTCUT;
+            keyLabel.text = $" {keySetting_.ToLocalizedString()} ";
+            // TODO not sure if height is set properly
+            keyLabel.height = OnScreenDisplayPanel.LABEL_HEIGHT + (2 * OnScreenDisplayPanel.PADDING);
+            keyLabel.relativePosition = position;
+            return keyLabel;
+        }
+    }
+}

--- a/TLM/TLM/UI/MainMenu/OSD/OsdItem_Text.cs
+++ b/TLM/TLM/UI/MainMenu/OSD/OsdItem_Text.cs
@@ -1,0 +1,28 @@
+namespace TrafficManager.UI.MainMenu.OSD {
+    using ColossalFramework.UI;
+    using UnityEngine;
+
+    /// <summary>
+    /// Represents a text label (without a keyboard shortcut)
+    /// </summary>
+    public class OsdItem_Text : OsdItem {
+        private string text_;
+
+        public OsdItem_Text(string text) {
+            text_ = text;
+        }
+
+        public override Vector2 AddTo(UIPanel parent, Vector2 position) {
+            var label = parent.AddUIComponent<UILabel>();
+            label.textColor = OnScreenDisplayPanel.PALETTE_TEXT;
+            label.text = text_;
+            label.relativePosition = position;
+            label.autoHeight = true;
+            label.textAlignment = UIHorizontalAlignment.Left;
+
+            position.x += label.width + (2 * OnScreenDisplayPanel.PADDING);
+
+            return position;
+        }
+    }
+}

--- a/TLM/TLM/UI/MainMenu/OSD/OsdUIPanel.cs
+++ b/TLM/TLM/UI/MainMenu/OSD/OsdUIPanel.cs
@@ -1,0 +1,25 @@
+namespace TrafficManager.UI.MainMenu.OSD {
+    using ColossalFramework.UI;
+    using CSUtil.Commons;
+    using State;
+
+    public class OsdUIPanel: UIPanel {
+        protected override void OnPositionChanged() {
+            GlobalConfig config = GlobalConfig.Instance;
+
+            bool posChanged = config.Main.OSDPanelX != (int)absolutePosition.x
+                              || config.Main.OSDPanelY != (int)absolutePosition.y;
+
+            if (posChanged) {
+                Log._Debug($"OSD position changed to {absolutePosition.x}|{absolutePosition.y}");
+
+                config.Main.OSDPanelX = (int)absolutePosition.x;
+                config.Main.OSDPanelY = (int)absolutePosition.y;
+
+                GlobalConfig.WriteConfig();
+            }
+
+            base.OnPositionChanged();
+        }
+    }
+}

--- a/TLM/TLM/UI/SubTools/LaneConnectorTool.cs
+++ b/TLM/TLM/UI/SubTools/LaneConnectorTool.cs
@@ -443,17 +443,21 @@ namespace TrafficManager.UI.SubTools {
 
         private static void OsdSetup_SelectNode() {
             LoadingExtension.BaseUI.MainMenu.OsdPanel.Setup()
-                            .Title("Lane Connections: Select a node")
-                            .Shortcut("Exit tool", KeybindSettingsBase.ToolCancelViewOnly)
+                            .Title(Translation.GetString("OSD_Lane_Connection__Select"))
+                            .Shortcut(Translation.GetString("OSD_Exit_tool"),
+                                      KeybindSettingsBase.ToolCancelViewOnly)
                             .Show();
         }
 
         private static void OsdSetup_LinkLanes() {
             LoadingExtension.BaseUI.MainMenu.OsdPanel.Setup()
-                            .Title("Link the lanes")
-                            .Shortcut("Clear", KeybindSettingsBase.LaneConnectorDelete)
-                            .Shortcut("Stay in lane", KeybindSettingsBase.LaneConnectorStayInLane)
-                            .Shortcut("Exit tool", KeybindSettingsBase.ToolCancelViewOnly)
+                            .Title(Translation.GetString("OSD_Lane_Connection__Link"))
+                            .Shortcut(Translation.GetString("OSD_Lane_Connection_Clear"),
+                                      KeybindSettingsBase.LaneConnectorDelete)
+                            .Shortcut(Translation.GetString("OSD_Lane_Connection_Stay_in_lane"),
+                                      KeybindSettingsBase.LaneConnectorStayInLane)
+                            .Shortcut(Translation.GetString("OSD_Exit_tool"),
+                                      KeybindSettingsBase.ToolCancelViewOnly)
                             .Show();
         }
 
@@ -490,8 +494,7 @@ namespace TrafficManager.UI.SubTools {
 
         public override void Cleanup() {
             // Clear OSD keybinds
-            var osd = LoadingExtension.BaseUI.MainMenu.OsdPanel;
-            osd.Clear();
+            LoadingExtension.BaseUI.MainMenu.OsdPanel.Clear();
         }
 
         public override void Initialize() {

--- a/TLM/TLM/UI/SubTools/LaneConnectorTool.cs
+++ b/TLM/TLM/UI/SubTools/LaneConnectorTool.cs
@@ -300,6 +300,10 @@ namespace TrafficManager.UI.SubTools {
                         SelectedNodeId = 0;
                         selectedMarker = null;
                         stayInLaneMode = StayInLaneMode.None;
+
+                        // Update OSD help text
+                        OsdSetup_SelectNode();
+
                         return;
                     }
 
@@ -315,6 +319,9 @@ namespace TrafficManager.UI.SubTools {
                             SelectedNodeId = HoveredNodeId;
                             selectedMarker = null;
                             stayInLaneMode = StayInLaneMode.None;
+
+                            // Update OSD help text
+                            OsdSetup_LinkLanes();
 
                             currentNodeMarkers[SelectedNodeId] = markers;
                         }
@@ -403,6 +410,9 @@ namespace TrafficManager.UI.SubTools {
 						Log._Debug($"TppLaneConnectorTool: OnSecondaryClickOverlay: selected node id = 0");
 #endif
                     SelectedNodeId = 0;
+
+                    // Update OSD help text
+                    OsdSetup_SelectNode();
                     break;
                 case MarkerSelectionMode.SelectTarget:
                     // deselect source marker
@@ -426,6 +436,25 @@ namespace TrafficManager.UI.SubTools {
             hoveredMarker = null;
             stayInLaneMode = StayInLaneMode.None;
             RefreshCurrentNodeMarkers();
+
+            // Set up the OSD to show the first tip for the user
+            OsdSetup_SelectNode();
+        }
+
+        private static void OsdSetup_SelectNode() {
+            LoadingExtension.BaseUI.MainMenu.OsdPanel.Setup()
+                            .Title("Lane Connections: Select a node")
+                            .Shortcut("Exit tool", KeybindSettingsBase.ToolCancelViewOnly)
+                            .Show();
+        }
+
+        private static void OsdSetup_LinkLanes() {
+            LoadingExtension.BaseUI.MainMenu.OsdPanel.Setup()
+                            .Title("Link the lanes")
+                            .Shortcut("Clear", KeybindSettingsBase.LaneConnectorDelete)
+                            .Shortcut("Stay in lane", KeybindSettingsBase.LaneConnectorStayInLane)
+                            .Shortcut("Exit tool", KeybindSettingsBase.ToolCancelViewOnly)
+                            .Show();
         }
 
         private void RefreshCurrentNodeMarkers(ushort forceNodeId=0) {
@@ -460,7 +489,9 @@ namespace TrafficManager.UI.SubTools {
         }
 
         public override void Cleanup() {
-
+            // Clear OSD keybinds
+            var osd = LoadingExtension.BaseUI.MainMenu.OsdPanel;
+            osd.Clear();
         }
 
         public override void Initialize() {

--- a/TLM/TLM/UI/TrafficManagerTool.cs
+++ b/TLM/TLM/UI/TrafficManagerTool.cs
@@ -291,14 +291,16 @@ namespace TrafficManager.UI {
                 return;
 
             // check if mouse is inside panel
-            if (LoadingExtension.BaseUI.GetMenu().containsMouse
+            var mainMenuPanel = LoadingExtension.BaseUI.GetMenu();
+            var mainMenuContainsMouse = mainMenuPanel != null && mainMenuPanel.containsMouse;
 #if DEBUG
-                || LoadingExtension.BaseUI.GetDebugMenu().containsMouse
+            var debugMenuPanel = LoadingExtension.BaseUI.GetDebugMenu();
+            var debugMenuContainsMouse = debugMenuPanel != null && debugMenuPanel.containsMouse;
+#else
+            const bool debugMenuContainsMouse = false;
 #endif
-                ) {
-#if DEBUG
+            if (mainMenuContainsMouse || debugMenuContainsMouse) {
                 Log._Debug($"TrafficManagerTool: OnToolUpdate: Menu contains mouse. Ignoring click.");
-#endif
                 return;
             }
 

--- a/TLM/TLM/UI/UIBase.cs
+++ b/TLM/TLM/UI/UIBase.cs
@@ -8,9 +8,11 @@ namespace TrafficManager.UI {
 
         public UIMainMenuButton MainMenuButton { get; private set; }
         public MainMenuPanel MainMenu { get; private set; }
+
 #if DEBUG
         public DebugMenuPanel DebugMenu { get; private set; }
 #endif
+
         public static TrafficManagerTool GetTrafficManagerTool(bool createIfRequired=true) {
             if (tool == null && createIfRequired) {
                 Log.Info("Initializing traffic manager tool...");
@@ -21,7 +23,9 @@ namespace TrafficManager.UI {
 
             return tool;
         }
+
         private static TrafficManagerTool tool = null;
+
         public static TrafficManagerMode ToolMode { get; set; }
 
         private bool _uiShown = false;
@@ -39,6 +43,7 @@ namespace TrafficManager.UI {
             // add the menu
             MainMenu = (MainMenuPanel)uiView.AddUIComponent(typeof(MainMenuPanel));
             MainMenu.gameObject.AddComponent<CustomKeyHandler>();
+
 #if DEBUG
             DebugMenu = (DebugMenuPanel)uiView.AddUIComponent(typeof(DebugMenuPanel));
 #endif


### PR DESCRIPTION
- [x] ~A panel attached to the Main Menu Panel~
  - [x] ~Repositions itself when the main menu is moved~
- [x] Tools can set the tooltip and keyboard shortcuts to show, or clear them
- [x] Clears when the tools are deselected
- [x] Can be dragged around
- [x] Means to close and show again
  - [ ] Add branding (small logo or a "TM:PE" label)
- [ ] Support longer strings and word wrapping
- [ ] Add support for tools
  - [x] Lane connector
  - [ ] Lane arrows
  - [ ] Junction restrictions
  - [ ] Speed limits
  - [ ] Car/train restrictions
  - [ ] Parking restrictions
- [x] Add the way to show/hide
- [x] Translations

![image](https://user-images.githubusercontent.com/288724/60844419-7f772280-a1d9-11e9-840a-91b711b4ad0d.png)

Closes #410