### PR TITLE
Fix typo in tag compare URLs in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ This changelog includes all versions and major variants of the mod going all the
 > * **TPP** = Traffic++
 > * **TM** = Traffic Manager
 
-#### TM:PE V[11.1.1-hotfix1](https://github.com/CitesSkylinesMods/TMPE/compare/11.1.1...11.1.1-hotfix1) LABS, 01/03/2020
+#### TM:PE V[11.1.1-hotfix1](https://github.com/CitiesSkylinesMods/TMPE/compare/11.1.1...11.1.1-hotfix1) LABS, 01/03/2020
 
 - Fixed: Vehicles stopping at Yield signs (#761, #756)
 - Fixed: Missing despawn buttons on cim and vehicle info panels (#765, #763, #759)
@@ -30,7 +30,7 @@ This changelog includes all versions and major variants of the mod going all the
 - Fixed: Faulty UI on tourist despawn button (#765)
 - Updated: Docs - Reference paths for EA Origin deployed game (thanks DannyDannyDan) ( #751)
 
-#### TM:PE V[11.1.1](https://github.com/CitesSkylinesMods/TMPE/compare/11.1.0...11.1.1) LABS, 29/02/2020
+#### TM:PE V[11.1.1](https://github.com/CitiesSkylinesMods/TMPE/compare/11.1.0...11.1.1) LABS, 29/02/2020
 
 - Added: The `Simulation Accuracy` option has been revived! (#742, #707)
 - Added: `Shift` key applies a setting to entire route + lane highlight (#138, #721, #709, #708, #667, #388, #33)
@@ -75,7 +75,7 @@ This changelog includes all versions and major variants of the mod going all the
 - Steam: [TM:PE v11 LABS](https://steamcommunity.com/sharedfiles/filedetails/?id=1806963141)
 - GitHub: [CitiesSkylinesMods/TMPE](https://github.com/CitiesSkylinesMods/TMPE)
 
-#### TM:PE V[11.1.0](https://github.com/CitesSkylinesMods/TMPE/compare/11.0...11.1.0) STABLE, 29/02/2020
+#### TM:PE V[11.1.0](https://github.com/CitiesSkylinesMods/TMPE/compare/11.0...11.1.0) STABLE, 29/02/2020
 
 - Added: Quick setup of priority roads (`Ctrl+Click junction`, `Shift+Ctrl+Click road`) (#621, #541, #542, #568, #577, #7)
 - Added: `Delete` key resets junction restrictions for selected junction (#639, #623, #568, #6)
@@ -94,7 +94,7 @@ This changelog includes all versions and major variants of the mod going all the
 - Meta: New WIP website: https://tmpe.me (#642, #643)
 - Steam: [TM:PE v11 STABLE](https://steamcommunity.com/sharedfiles/filedetails/?id=1637663252)
 
-#### TM:PE V[11.1.0](https://github.com/CitesSkylinesMods/TMPE/compare/11.0...11.1.0) LABS, 03/02/2020
+#### TM:PE V[11.1.0](https://github.com/CitiesSkylinesMods/TMPE/compare/11.0...11.1.0) LABS, 03/02/2020
 
 - Added: Quick setup of priority roads (`Ctrl+Click junction`, `Shift+Ctrl+Click road`) (#621, #541, #542, #568, #577, #7)
 - Added: `Delete` key resets junction restrictions for selected junction (#639, #623, #568, #6)
@@ -113,7 +113,7 @@ This changelog includes all versions and major variants of the mod going all the
 - Meta: New WIP website: https://tmpe.me (#642, #643)
 - Steam: [TM:PE v11 LABS](https://steamcommunity.com/sharedfiles/filedetails/?id=1806963141)
 
-### TM:PE V[11.0](https://github.com/CitesSkylinesMods/TMPE/compare/10.21.1...11.0) STABLE, 03/02/2020
+### TM:PE V[11.0](https://github.com/CitiesSkylinesMods/TMPE/compare/10.21.1...11.0) STABLE, 03/02/2020
 
 - Contains ~100 improvements from TM:PE v11 ALPHA previews, including:
     - Timed traffic lights: Add default sequence (Ctrl+Click a junction)
@@ -134,7 +134,7 @@ This changelog includes all versions and major variants of the mod going all the
 - Meta: Renamed LABS and ALPHA workshop pages to V11 STABLE and V11 LABS respectively
 - Steam: [TM:PE v11 STABLE](https://steamcommunity.com/sharedfiles/filedetails/?id=1637663252)
 
-### TM:PE V[11.0](https://github.com/CitesSkylinesMods/TMPE/compare/10.21.1...11.0) LABS, 03/02/2020
+### TM:PE V[11.0](https://github.com/CitiesSkylinesMods/TMPE/compare/10.21.1...11.0) LABS, 03/02/2020
 
 - Contains ~100 improvements from TM:PE v11 ALPHA previews, including:
     - Timed traffic lights: Add default sequence (Ctrl+Click a junction)
@@ -301,13 +301,13 @@ This changelog includes all versions and major variants of the mod going all the
 - Maintainer: aubergine18 (GitHub user aubergine10)
 - GitHub: [krzychu124/Cities-Skylines-Traffic-Manager-President-Edition](https://github.com/krzychu124/Cities-Skylines-Traffic-Manager-President-Edition)
 
-### TM:PE LABS [10.21.1 hotfix](https://github.com/CitesSkylinesMods/TMPE/compare/10.21...10.21.1), 06/07/2019
+### TM:PE LABS [10.21.1 hotfix](https://github.com/CitiesSkylinesMods/TMPE/compare/10.21...10.21.1), 06/07/2019
 
 - Fixed: Speed panel tanks fps if train tracks on screen (thanks rlas & DaEgi01!) (#411, #413)
 - Meta: Main changelog refactored (#412)
 - Steam: [Traffic Manager: President Edition (LABS)](https://steamcommunity.com/sharedfiles/filedetails/?id=1637663252)
 
-### TM:PE LABS [10.21](https://github.com/CitesSkylinesMods/TMPE/compare/10.20...10.21), 02/07/2019
+### TM:PE LABS [10.21](https://github.com/CitiesSkylinesMods/TMPE/compare/10.20...10.21), 02/07/2019
 
 - Added: Cims have individual driving styles to determine lane changes and driving speed (#263 #334)
 - Added: Miles Per Hour option for speed limits (thanks kvakvs) (#384)

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Official releases:
 - Meta: New WIP website: https://tmpe.me (#642, #643)
 - Steam: [TM:PE v11 STABLE](https://steamcommunity.com/sharedfiles/filedetails/?id=1637663252)
 
-#### TM:PE V[11.1.1-hotfix1](https://github.com/CitesSkylinesMods/TMPE/compare/11.1.1...11.1.1-hotfix1) LABS, 01/03/2020
+#### TM:PE V[11.1.1-hotfix1](https://github.com/CitiesSkylinesMods/TMPE/compare/11.1.1...11.1.1-hotfix1) LABS, 01/03/2020
 
 - Fixed: Vehicles stopping at Yield signs (#761, #756)
 - Fixed: Missing despawn buttons on cim and vehicle info panels (#765, #763, #759)


### PR DESCRIPTION
This just fixes a typo in the tag compare URLs in the changelog and readme.