### PR TITLE
Fix DLC filter in SpeedLimitManager

### DIFF
--- a/TLM/TLM/Manager/Impl/SpeedLimitManager.cs
+++ b/TLM/TLM/Manager/Impl/SpeedLimitManager.cs
@@ -720,7 +720,7 @@ namespace TrafficManager.Manager.Impl {
                 }
 
                 // If it requires DLC, check the DLC is active
-                if (info.m_dlcRequired != 0 && (uint)(info.m_dlcRequired & dlcMask) != 0u) {
+                if ((info.m_dlcRequired & dlcMask) != info.m_dlcRequired) {
                     log.AppendFormat(
                         "- Skipped: NetInfo #{0} ({1}) - required DLC not active.\n",
                         i,


### PR DESCRIPTION
Fixes #818 - DLC filter wasn't working, causing some roads to not appear in default speed limit UI.