### PR TITLE
Parking Restrictions tool - Lane highlighting

### DIFF
--- a/TLM/TLM/Manager/Impl/ParkingRestrictionsManager.cs
+++ b/TLM/TLM/Manager/Impl/ParkingRestrictionsManager.cs
@@ -1,9 +1,10 @@
-﻿namespace TrafficManager.Manager.Impl {
+namespace TrafficManager.Manager.Impl {
     using CSUtil.Commons;
     using System.Collections.Generic;
     using System;
     using TrafficManager.API.Manager;
     using TrafficManager.API.Traffic.Data;
+    using TrafficManager.State.ConfigData;
 
     public class ParkingRestrictionsManager
         : AbstractGeometryObservingManager,
@@ -82,6 +83,13 @@
         }
 
         protected int GetDirIndex(NetInfo.Direction dir) {
+#if DEBUG
+            if(DebugSwitch.BasicParkingAILog.Get() &&
+                dir != NetInfo.Direction.Forward &&
+                dir != NetInfo.Direction.Backward) {
+                Log.Error($"bad direction: {dir} expected forward or backward");
+            }
+#endif
             return dir == NetInfo.Direction.Backward ? 1 : 0;
         }
 

--- a/TLM/TLM/Manager/Impl/ParkingRestrictionsManager.cs
+++ b/TLM/TLM/Manager/Impl/ParkingRestrictionsManager.cs
@@ -5,6 +5,8 @@ namespace TrafficManager.Manager.Impl {
     using TrafficManager.API.Manager;
     using TrafficManager.API.Traffic.Data;
     using TrafficManager.State.ConfigData;
+    using TrafficManager.Util;
+    using ColossalFramework;
 
     public class ParkingRestrictionsManager
         : AbstractGeometryObservingManager,
@@ -47,6 +49,23 @@ namespace TrafficManager.Manager.Impl {
         }
 
         public bool SetParkingAllowed(ushort segmentId, NetInfo.Direction finalDir, bool flag) {
+#if DEBUG
+            if (DebugSwitch.BasicParkingAILog.Get()) {
+                if (finalDir != NetInfo.Direction.Forward &&
+                finalDir != NetInfo.Direction.Backward) {
+                    Log.Error($"bad parking direction: {finalDir} expected forward or backward");
+                }
+                foreach(var lane in segmentId.ToSegment().Info.m_lanes) {
+                    if (lane.m_laneType.IsFlagSet(NetInfo.LaneType.Parking) &&
+                        lane.m_finalDirection != NetInfo.Direction.Forward &&
+                        lane.m_finalDirection != NetInfo.Direction.Backward) {
+                        Log.Error($"parking lane with bad m_finalDirection:{lane.m_finalDirection}, expected forward or backward");
+                    }
+                }
+
+            }
+#endif
+
             if (!MayHaveParkingRestriction(segmentId)) {
                 return false;
             }
@@ -83,13 +102,6 @@ namespace TrafficManager.Manager.Impl {
         }
 
         protected int GetDirIndex(NetInfo.Direction dir) {
-#if DEBUG
-            if(DebugSwitch.BasicParkingAILog.Get() &&
-                dir != NetInfo.Direction.Forward &&
-                dir != NetInfo.Direction.Backward) {
-                Log.Error($"bad direction: {dir} expected forward or backward");
-            }
-#endif
             return dir == NetInfo.Direction.Backward ? 1 : 0;
         }
 

--- a/TLM/TLM/UI/MainMenu/ParkingRestrictionsButton.cs
+++ b/TLM/TLM/UI/MainMenu/ParkingRestrictionsButton.cs
@@ -1,4 +1,4 @@
-﻿namespace TrafficManager.UI.MainMenu {
+namespace TrafficManager.UI.MainMenu {
     using TrafficManager.State;
 
     public class ParkingRestrictionsButton : MenuToolModeButton {
@@ -6,7 +6,9 @@
 
         protected override ButtonFunction Function => ButtonFunction.ParkingRestrictions;
 
-        public override string Tooltip => Translation.Menu.Get("Tooltip:Parking restrictions");
+        public override string Tooltip =>
+            Translation.Menu.Get("Tooltip:Parking restrictions") + "\n" +
+            Translation.Menu.Get("Tooltip.Keybinds:Parking restrictions");
 
         public override bool Visible => Options.parkingRestrictionsEnabled;
     }

--- a/TLM/TLM/UI/SubTools/ParkingRestrictionsTool.cs
+++ b/TLM/TLM/UI/SubTools/ParkingRestrictionsTool.cs
@@ -257,7 +257,7 @@ namespace TrafficManager.UI.SubTools {
             {
                 segCenter = new Dictionary<NetInfo.Direction, Vector3>();
                 segmentCenterByDir.Add(segmentId, segCenter);
-                TrafficManagerTool.CalculateSegmentCenterByDir(segmentId, segCenter);
+                TrafficManagerTool.CalculateSegmentCenterByDir(segmentId, segCenter, SIGN_SIZE);
             }
 
             foreach (KeyValuePair<NetInfo.Direction, Vector3> e in segCenter) {
@@ -281,7 +281,7 @@ namespace TrafficManager.UI.SubTools {
                     size,
                     size);
 
-                if (Options.speedLimitsOverlay) {
+                if (viewOnly && Options.speedLimitsOverlay) {
                     boundingBox.y -= size + 10f;
                 }
 

--- a/TLM/TLM/UI/SubTools/ParkingRestrictionsTool.cs
+++ b/TLM/TLM/UI/SubTools/ParkingRestrictionsTool.cs
@@ -58,9 +58,7 @@ namespace TrafficManager.UI.SubTools {
 
         public override void OnActivate() { }
 
-        public override void OnPrimaryClickOverlay() {
-
-        }
+        public override void OnPrimaryClickOverlay() { }
 
         private SegmentLaneMarker GetLaneMarker(ushort segmentId, NetInfo.Direction direction) {
             Bezier3 bezier = default(Bezier3);
@@ -211,6 +209,7 @@ namespace TrafficManager.UI.SubTools {
 
             bool hovered = false;
             bool clicked = !viewOnly && MainTool.CheckClicked();
+
             for (int segmentIdIndex = CachedVisibleSegmentIds.Size - 1;
                  segmentIdIndex >= 0;
                  segmentIdIndex--)

--- a/TLM/TLM/UI/SubTools/ParkingRestrictionsTool.cs
+++ b/TLM/TLM/UI/SubTools/ParkingRestrictionsTool.cs
@@ -21,18 +21,18 @@ namespace TrafficManager.UI.SubTools {
 
         private const float SIGN_SIZE = 80f;
 
-        private struct RenderInfo {
-            internal NetInfo.Direction direction;
+        private struct RenderData {
+            internal NetInfo.Direction finalDirection;
             internal ushort segmentId;
 
-            public static bool operator ==(RenderInfo a, RenderInfo b) =>
-                a.segmentId == b.segmentId && a.direction == b.direction;
+            public static bool operator ==(RenderData a, RenderData b) =>
+                a.segmentId == b.segmentId && a.finalDirection == b.finalDirection;
 
-            public static bool operator !=(RenderInfo a, RenderInfo b) =>
+            public static bool operator !=(RenderData a, RenderData b) =>
                 !(a == b);
         }
         private SegmentLaneMarker LaneMarker;
-        private RenderInfo renderInfo;
+        private RenderData renderInfo;
 
         /// <summary>
         /// Stores potentially visible segment ids while the camera did not move
@@ -56,7 +56,7 @@ namespace TrafficManager.UI.SubTools {
         public override void OnPrimaryClickOverlay() { }
 
         private void RenderSegmentParkings(RenderManager.CameraInfo cameraInfo) {
-            bool allowed = parkingManager.IsParkingAllowed(renderInfo.segmentId, renderInfo.direction);
+            bool allowed = parkingManager.IsParkingAllowed(renderInfo.segmentId, renderInfo.finalDirection);
             bool pressed = Input.GetMouseButton(0);
             Color color;
             if (pressed) {
@@ -77,7 +77,7 @@ namespace TrafficManager.UI.SubTools {
                 ref NetSegment segment,
                 byte laneIndex) => {
                     bool isParking = laneInfo.m_laneType.IsFlagSet(NetInfo.LaneType.Parking);
-                    if (isParking && laneInfo.m_direction == renderInfo.direction) {
+                    if (isParking && laneInfo.m_finalDirection == renderInfo.finalDirection) {
                         bezier = lane.m_bezier;
                         LaneMarker = new SegmentLaneMarker(bezier);
                         LaneMarker.RenderOverlay(cameraInfo, color, enlarge: pressed);
@@ -93,7 +93,7 @@ namespace TrafficManager.UI.SubTools {
                 int laneIndex = data.CurLanePos.laneIndex;
                 NetInfo.Lane laneInfo = segmentId.ToSegment().Info.m_lanes[laneIndex];
 
-                NetInfo.Direction direction = laneInfo.m_direction;
+                NetInfo.Direction finalDirection = laneInfo.m_finalDirection;
 
                 if (!data.SegVisitData.Initial) {
                     bool reverse =
@@ -105,10 +105,10 @@ namespace TrafficManager.UI.SubTools {
                     bool invert = invert1 != invert2;
 
                     if (reverse ^ invert) {
-                        direction = NetInfo.InvertDirection(direction);
+                        finalDirection = NetInfo.InvertDirection(finalDirection);
                     }
                 }
-                if (direction == renderInfo.direction) {
+                if (finalDirection == renderInfo.finalDirection) {
                     bool pressed = Input.GetMouseButton(0);
                     Color color = MainTool.GetToolColor(pressed, false);
                     uint otherLaneId = data.CurLanePos.laneId;
@@ -227,13 +227,13 @@ namespace TrafficManager.UI.SubTools {
                     ref camPos);
                 if (dir != NetInfo.Direction.None) {
                     renderInfo.segmentId = segmentId;
-                    renderInfo.direction = dir;
+                    renderInfo.finalDirection = dir;
                     hovered = true;
                 } 
             }
             if (!hovered) {
                 renderInfo.segmentId = 0;
-                renderInfo.direction = NetInfo.Direction.None;
+                renderInfo.finalDirection = NetInfo.Direction.None;
             }
         }
 

--- a/TLM/TLM/UI/SubTools/SpeedLimits/SpeedLimitsTool.cs
+++ b/TLM/TLM/UI/SubTools/SpeedLimits/SpeedLimitsTool.cs
@@ -724,7 +724,10 @@ namespace TrafficManager.UI.SubTools.SpeedLimits {
                         out Dictionary<NetInfo.Direction, Vector3> segCenter)) {
                     segCenter = new Dictionary<NetInfo.Direction, Vector3>();
                     segmentCenterByDir.Add(segmentId, segCenter);
-                    TrafficManagerTool.CalculateSegmentCenterByDir(segmentId, segCenter, speedLimitSignSize);
+                    TrafficManagerTool.CalculateSegmentCenterByDir(
+                        segmentId,
+                        segCenter,
+                        speedLimitSignSize*TrafficManagerTool.MAX_ZOOM);
                 }
 
                 foreach (KeyValuePair<NetInfo.Direction, Vector3> e in segCenter) {

--- a/TLM/TLM/UI/SubTools/SpeedLimits/SpeedLimitsTool.cs
+++ b/TLM/TLM/UI/SubTools/SpeedLimits/SpeedLimitsTool.cs
@@ -1,4 +1,4 @@
-﻿namespace TrafficManager.UI.SubTools.SpeedLimits {
+namespace TrafficManager.UI.SubTools.SpeedLimits {
     using ColossalFramework.UI;
     using ColossalFramework;
     using CSUtil.Commons;
@@ -724,7 +724,7 @@
                         out Dictionary<NetInfo.Direction, Vector3> segCenter)) {
                     segCenter = new Dictionary<NetInfo.Direction, Vector3>();
                     segmentCenterByDir.Add(segmentId, segCenter);
-                    TrafficManagerTool.CalculateSegmentCenterByDir(segmentId, segCenter);
+                    TrafficManagerTool.CalculateSegmentCenterByDir(segmentId, segCenter, speedLimitSignSize);
                 }
 
                 foreach (KeyValuePair<NetInfo.Direction, Vector3> e in segCenter) {

--- a/TLM/TLM/UI/TrafficManagerTool.cs
+++ b/TLM/TLM/UI/TrafficManagerTool.cs
@@ -135,7 +135,7 @@ namespace TrafficManager.UI {
             return Screen.height / 1200f;
         }
 
-        internal const float MAX_ZOOM = 0.04f;
+        internal const float MAX_ZOOM = 0.05f;
 
         internal static float GetWindowAlpha() {
             return TransparencyToAlpha(GlobalConfig.Instance.Main.GuiTransparency);

--- a/TLM/TLM/UI/TrafficManagerTool.cs
+++ b/TLM/TLM/UI/TrafficManagerTool.cs
@@ -1695,7 +1695,8 @@ namespace TrafficManager.UI {
 
         internal static void CalculateSegmentCenterByDir(
             ushort segmentId,
-            Dictionary<NetInfo.Direction, Vector3> segmentCenterByDir)
+            Dictionary<NetInfo.Direction, Vector3> segmentCenterByDir,
+            float minDistance = 0)
         {
             segmentCenterByDir.Clear();
             NetManager netManager = Singleton<NetManager>.instance;
@@ -1732,6 +1733,19 @@ namespace TrafficManager.UI {
 
             foreach (KeyValuePair<NetInfo.Direction, int> e in numCentersByDir) {
                 segmentCenterByDir[e.Key] /= (float)e.Value;
+            }
+
+            if(minDistance>0) {
+                int numDirs = segmentCenterByDir.Count;
+                
+                bool b1 = segmentCenterByDir.TryGetValue(NetInfo.Direction.Forward, out Vector3 pos1);
+                bool b2 = segmentCenterByDir.TryGetValue(NetInfo.Direction.Backward, out Vector3 pos2);
+                if (b1 && b2 && (pos1 - pos2).sqrMagnitude < minDistance) {
+                    var move = (pos1 - pos2).normalized;
+                    move *= minDistance * (numDirs - 1) / 2;
+                    segmentCenterByDir[NetInfo.Direction.Forward] = pos1 + move;
+                    segmentCenterByDir[NetInfo.Direction.Backward] = pos2 - move;
+                }
             }
         }
 

--- a/TLM/TLM/UI/TrafficManagerTool.cs
+++ b/TLM/TLM/UI/TrafficManagerTool.cs
@@ -1736,13 +1736,12 @@ namespace TrafficManager.UI {
             }
 
             if(minDistance>0) {
-                int numDirs = segmentCenterByDir.Count;
-                
                 bool b1 = segmentCenterByDir.TryGetValue(NetInfo.Direction.Forward, out Vector3 pos1);
                 bool b2 = segmentCenterByDir.TryGetValue(NetInfo.Direction.Backward, out Vector3 pos2);
                 if (b1 && b2 && (pos1 - pos2).sqrMagnitude < minDistance) {
                     var move = (pos1 - pos2).normalized;
-                    move *= minDistance * (numDirs - 1) / 2;
+                    move *= minDistance / 2;
+                    //move *= (segmentCenterByDir.Count - 1) / 2;
                     segmentCenterByDir[NetInfo.Direction.Forward] = pos1 + move;
                     segmentCenterByDir[NetInfo.Direction.Backward] = pos2 - move;
                 }


### PR DESCRIPTION
fixes #702 

parking lanes are highlighted:
- green=allowed red=not allowed.
- shift => blue color for all affected segments. (see issue for pictures)
- click => highlight is emboldened and turns orange (visual feedback)
- oneway roads have 2 parking lanes affected by the same GUI, I highlight both lanes here.

Scope:
The scope of this review is not to change the functionality of the parking tool, but rather provide visual feedback for what it already does.

Crowdin: I did not introduce the shift functionality but since it does not show in the tooltip keybind I decided to add it. Can anyone add the following crowdin key:
```
FILE: Menu.csv
"Tooltip.Keybinds:Parking restrictions"=>"[shift] apply changes to the whole road."
```

EDIT: fixed overlapping sprite overlays. see https://github.com/CitiesSkylinesMods/TMPE/pull/708#issuecomment-587823337
