### PR TITLE
pushed TMPE to harmony 2.

### DIFF
--- a/TLM/TLM/LoadingExtension.cs
+++ b/TLM/TLM/LoadingExtension.cs
@@ -53,7 +53,7 @@ namespace TrafficManager {
 
         public static List<Detour> Detours { get; set; }
 
-        public static Harmony HarmonyInst { get; private set; }
+        public static Harmony  HarmonyInst { get; private set; }
 
         /// <summary>
         /// Contains loaded languages and lookup functions for text translations

--- a/TLM/TLM/LoadingExtension.cs
+++ b/TLM/TLM/LoadingExtension.cs
@@ -2,7 +2,7 @@ namespace TrafficManager {
     using ColossalFramework.UI;
     using ColossalFramework;
     using CSUtil.Commons;
-    using Harmony;
+    using HarmonyLib;
     using ICities;
     using JetBrains.Annotations;
     using Object = UnityEngine.Object;
@@ -53,7 +53,7 @@ namespace TrafficManager {
 
         public static List<Detour> Detours { get; set; }
 
-        public static HarmonyInstance HarmonyInst { get; private set; }
+        public static Harmony HarmonyInst { get; private set; }
 
         /// <summary>
         /// Contains loaded languages and lookup functions for text translations
@@ -174,7 +174,7 @@ namespace TrafficManager {
             try {
                 Log.Info("Deploying Harmony patches");
 #if DEBUG
-                HarmonyInstance.DEBUG = true;
+                Harmony.DEBUG = true;
 #endif
                 Assembly assembly = Assembly.GetExecutingAssembly();
 
@@ -182,7 +182,7 @@ namespace TrafficManager {
 
                 // Harmony attribute-driven patching
                 Log.Info($"Performing Harmony attribute-driven patching");
-                HarmonyInst = HarmonyInstance.Create(HARMONY_ID);
+                HarmonyInst = new Harmony(HARMONY_ID);
                 HarmonyInst.PatchAll(assembly);
 
                 foreach (Type type in assembly.GetTypes()) {

--- a/TLM/TLM/Patch/_CitizenManager/ReleaseCitizenInstancePatch.cs
+++ b/TLM/TLM/Patch/_CitizenManager/ReleaseCitizenInstancePatch.cs
@@ -1,5 +1,5 @@
 ﻿namespace TrafficManager.Patch._CitizenManager {
-    using Harmony;
+    using HarmonyLib;
     using JetBrains.Annotations;
 
     [HarmonyPatch(typeof(CitizenManager), "ReleaseCitizenInstance")]

--- a/TLM/TLM/Patch/_CitizenManager/ReleaseCitizenPatch.cs
+++ b/TLM/TLM/Patch/_CitizenManager/ReleaseCitizenPatch.cs
@@ -1,5 +1,5 @@
 ﻿namespace TrafficManager.Patch._CitizenManager {
-    using Harmony;
+    using HarmonyLib;
     using JetBrains.Annotations;
 
     [HarmonyPatch(typeof(CitizenManager), "ReleaseCitizen")]

--- a/TLM/TLM/Patch/_HumanAI/ArriveAtDestinationPatch.cs
+++ b/TLM/TLM/Patch/_HumanAI/ArriveAtDestinationPatch.cs
@@ -1,6 +1,6 @@
 ﻿namespace TrafficManager.Patch._HumanAI {
     using ColossalFramework;
-    using Harmony;
+    using HarmonyLib;
     using JetBrains.Annotations;
     using TrafficManager.State;
 

--- a/TLM/TLM/Patch/_NetManager/FinalizeSegmentPatch.cs
+++ b/TLM/TLM/Patch/_NetManager/FinalizeSegmentPatch.cs
@@ -1,5 +1,5 @@
 ﻿namespace TrafficManager.Patch._NetManager {
-    using Harmony;
+    using HarmonyLib;
     using JetBrains.Annotations;
 
     [HarmonyPatch(typeof(NetManager), "FinalizeSegment")]

--- a/TLM/TLM/Patch/_NetManager/UpdateSegmentPatch.cs
+++ b/TLM/TLM/Patch/_NetManager/UpdateSegmentPatch.cs
@@ -1,5 +1,5 @@
 ﻿namespace TrafficManager.Patch._NetManager {
-    using Harmony;
+    using HarmonyLib;
     using JetBrains.Annotations;
 
     [HarmonyPatch(

--- a/TLM/TLM/Patch/_RoadBaseAI/GetTrafficLightNodeStatePatch.cs
+++ b/TLM/TLM/Patch/_RoadBaseAI/GetTrafficLightNodeStatePatch.cs
@@ -1,6 +1,6 @@
 ﻿namespace TrafficManager.Patch._RoadBaseAI {
     using ColossalFramework;
-    using Harmony;
+    using HarmonyLib;
     using JetBrains.Annotations;
     using TrafficManager.State;
     using UnityEngine;

--- a/TLM/TLM/Patch/_RoadBaseAI/SetTrafficLightStatePatch.cs
+++ b/TLM/TLM/Patch/_RoadBaseAI/SetTrafficLightStatePatch.cs
@@ -1,5 +1,5 @@
 ﻿namespace TrafficManager.Patch._RoadBaseAI {
-    using Harmony;
+    using HarmonyLib;
     using JetBrains.Annotations;
     using TrafficManager.State;
     using static RoadBaseAI;

--- a/TLM/TLM/Patch/_RoadBaseAI/UpdateLanesPatch.cs
+++ b/TLM/TLM/Patch/_RoadBaseAI/UpdateLanesPatch.cs
@@ -1,6 +1,6 @@
 ﻿namespace TrafficManager.Patch._RoadBaseAI {
     using ColossalFramework;
-    using Harmony;
+    using HarmonyLib;
     using JetBrains.Annotations;
     using TrafficManager.State;
 

--- a/TLM/TLM/Patch/_RoadBaseAI/UpdateNodePatch.cs
+++ b/TLM/TLM/Patch/_RoadBaseAI/UpdateNodePatch.cs
@@ -1,6 +1,6 @@
 namespace TrafficManager.Patch._RoadBaseAI {
     using ColossalFramework;
-    using Harmony;
+    using HarmonyLib;
     using JetBrains.Annotations;
     using TrafficManager.Manager.Impl;
     using TrafficManager.State;

--- a/TLM/TLM/Patch/_Vehicle/SpawnPatch.cs
+++ b/TLM/TLM/Patch/_Vehicle/SpawnPatch.cs
@@ -1,7 +1,7 @@
 ﻿using ColossalFramework;
 using ColossalFramework.Math;
 using CSUtil.Commons;
-using Harmony;
+using HarmonyLib;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/TLM/TLM/Patch/_Vehicle/UnspawnPatch.cs
+++ b/TLM/TLM/Patch/_Vehicle/UnspawnPatch.cs
@@ -1,7 +1,7 @@
 ﻿using ColossalFramework;
 using ColossalFramework.Math;
 using CSUtil.Commons;
-using Harmony;
+using HarmonyLib;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/TLM/TLM/Patch/_VehicleManager/CreateVehiclePatch.cs
+++ b/TLM/TLM/Patch/_VehicleManager/CreateVehiclePatch.cs
@@ -1,5 +1,5 @@
 ﻿namespace TrafficManager.Patch._VehicleManager {
-    using Harmony;
+    using HarmonyLib;
     using JetBrains.Annotations;
 
     [HarmonyPatch(typeof(VehicleManager), "CreateVehicle")]

--- a/TLM/TLM/Patch/_VehicleManager/ReleaseVehiclePatch.cs
+++ b/TLM/TLM/Patch/_VehicleManager/ReleaseVehiclePatch.cs
@@ -1,5 +1,5 @@
 ﻿namespace TrafficManager.Patch._VehicleManager {
-    using Harmony;
+    using HarmonyLib;
     using JetBrains.Annotations;
 
     [HarmonyPatch(typeof(VehicleManager), "ReleaseVehicle")]


### PR DESCRIPTION
fixes #782 

I just did simple search and replace and everything worked.
don't want to mess with redirection framework as that should be part of a separate effort. that means manual patching also stays there.

Plan: this will not be merge until we are ready and organized with other developers.
At some point we may want to switch to harmony mod. this PR would be a preparation of that.
I can continue #734 on the top of this.

Test:
I used lane connector to force cars to change lanes, they did. that proves that path finding patch is working.

EDIT: oh and by the way I had to update redirection framework as well. that is where the harmony dll lies. https://github.com/CitiesSkylinesMods/RedirectionFramework/pull/3
