### PR TITLE
Small class to display warning and error prompts

### DIFF
--- a/TLM/TLM/State/Keybinds/KeybindUI.cs
+++ b/TLM/TLM/State/Keybinds/KeybindUI.cs
@@ -8,6 +8,7 @@ namespace TrafficManager.State.Keybinds {
     using System;
     using TrafficManager.UI;
     using UnityEngine;
+    using TrafficManager.UI.Helpers;
 
     /// <summary>
     /// Helper for creating keyboard bindings Settings page.
@@ -219,9 +220,7 @@ namespace TrafficManager.State.Keybinds {
                         var message = Translation.Options.Get("Keybinds.Dialog.Text:Keybind conflict")
                                       + "\n\n" + maybeConflict;
                         Log.Info($"Keybind conflict: {message}");
-                        UIView.library
-                          .ShowModal<ExceptionPanel>("ExceptionPanel")
-                          .SetMessage("Key Conflict", message, false);
+                        Prompt.Warning("Key Conflict", message);
                     } else {
                         editedBinding.Value.TargetKey.value = inputKey;
                         editedBinding.Value.Target.NotifyKeyChanged();
@@ -257,9 +256,7 @@ namespace TrafficManager.State.Keybinds {
                     var message = Translation.Options.Get("Keybinds.Dialog.Text:Keybind conflict")
                                   + "\n\n" + maybeConflict;
                     Log.Info($"Keybind conflict: {message}");
-                    UIView.library
-                          .ShowModal<ExceptionPanel>("ExceptionPanel")
-                          .SetMessage("Key Conflict", message, false);
+                    Prompt.Warning("Key Conflict", message);
                 } else {
                     editedBinding.Value.TargetKey.value = inputKey;
                     editedBinding.Value.Target.NotifyKeyChanged();

--- a/TLM/TLM/State/Options.cs
+++ b/TLM/TLM/State/Options.cs
@@ -164,11 +164,10 @@ namespace TrafficManager.State {
             }
 
             if (warn) {
-                UIView.library.ShowModal<ExceptionPanel>("ExceptionPanel").SetMessage(
+                Prompt.Warning(
                     "Nope!",
                     Translation.Options.Get("Dialog.Text:Settings are stored in savegame")
-                    + " https://www.viathinksoft.de/tmpe/#options",
-                    false);
+                    + " https://github.com/CitiesSkylinesMods/TMPE/wiki/Settings");
             }
 
             return false;

--- a/TLM/TLM/TLM.csproj
+++ b/TLM/TLM/TLM.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -150,6 +150,7 @@
     <Compile Include="Manager\Impl\ExtSegmentEndManager.cs" />
     <Compile Include="Manager\Impl\ExtSegmentManager.cs" />
     <Compile Include="UI\Helpers\NodeLaneMarker.cs" />
+    <Compile Include="UI\Helpers\Prompt.cs" />
     <Compile Include="UI\Helpers\SegmentLaneMarker.cs" />
     <Compile Include="UI\Helpers\ExtUITabStrip.cs" />
     <Compile Include="Manager\Impl\SegmentEndManager.cs" />
@@ -525,7 +526,7 @@
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Traffic\Data\" />
-    <Folder Include="U\MainMenu" />
+    <Folder Include="U\MainMenu\" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Resources\TrafficLights\pedestrian_mode_1.png" />

--- a/TLM/TLM/ThreadingExtension.cs
+++ b/TLM/TLM/ThreadingExtension.cs
@@ -13,6 +13,7 @@ namespace TrafficManager {
     using TrafficManager.State;
     using TrafficManager.UI;
     using UnityEngine;
+    using TrafficManager.UI.Helpers;
 
     [UsedImplicitly]
     public sealed class ThreadingExtension : ThreadingExtensionBase {
@@ -98,16 +99,7 @@ namespace TrafficManager {
                     Log.Info(log);
 
                     if (GlobalConfig.Instance.Main.ShowCompatibilityCheckErrorMessage) {
-                        Singleton<SimulationManager>.instance.m_ThreadingWrapper.QueueMainThread(
-                            () => {
-                                UIView
-                                    .library
-                                    .ShowModal<ExceptionPanel>(
-                                        "ExceptionPanel").SetMessage(
-                                        "Incompatibility Issue",
-                                        error,
-                                        true);
-                            });
+                        Prompt.Error("TM:PE Incompatibility Issue", error);
                     }
                 }
             }

--- a/TLM/TLM/UI/Helpers/Prompt.cs
+++ b/TLM/TLM/UI/Helpers/Prompt.cs
@@ -1,11 +1,18 @@
 namespace TrafficManager.UI.Helpers {
     using ColossalFramework;
     using ColossalFramework.UI;
+    using System;
+    using UnityEngine.SceneManagement;
 
     /// <summary>
-    /// Use this class to display small dialog prompts to the user.
+    /// Use this class to display small but annoying dialog prompts to the user.
     ///
-    /// Currently this is only tested for use in `LoadingExtension.OnLevelLoaded()`.
+    /// TODO: At some point add more panels, such as:
+    /// * ConfirmPanel
+    /// * ExitConfirmPanel
+    /// * MessageBoxPanel
+    /// * TutorialPanel
+    /// * TutorialAdvisorPanel
     /// </summary>
     public class Prompt {
 
@@ -20,7 +27,7 @@ namespace TrafficManager.UI.Helpers {
         }
 
         /// <summary>
-        /// Display a warning prompt in the center of the screen.
+        /// Display a formatted warning prompt in the center of the screen.
         /// </summary>
         /// 
         /// <param name="title">Dialog title.</param>
@@ -40,7 +47,7 @@ namespace TrafficManager.UI.Helpers {
         }
 
         /// <summary>
-        /// Display an error prompt in the center of the screen.
+        /// Display an formatted error prompt in the center of the screen.
         /// </summary>
         /// 
         /// <param name="title">Dialog title.</param>
@@ -59,18 +66,21 @@ namespace TrafficManager.UI.Helpers {
         /// <param name="message">Dialog body text.</param>
         /// <param name="isError">If <c>true</c>, the dialog is styled as an error.</param>
         internal static void ExceptionPanel(string title, string message, bool isError) {
-            // todo: make sure it works everywhere:
-            // * from main menu
-            // * while a city is loading
-            // * while in a city (in-game)
-            // * while a city is unloading.
-
-            Singleton<SimulationManager>.instance.m_ThreadingWrapper.QueueMainThread(
-                () => {
-                    UIView.library
-                        .ShowModal<ExceptionPanel>("ExceptionPanel")
-                        .SetMessage(title, message, isError);
-                });
+            // if in-game, queue in main thread, otherwise display immediately
+            // note: I have no idea if this is good way to do it!
+            Action show = 
+            if (SceneManager.GetActiveScene().name == "Game") {
+                Singleton<SimulationManager>.instance.m_ThreadingWrapper.QueueMainThread(
+                    () => {
+                        UIView.library
+                            .ShowModal<ExceptionPanel>("ExceptionPanel")
+                            .SetMessage(title, message, isError);
+                    });
+            } else {
+                UIView.library
+                    .ShowModal<ExceptionPanel>("ExceptionPanel")
+                    .SetMessage(title, message, isError);
+            }
         }
     }
 }

--- a/TLM/TLM/UI/Helpers/Prompt.cs
+++ b/TLM/TLM/UI/Helpers/Prompt.cs
@@ -1,6 +1,7 @@
 namespace TrafficManager.UI.Helpers {
     using ColossalFramework;
     using ColossalFramework.UI;
+    using CSUtil.Commons;
     using System;
     using UnityEngine.SceneManagement;
 
@@ -66,20 +67,22 @@ namespace TrafficManager.UI.Helpers {
         /// <param name="message">Dialog body text.</param>
         /// <param name="isError">If <c>true</c>, the dialog is styled as an error.</param>
         internal static void ExceptionPanel(string title, string message, bool isError) {
-            // if in-game, queue in main thread, otherwise display immediately
-            // note: I have no idea if this is good way to do it!
-            Action show = 
-            if (SceneManager.GetActiveScene().name == "Game") {
-                Singleton<SimulationManager>.instance.m_ThreadingWrapper.QueueMainThread(
-                    () => {
-                        UIView.library
-                            .ShowModal<ExceptionPanel>("ExceptionPanel")
-                            .SetMessage(title, message, isError);
-                    });
-            } else {
+            Action prompt = () => {
                 UIView.library
                     .ShowModal<ExceptionPanel>("ExceptionPanel")
                     .SetMessage(title, message, isError);
+            };
+
+            try {
+                if (SceneManager.GetActiveScene().name == "Game") {
+                    Singleton<SimulationManager>.instance.m_ThreadingWrapper.QueueMainThread(prompt);
+                } else {
+                    prompt();
+                }
+            } catch (Exception e) {
+                Log.ErrorFormat(
+                    "Error displaying a Prompt:\n{0}",
+                    e.ToString());
             }
         }
     }

--- a/TLM/TLM/UI/Helpers/Prompt.cs
+++ b/TLM/TLM/UI/Helpers/Prompt.cs
@@ -20,12 +20,34 @@ namespace TrafficManager.UI.Helpers {
         }
 
         /// <summary>
+        /// Display a warning prompt in the center of the screen.
+        /// </summary>
+        /// 
+        /// <param name="title">Dialog title.</param>
+        /// <param name="messageFormat">Dialog body text format.</param>
+        /// <param name="args">Values to put in the <paramref name="messageFormat"/>.</param>
+        public static void WarningFormat(string title, string messageFormat, params object[] args) {
+            ExceptionPanel(title, string.Format(messageFormat, args), false);
+        }
+
+        /// <summary>
         /// Display an error prompt in the centre of the screen.
         /// </summary>
         /// <param name="title">Dialog title.</param>
         /// <param name="message">Dialog body text.</param>
         public static void Error(string title, string message) {
             ExceptionPanel(title, message, true);
+        }
+
+        /// <summary>
+        /// Display an error prompt in the center of the screen.
+        /// </summary>
+        /// 
+        /// <param name="title">Dialog title.</param>
+        /// <param name="messageFormat">Dialog body text format.</param>
+        /// <param name="args">Values to put in the <paramref name="messageFormat"/>.</param>
+        public static void ErrorFormat(string title, string messageFormat, params object[] args) {
+            ExceptionPanel(title, string.Format(messageFormat, args), true);
         }
 
         /// <summary>

--- a/TLM/TLM/UI/Helpers/Prompt.cs
+++ b/TLM/TLM/UI/Helpers/Prompt.cs
@@ -1,0 +1,54 @@
+namespace TrafficManager.UI.Helpers {
+    using ColossalFramework;
+    using ColossalFramework.UI;
+
+    /// <summary>
+    /// Use this class to display small dialog prompts to the user.
+    ///
+    /// Currently this is only tested for use in `LoadingExtension.OnLevelLoaded()`.
+    /// </summary>
+    public class Prompt {
+
+        /// <summary>
+        /// Display a warning prompt in the centre of the screen.
+        /// </summary>
+        /// 
+        /// <param name="title">Dialog title.</param>
+        /// <param name="message">Dialog body text.</param>
+        public static void Warning(string title, string message) {
+            ExceptionPanel(title, message, false);
+        }
+
+        /// <summary>
+        /// Display an error prompt in the centre of the screen.
+        /// </summary>
+        /// <param name="title">Dialog title.</param>
+        /// <param name="message">Dialog body text.</param>
+        public static void Error(string title, string message) {
+            ExceptionPanel(title, message, true);
+        }
+
+        /// <summary>
+        /// Display an exception message in the center of the screen, optionally
+        /// styled as an error.
+        /// </summary>
+        /// 
+        /// <param name="title">Dialog title.</param>
+        /// <param name="message">Dialog body text.</param>
+        /// <param name="isError">If <c>true</c>, the dialog is styled as an error.</param>
+        internal static void ExceptionPanel(string title, string message, bool isError) {
+            // todo: make sure it works everywhere:
+            // * from main menu
+            // * while a city is loading
+            // * while in a city (in-game)
+            // * while a city is unloading.
+
+            Singleton<SimulationManager>.instance.m_ThreadingWrapper.QueueMainThread(
+                () => {
+                    UIView.library
+                        .ShowModal<ExceptionPanel>("ExceptionPanel")
+                        .SetMessage(title, message, isError);
+                });
+        }
+    }
+}

--- a/TLM/TLM/UI/SubTools/ManualTrafficLightsTool.cs
+++ b/TLM/TLM/UI/SubTools/ManualTrafficLightsTool.cs
@@ -1,7 +1,6 @@
-﻿namespace TrafficManager.UI.SubTools {
+namespace TrafficManager.UI.SubTools {
     using ColossalFramework;
     using JetBrains.Annotations;
-    using TrafficLight;
     using TrafficManager.API.Manager;
     using TrafficManager.API.Traffic.Data;
     using TrafficManager.API.Traffic.Enums;
@@ -62,8 +61,7 @@
                 //        }
                 //    }
             } else {
-                MainTool.ShowError(
-                    Translation.TrafficLights.Get("Dialog.Text:Node has timed TL script"));
+                MainTool.WarningPrompt(Translation.TrafficLights.Get("Dialog.Text:Node has timed TL script"));
             }
         }
 

--- a/TLM/TLM/UI/SubTools/PrioritySignsTool.cs
+++ b/TLM/TLM/UI/SubTools/PrioritySignsTool.cs
@@ -591,7 +591,7 @@ namespace TrafficManager.UI.SubTools {
                 // Log._Debug($"PrioritySignsTool.MayNodeHavePrioritySigns: Node {nodeId} does not
                 //     allow priority signs: {reason}");
                 if (reason == SetPrioritySignError.HasTimedLight) {
-                    MainTool.ShowError(
+                    MainTool.WarningPrompt(
                         Translation.TrafficLights.Get("Dialog.Text:Node has timed TL script"));
                 }
 

--- a/TLM/TLM/UI/SubTools/TimedTrafficLightsTool.cs
+++ b/TLM/TLM/UI/SubTools/TimedTrafficLightsTool.cs
@@ -106,7 +106,8 @@ namespace TrafficManager.UI.SubTools {
             bool ctrlDown = Input.GetKey(KeyCode.LeftControl) || Input.GetKey(KeyCode.RightControl);
             if(ctrlDown) {
                 AutoTimedTrafficLights.ErrorResult res = AutoTimedTrafficLights.Setup(HoveredNodeId);
-                    string message = null;
+                string message = null;
+
                 switch (res) {
                     case AutoTimedTrafficLights.ErrorResult.NotSupported:
                         MainTool.Guide.Activate("TimedTrafficLightsTool_Auto TL no need");
@@ -126,7 +127,7 @@ namespace TrafficManager.UI.SubTools {
                         Translation.TrafficLights.Get("Dialog.Text:Auto TL create failed because") +
                         "\n" +
                         Translation.TrafficLights.Get(message);
-                    MainTool.ShowError(message);
+                    MainTool.WarningPrompt(message);
                     return;
                 }
                 RefreshCurrentTimedNodeIds(HoveredNodeId);
@@ -160,7 +161,7 @@ namespace TrafficManager.UI.SubTools {
                                 MainTool.SetToolMode(ToolMode.TimedLightsShowLights);
                             }
                         } else {
-                            MainTool.ShowError(T("Dialog.Text:Node has timed TL script"));
+                            MainTool.WarningPrompt(T("Dialog.Text:Node has timed TL script"));
                         }
                     }
 
@@ -242,14 +243,14 @@ namespace TrafficManager.UI.SubTools {
                                             .CountSegments();
 
                     if (numSourceSegments != numTargetSegments) {
-                        MainTool.ShowError(
+                        MainTool.WarningPrompt(
                             T("Dialog.Text:Incompatible traffic light script"));
                         return;
                     }
 
                     // check for existing simulation
                     if (tlsMan.HasTimedSimulation(HoveredNodeId)) {
-                        MainTool.ShowError(
+                        MainTool.WarningPrompt(
                             T("Dialog.Text:Node has timed TL script"));
                         return;
                     }

--- a/TLM/TLM/UI/SubTools/ToggleTrafficLightsTool.cs
+++ b/TLM/TLM/UI/SubTools/ToggleTrafficLightsTool.cs
@@ -61,13 +61,13 @@ namespace TrafficManager.UI.SubTools {
                 if (showMessageOnError) {
                     switch (reason) {
                         case ToggleTrafficLightError.HasTimedLight: {
-                            MainTool.ShowError(
+                            MainTool.WarningPrompt(
                                 Translation.TrafficLights.Get("Dialog.Text:Node has timed TL script"));
                             break;
                         }
 
                         case ToggleTrafficLightError.IsLevelCrossing: {
-                            MainTool.ShowError(
+                            MainTool.WarningPrompt(
                                 Translation.TrafficLights.Get("Dialog.Text:Node is level crossing"));
                             break;
                         }

--- a/TLM/TLM/UI/TrafficManagerTool.cs
+++ b/TLM/TLM/UI/TrafficManagerTool.cs
@@ -14,15 +14,15 @@ namespace TrafficManager.UI {
     using JetBrains.Annotations;
     using TrafficManager.Manager.Impl;
     using TrafficManager.State;
+#if DEBUG
     using TrafficManager.State.ConfigData;
+#endif
     using TrafficManager.UI.MainMenu;
     using TrafficManager.UI.SubTools;
     using TrafficManager.UI.SubTools.SpeedLimits;
     using TrafficManager.Util;
     using UnityEngine;
     using TrafficManager.UI.Helpers;
-    using GenericGameBridge.Service;
-    using CitiesGameBridge.Service;
 
     [UsedImplicitly]
     public class TrafficManagerTool
@@ -1871,16 +1871,17 @@ namespace TrafficManager.UI {
             return false;
         }
 
-        /// <summary>Displays modal popup with an error</summary>
-        /// <param name="text">The localized message</param>
-        public void ShowError(string text) {
-            if (text == null) {
+        /// <summary>
+        /// Displays a warning prompt in center of the screen.
+        /// </summary>
+        /// 
+        /// <param name="message">The localized body text of the prompt.</param>
+        public void WarningPrompt(string message) {
+            if (string.IsNullOrEmpty(message)) {
                 return;
             }
 
-            UIView.library
-                  .ShowModal<ExceptionPanel>("ExceptionPanel")
-                  .SetMessage("Info", text, false);
+            Prompt.Warning("Warning", message);
         }
     }
 }


### PR DESCRIPTION
Just a simple helper to display warning/error prompts in center of screen.

There's a few places where these things are used, most notably:

* Warning that setting can only be changed in-game (mod options screen from main menu)
* Warning about game version mismatch (in-game)
* Warning about detour/patch issues (in-game)
* Probably some user interactions in-game that haven't yet been moved to `GuideManager`?

Usage from call site:

```cs
using TrafficManager.UI.Helpers;

// ...

Prompt.Warning("title", "body text");

Prompt.Error("title", "body text");
```

#### TODO:

- [x] Currently the prompts are wrapped in `Singleton<SimulationManager>.instance.m_ThreadingWrapper.QueueMainThread`, so **they will only work while in-game**. From main menu, that stuff isn't required.

* What's the best way to check whether I need to do the `QueueMainThread` stuff?
* Also, should I be checking `System.Threading.Thread.CurrentThread.Name != "Simulation"` like in `GuideWrapper.cs`?

Answers on a postcard to usual address please :)

- [x] Add some `...Format()` method overloads.
- [x] Find where the prompts are currently used in solution and make them use the `Prompt` helper

Following prompts have been updated:

* Keybinds - shortcut already exists (both on key and mouse)
* Mod options - when user changes game-only option from main menu
* Threading extension - if an unexpected incompatibility is found
* Main Tool - `ShowError()` renamed to `ShowWarning()` now uses `Prompt.Warning()`, affects:
    * Manual traffic light tool - if user clicks junction with TTL
    * Toggle traffic light tool - if user clicks junction with TTL
    * TTL tool - 4 separate warnings
    * Priority signs tool - if user clicks junction with TTL
* Stuff in `LoadingExtenion` has _not_ been altered as it will be replaced by PRs #773 and #699.