### PR TITLE
Decruft SpeedLimitManager.LoadData() logging

### DIFF
--- a/TLM/TLM/Manager/Impl/SpeedLimitManager.cs
+++ b/TLM/TLM/Manager/Impl/SpeedLimitManager.cs
@@ -851,13 +851,13 @@ namespace TrafficManager.Manager.Impl {
             bool success = true;
             Log.Info($"Loading lane speed limit data. {data.Count} elements");
 #if DEBUG
-            bool debugLogging = DebugSwitch.SpeedLimits.Get();
+            bool debugSpeedLimits = DebugSwitch.SpeedLimits.Get();
 #endif
             foreach (Configuration.LaneSpeedLimit laneSpeedLimit in data) {
                 try {
                     if (!Services.NetService.IsLaneValid(laneSpeedLimit.laneId)) {
 #if DEBUG
-                        Log._DebugIf(debugLogging, () =>
+                        Log._DebugIf(debugSpeedLimits, () =>
                             $"SpeedLimitManager.LoadData: Skipping lane {laneSpeedLimit.laneId}: Lane is invalid");
 #endif
                         continue;
@@ -871,7 +871,7 @@ namespace TrafficManager.Manager.Impl {
                                    .instance.m_segments.m_buffer[segmentId].Info;
                     float customSpeedLimit = GetCustomNetInfoSpeedLimit(info);
 #if DEBUG
-                    Log._DebugIf(debugLogging, () =>
+                    Log._DebugIf(debugSpeedLimits, () =>
                         $"SpeedLimitManager.LoadData: Handling lane {laneSpeedLimit.laneId}: " +
                         $"Custom speed limit of segment {segmentId} info ({info}, name={info?.name}, " +
                         $"lanes={info?.m_lanes} is {customSpeedLimit}");
@@ -880,7 +880,7 @@ namespace TrafficManager.Manager.Impl {
                     if (IsValidRange(customSpeedLimit)) {
                         // lane speed limit differs from default speed limit
 #if DEBUG
-                        Log._DebugIf(debugLogging, () =>
+                        Log._DebugIf(debugSpeedLimits, () =>
                             "SpeedLimitManager.LoadData: Loading lane speed limit: " +
                             $"lane {laneSpeedLimit.laneId} = {laneSpeedLimit.speedLimit} km/h");
 #endif
@@ -890,7 +890,7 @@ namespace TrafficManager.Manager.Impl {
                         Flags.SetLaneSpeedLimit(laneSpeedLimit.laneId, kmph);
                     } else {
 #if DEBUG
-                    Log._DebugIf(debugLogging, () =>
+                    Log._DebugIf(debugSpeedLimits, () =>
                         "SpeedLimitManager.LoadData: " +
                         $"Skipping lane speed limit of lane {laneSpeedLimit.laneId} " +
                         $"({laneSpeedLimit.speedLimit} km/h)");

--- a/TLM/TLM/Manager/Impl/SpeedLimitManager.cs
+++ b/TLM/TLM/Manager/Impl/SpeedLimitManager.cs
@@ -8,12 +8,12 @@ namespace TrafficManager.Manager.Impl {
     using TrafficManager.API.Manager;
     using TrafficManager.API.Traffic.Data;
     using TrafficManager.State;
+#if DEBUG
+    using TrafficManager.State.ConfigData;
+#endif
     using TrafficManager.UI.SubTools.SpeedLimits;
     using TrafficManager.Util;
     using UnityEngine;
-#if DEBUG
-    using State.ConfigData;
-#endif
 
     public class SpeedLimitManager
         : AbstractGeometryObservingManager,
@@ -874,10 +874,11 @@ namespace TrafficManager.Manager.Impl {
 
                     if (IsValidRange(customSpeedLimit)) {
                         // lane speed limit differs from default speed limit
+#if DEBUG
                         Log._DebugIf(DebugSwitch.SpeedLimits.Get(), () =>
                             "SpeedLimitManager.LoadData: Loading lane speed limit: " +
                             $"lane {laneSpeedLimit.laneId} = {laneSpeedLimit.speedLimit} km/h");
-
+#endif
                         float kmph = laneSpeedLimit.speedLimit /
                                      Constants.SPEED_TO_KMPH; // convert to game units
 

--- a/TLM/TLM/Manager/Impl/SpeedLimitManager.cs
+++ b/TLM/TLM/Manager/Impl/SpeedLimitManager.cs
@@ -874,16 +874,13 @@ namespace TrafficManager.Manager.Impl {
 
                     if (IsValidRange(customSpeedLimit)) {
                         // lane speed limit differs from default speed limit
-#if DEBUGLOAD
-                        Log._Debug($"SpeedLimitManager.LoadData: Loading lane speed limit: lane "+
-                            $"{laneSpeedLimit.laneId} = {laneSpeedLimit.speedLimit}");
-#endif
-                        Flags.SetLaneSpeedLimit(laneSpeedLimit.laneId, laneSpeedLimit.speedLimit);
-                        Log._Debug(
-                            $"SpeedLimitManager.LoadData: Loading lane speed limit: " +
+                        Log._DebugIf(DebugSwitch.SpeedLimits.Get(), () =>
+                            "SpeedLimitManager.LoadData: Loading lane speed limit: " +
                             $"lane {laneSpeedLimit.laneId} = {laneSpeedLimit.speedLimit} km/h");
+
                         float kmph = laneSpeedLimit.speedLimit /
                                      Constants.SPEED_TO_KMPH; // convert to game units
+
                         Flags.SetLaneSpeedLimit(laneSpeedLimit.laneId, kmph);
                     } else {
 #if DEBUGLOAD

--- a/TLM/TLM/Manager/Impl/SpeedLimitManager.cs
+++ b/TLM/TLM/Manager/Impl/SpeedLimitManager.cs
@@ -850,11 +850,15 @@ namespace TrafficManager.Manager.Impl {
         public bool LoadData(List<Configuration.LaneSpeedLimit> data) {
             bool success = true;
             Log.Info($"Loading lane speed limit data. {data.Count} elements");
+#if DEBUG
+            bool debugLogging = DebugSwitch.SpeedLimits.Get();
+#endif
             foreach (Configuration.LaneSpeedLimit laneSpeedLimit in data) {
                 try {
                     if (!Services.NetService.IsLaneValid(laneSpeedLimit.laneId)) {
-#if DEBUGLOAD
-                        Log._Debug($"SpeedLimitManager.LoadData: Skipping lane {laneSpeedLimit.laneId}: Lane is invalid");
+#if DEBUG
+                        Log._DebugIf(debugLogging, () =>
+                            $"SpeedLimitManager.LoadData: Skipping lane {laneSpeedLimit.laneId}: Lane is invalid");
 #endif
                         continue;
                     }
@@ -866,8 +870,9 @@ namespace TrafficManager.Manager.Impl {
                     NetInfo info = Singleton<NetManager>
                                    .instance.m_segments.m_buffer[segmentId].Info;
                     float customSpeedLimit = GetCustomNetInfoSpeedLimit(info);
-#if DEBUGLOAD
-                    Log._Debug($"SpeedLimitManager.LoadData: Handling lane {laneSpeedLimit.laneId}: " +
+#if DEBUG
+                    Log._DebugIf(debugLogging, () =>
+                        $"SpeedLimitManager.LoadData: Handling lane {laneSpeedLimit.laneId}: " +
                         $"Custom speed limit of segment {segmentId} info ({info}, name={info?.name}, " +
                         $"lanes={info?.m_lanes} is {customSpeedLimit}");
 #endif
@@ -875,7 +880,7 @@ namespace TrafficManager.Manager.Impl {
                     if (IsValidRange(customSpeedLimit)) {
                         // lane speed limit differs from default speed limit
 #if DEBUG
-                        Log._DebugIf(DebugSwitch.SpeedLimits.Get(), () =>
+                        Log._DebugIf(debugLogging, () =>
                             "SpeedLimitManager.LoadData: Loading lane speed limit: " +
                             $"lane {laneSpeedLimit.laneId} = {laneSpeedLimit.speedLimit} km/h");
 #endif
@@ -884,8 +889,9 @@ namespace TrafficManager.Manager.Impl {
 
                         Flags.SetLaneSpeedLimit(laneSpeedLimit.laneId, kmph);
                     } else {
-#if DEBUGLOAD
-                    Log._Debug($"SpeedLimitManager.LoadData: " +
+#if DEBUG
+                    Log._DebugIf(debugLogging, () =>
+                        "SpeedLimitManager.LoadData: " +
                         $"Skipping lane speed limit of lane {laneSpeedLimit.laneId} " +
                         $"({laneSpeedLimit.speedLimit} km/h)");
 #endif


### PR DESCRIPTION
Fixes #735 

* Encapsulate lane speed limit logging in a debug switch to prevent log spam in `DEBUG` builds
    * `DebugSwitch.SpeedLimits.Get()` (switch 26)
* Remove duplicate logging
* Remove duplicate `Flags.SetLaneSpeedLimit()` calls

Code hints showing that `Flags` is obsolete - is there something else that should be used here?

~~Also, what is `DEBUGLOAD` switch doing in this file; old lint? Should it be removed and replaced with `DebugSwitch.SpeedLimits.Get()` filters?~~

* Got rid of the `DEBUGLOAD` and updated all debug logging in the `LoadData()` method.