### PR TITLE
fixed the direction of auto-TTL for RHT

### DIFF
--- a/TLM/TLM/Util/AutoTimedTrafficLights.cs
+++ b/TLM/TLM/Util/AutoTimedTrafficLights.cs
@@ -64,7 +64,7 @@ namespace TrafficManager.Util {
         /// <param name="nodeId">the junction</param>
         /// <returns>a list of segments aranged in counter clockwise direction.</returns>
         private static List<ushort> ArrangedSegments(ushort nodeId) {
-            ClockDirection clockDir = RHT ? ClockDirection.CounterClockwise : ClockDirection.CounterClockwise;
+            ClockDirection clockDir = RHT ? ClockDirection.Clockwise : ClockDirection.CounterClockwise;
             List<ushort> segList = new List<ushort>();
             netService.IterateNodeSegments(
                 nodeId,


### PR DESCRIPTION
fixes #769

fixed the direction of auto-TTL for RHT. This fixes the problem with pedestrian lights too.
see diff. Its a one word. 

RHT:
![Screenshot (639)](https://user-images.githubusercontent.com/26344691/75672033-85e66d00-5c88-11ea-9ff5-ae7ec9d83925.png)
![Screenshot (640)](https://user-images.githubusercontent.com/26344691/75672040-90086b80-5c88-11ea-9d90-74af8dbd7080.png)
LHT:
![Screenshot (642)](https://user-images.githubusercontent.com/26344691/75672097-a8788600-5c88-11ea-9a94-dd70673aae4f.png)
![Screenshot (643)](https://user-images.githubusercontent.com/26344691/75672106-ad3d3a00-5c88-11ea-8ebf-906dbebe5a1e.png)
![Screenshot (644)](https://user-images.githubusercontent.com/26344691/75672167-d8c02480-5c88-11ea-9731-e79a684cf39b.png)
