### PR TITLE
 avoid reload if game is already loaded.

### DIFF
--- a/TLM/TLM/LoadingExtension.cs
+++ b/TLM/TLM/LoadingExtension.cs
@@ -265,6 +265,7 @@ namespace TrafficManager {
             if(IsGameLoaded) {
                 // When another mod is detected, OnCreated is called again for god - or CS team - knows what reason!
                 Log._Debug("Hot reload of another mod detected. Skipping LoadingExtension.OnCreated() ...");
+                return;
             }
 
             Detours = new List<Detour>();

--- a/TLM/TLM/LoadingExtension.cs
+++ b/TLM/TLM/LoadingExtension.cs
@@ -24,22 +24,9 @@ namespace TrafficManager {
         private const string HARMONY_ID = "de.viathinksoft.tmpe";
         internal static LoadingExtension Instance = null;
 
-        internal bool InGameHotReload { get; private set; } = false;
-
-        internal static AppMode currentMode => SimulationManager.instance.m_ManagersWrapper.loading.currentMode;
-
-        internal static bool InGame() {
-            try {
-                return currentMode == AppMode.Game;
-            } catch {
-                return false;
-            }
-        }
-
         FastList<ISimulationManager> simManager =>
             typeof(SimulationManager).GetField("m_managers", BindingFlags.Static | BindingFlags.NonPublic)
                 ?.GetValue(null) as FastList<ISimulationManager>;
-
 
         public class Detour {
             public MethodInfo OriginalMethod;
@@ -284,7 +271,6 @@ namespace TrafficManager {
             RegisterCustomManagers();
 
             Instance = this;
-            InGameHotReload = InGame();
         }
 
         private void RegisterCustomManagers() {

--- a/TLM/TLM/LoadingExtension.cs
+++ b/TLM/TLM/LoadingExtension.cs
@@ -262,6 +262,10 @@ namespace TrafficManager {
 
             // SelfDestruct.DestructOldInstances(this);
             base.OnCreated(loading);
+            if(IsGameLoaded) {
+                // When another mod is detected, OnCreated is called again for god - or CS team - knows what reason!
+                Log._Debug("Hot reload of another mod detected. Skipping LoadingExtension.OnCreated() ...");
+            }
 
             Detours = new List<Detour>();
             RegisteredManagers = new List<ICustomManager>();

--- a/TLM/TLM/LoadingExtension.cs
+++ b/TLM/TLM/LoadingExtension.cs
@@ -310,6 +310,7 @@ namespace TrafficManager {
         }
 
         public override void OnReleased() {
+            TrafficManagerMod.Instance.InGameHotReload = false;
             Instance = null;
             base.OnReleased();
         }

--- a/TLM/TLM/State/SerializableDataExtension.cs
+++ b/TLM/TLM/State/SerializableDataExtension.cs
@@ -20,11 +20,13 @@ namespace TrafficManager.State {
         public static bool StateLoading;
 
         public override void OnCreated(ISerializableData serializableData) {
+            Log._Debug("SerializableDataExtension.OnCreated() called");
+            if(LoadingExtension.IsGameLoaded) {
+                Log._Debug("Hot reload of another mod detected. Skipping SerializableDataExtension.OnCreated() ...");
+            }
             _serializableData = serializableData;
 
-            Log._Debug("SerializableDataExtension.OnCreated() called");
-
-            if (TrafficManagerMod.Instance.InGameHotReload && !LoadingExtension.IsGameLoaded) {
+            if (TrafficManagerMod.Instance.InGameHotReload) {
                 Log._Debug("HOT RELOAD ...");
                 OnLoadData();
                 LoadingExtension.Instance.OnLevelLoaded(LoadMode.LoadGame);

--- a/TLM/TLM/State/SerializableDataExtension.cs
+++ b/TLM/TLM/State/SerializableDataExtension.cs
@@ -23,6 +23,7 @@ namespace TrafficManager.State {
             Log._Debug("SerializableDataExtension.OnCreated() called");
             if(LoadingExtension.IsGameLoaded) {
                 Log._Debug("Hot reload of another mod detected. Skipping SerializableDataExtension.OnCreated() ...");
+                return;
             }
             _serializableData = serializableData;
 

--- a/TLM/TLM/State/SerializableDataExtension.cs
+++ b/TLM/TLM/State/SerializableDataExtension.cs
@@ -24,7 +24,7 @@ namespace TrafficManager.State {
 
             Log._Debug("SerializableDataExtension.OnCreated() called");
 
-            if (LoadingExtension.Instance.InGameHotReload) {
+            if (TrafficManagerMod.Instance.InGameHotReload && !LoadingExtension.IsGameLoaded) {
                 Log._Debug("HOT RELOAD ...");
                 OnLoadData();
                 LoadingExtension.Instance.OnLevelLoaded(LoadMode.LoadGame);

--- a/TLM/TLM/TrafficManagerMod.cs
+++ b/TLM/TLM/TrafficManagerMod.cs
@@ -41,6 +41,21 @@ namespace TrafficManager {
 
         public string Description => "Manage your city's traffic";
 
+        internal static TrafficManagerMod Instance = null;
+
+        internal bool InGameHotReload { get; private set; } = false;
+
+        internal static AppMode currentMode => SimulationManager.instance.m_ManagersWrapper.loading.currentMode;
+
+        internal static bool InGame() {
+            try {
+                return currentMode == AppMode.Game;
+            }
+            catch {
+                return false;
+            }
+        }
+
         [UsedImplicitly]
         public void OnEnabled() {
             Log.InfoFormat(
@@ -75,6 +90,9 @@ namespace TrafficManager {
                     Log.InfoFormat("Mono version: {0}", displayName.Invoke(null, null));
                 }
             }
+
+            Instance = this;
+            InGameHotReload = InGame();
         }
 
         [UsedImplicitly]
@@ -84,11 +102,12 @@ namespace TrafficManager {
             LocaleManager.eventLocaleChanged -= Translation.HandleGameLocaleChange;
             Translation.IsListeningToGameLocaleChanged = false; // is this necessary?
 
-            if (LoadingExtension.InGame() && LoadingExtension.Instance != null) {
+            if (InGame() && LoadingExtension.Instance != null) {
                 //Hot reload Unloading
                 LoadingExtension.Instance.OnLevelUnloading();
                 LoadingExtension.Instance.OnReleased();
             }
+            Instance = null;
         }
 
         [UsedImplicitly]

--- a/TLM/TLM/TrafficManagerMod.cs
+++ b/TLM/TLM/TrafficManagerMod.cs
@@ -11,6 +11,7 @@ namespace TrafficManager {
     using TrafficManager.Util;
     using static TrafficManager.Util.Shortcuts;
     using ColossalFramework;
+    using UnityEngine.SceneManagement;
 
     public class TrafficManagerMod : IUserMod {
 #if LABS
@@ -45,16 +46,7 @@ namespace TrafficManager {
 
         internal bool InGameHotReload { get; private set; } = false;
 
-        internal static AppMode currentMode => SimulationManager.instance.m_ManagersWrapper.loading.currentMode;
-
-        internal static bool InGame() {
-            try {
-                return currentMode == AppMode.Game;
-            }
-            catch {
-                return false;
-            }
-        }
+        internal static bool InGame() => SceneManager.GetActiveScene().name == "Game";
 
         [UsedImplicitly]
         public void OnEnabled() {

--- a/TLM/TLM/TrafficManagerMod.cs
+++ b/TLM/TLM/TrafficManagerMod.cs
@@ -44,7 +44,7 @@ namespace TrafficManager {
 
         internal static TrafficManagerMod Instance = null;
 
-        internal bool InGameHotReload { get; private set; } = false;
+        internal bool InGameHotReload { get; set; } = false;
 
         internal static bool InGame() => SceneManager.GetActiveScene().name == "Game";
 

--- a/TLM/TLM/UI/MainMenu/VersionLabel.cs
+++ b/TLM/TLM/UI/MainMenu/VersionLabel.cs
@@ -11,7 +11,7 @@ namespace TrafficManager.UI.MainMenu {
                 MainMenuPanel.ScaledSize.GetTitlebarHeight());
             text = TrafficManagerMod.ModName;
 
-            if(LoadingExtension.Instance.InGameHotReload) {
+            if(TrafficManagerMod.Instance.InGameHotReload) {
                 // make it easier to Identify Hot reload.
                 text += " HOT RELOAD " +
                     Assembly.GetExecutingAssembly().GetName().Version;


### PR DESCRIPTION
https://github.com/CitiesSkylinesMods/TMPE/issues/730#issuecomment-593099188 : if TMPE is already loaded and another mod is hot reloaded, CS calls OnCreate() again.

For this reason I made the following changes:
- moved Hot Reload logic to `TrafficManagerMod.Enabled()`
- `OnCreated()` is skipped if `LoadingExtension.IsGameLoaded`

These logs prove that my changes are successful:
[output_log.txt](https://github.com/CitiesSkylinesMods/TMPE/files/4272039/output_log.txt)
[TMPE.log](https://github.com/CitiesSkylinesMods/TMPE/files/4272041/TMPE.log)
