### PR TITLE
fixed iteration exception when clicking on handles

### DIFF
--- a/TLM/TLM/UI/SubTools/VehicleRestrictionsTool.cs
+++ b/TLM/TLM/UI/SubTools/VehicleRestrictionsTool.cs
@@ -242,11 +242,11 @@ namespace TrafficManager.UI.SubTools {
                     segmentId,
                     ref netManager.m_segments.m_buffer[segmentId],
                     viewOnly || segmentId != SelectedSegmentId,
-                    out bool update)) {
+                    out bool updated)) {
                     handleHovered = true;
                 }
 
-                if (update) {
+                if (updated) {
                     break;
                 }
             }

--- a/TLM/TLM/UI/SubTools/VehicleRestrictionsTool.cs
+++ b/TLM/TLM/UI/SubTools/VehicleRestrictionsTool.cs
@@ -218,7 +218,6 @@ namespace TrafficManager.UI.SubTools {
         private void ShowSigns(bool viewOnly) {
             Vector3 camPos = Camera.main.transform.position;
             NetManager netManager = Singleton<NetManager>.instance;
-            ushort updatedSegmentId = 0;
             bool handleHovered = false;
 
             foreach (ushort segmentId in currentRestrictedSegmentIds) {
@@ -248,15 +247,11 @@ namespace TrafficManager.UI.SubTools {
                 }
 
                 if (update) {
-                    updatedSegmentId = segmentId;
+                    break;
                 }
             }
 
             overlayHandleHovered = handleHovered;
-
-            if (updatedSegmentId != 0) {
-                RefreshCurrentRestrictedSegmentIds(updatedSegmentId);
-            }
         }
 
         private void GuiVehicleRestrictionsWindow(int num) {
@@ -581,7 +576,7 @@ namespace TrafficManager.UI.SubTools {
                             vehicleType,
                             !allowed);
                         stateUpdated = true;
-
+                        RefreshCurrentRestrictedSegmentIds(segmentId);
                         if (RoadMode) {
                             ApplyRestrictionsToAllSegments(sortedLaneIndex, vehicleType);
                         }


### PR DESCRIPTION
fixes #744

I break after update segment list is updated to avoid exception. next loop will have a fresh start.

I can confirm that we don't get similar exceptions in speed limit tool or parking tool.