### PR TITLE
Auto-debug ExtCitizenInstanceManager.StartPathFind()

### DIFF
--- a/TLM/TLM/Manager/Impl/ExtCitizenInstanceManager.cs
+++ b/TLM/TLM/Manager/Impl/ExtCitizenInstanceManager.cs
@@ -27,7 +27,7 @@ namespace TrafficManager.Manager.Impl {
         /// * True = error occurred, log next patfind
         /// * False = stop logging and don't do any additional logging.
         /// </summary>
-        private TernaryBool pathFindAdHocDebug = TernaryBool.Undefined;
+        private static TernaryBool pathFindAdHocDebug = TernaryBool.Undefined;
 
         /// <summary>
         /// All additional data for citizen instance. Index: citizen instance id

--- a/TLM/TLM/Manager/Impl/ExtCitizenInstanceManager.cs
+++ b/TLM/TLM/Manager/Impl/ExtCitizenInstanceManager.cs
@@ -452,18 +452,41 @@ namespace TrafficManager.Manager.Impl {
                     enableTransport,
                     ignoreCost);
 
-            } catch (Exception ex) {
+            }
+            catch (Exception ex) {
 
+                // make sure we have copy of exception in TMPE.log
                 Log.Info(ex.ToString());
 
                 switch (pathFindAdHocDebug) {
+
                     case TernaryBool.False:
                         break;
+
                     case TernaryBool.Undefined:
                         pathFindAdHocDebug = TernaryBool.True;
-                        break;
-                    case TernaryBool.True:
+
+                        try {
+                            // run the code again, this time with full debug logging
+                            InternalStartPathFind(
+                                instanceID,
+                                ref instanceData,
+                                ref extInstance,
+                                ref extCitizen,
+                                startPos,
+                                endPos,
+                                vehicleInfo,
+                                enableTransport,
+                                ignoreCost);
+                        }
+                        catch {
+                            // ignore
+                        }
+
                         pathFindAdHocDebug = TernaryBool.False;
+                        break;
+
+                    default:
                         break;
                 }
 

--- a/TLM/TLM/Manager/Impl/ExtCitizenInstanceManager.cs
+++ b/TLM/TLM/Manager/Impl/ExtCitizenInstanceManager.cs
@@ -963,10 +963,17 @@ namespace TrafficManager.Manager.Impl {
              */
             if (extVehicleType == ExtVehicleType.PassengerCar ||
                 extVehicleType == ExtVehicleType.Bicycle) {
-                if (allowRandomParking && instanceData.m_targetBuilding != 0 &&
-                    (buildingsBuffer[instanceData.m_targetBuilding].Info.m_class.m_service
-                     > ItemClass.Service.Office
-                     || (instanceData.m_flags & CitizenInstance.Flags.TargetIsNode) != 0)) {
+
+                if (allowRandomParking
+                    && instanceData.m_targetBuilding != 0
+                    && buildingsBuffer[instanceData.m_targetBuilding].Info
+                    && (
+                        buildingsBuffer[instanceData.m_targetBuilding].Info.m_class.m_service > ItemClass.Service.Office
+                        || (instanceData.m_flags & CitizenInstance.Flags.TargetIsNode) != 0
+                       )
+                    )
+                {
+
                     randomParking = true;
                 }
             }

--- a/TLM/TLM/Manager/Impl/ExtCitizenInstanceManager.cs
+++ b/TLM/TLM/Manager/Impl/ExtCitizenInstanceManager.cs
@@ -556,7 +556,7 @@ namespace TrafficManager.Manager.Impl {
                                 // Parked vehicle not present but citizen wants to reach it
                                 // -> Reset path mode
                                 if (logParkingAi) {
-                                    Log._Debug(
+                                    Log.Info(
                                         $"CustomCitizenAI.ExtStartPathFind({instanceID}): Citizen " +
                                         $"has CurrentPathMode={extInstance.pathMode} but no parked " +
                                         "vehicle present. Change to 'None'.");
@@ -567,7 +567,7 @@ namespace TrafficManager.Manager.Impl {
                                 // Parked vehicle is present and citizen wants to reach it
                                 // -> Prohibit car usage
                                 if (extendedLogParkingAi) {
-                                    Log._Debug(
+                                    Log.Info(
                                         $"CustomCitizenAI.ExtStartPathFind({instanceID}): Citizen " +
                                         $"has CurrentPathMode={extInstance.pathMode}.  Change to " +
                                         "'CalculatingWalkingPathToParkedCar'.");
@@ -587,7 +587,7 @@ namespace TrafficManager.Manager.Impl {
                             // Citizen walks to target
                             // -> Reset path mode
                             if (extendedLogParkingAi) {
-                                Log._Debug(
+                                Log.Info(
                                     $"CustomCitizenAI.ExtStartPathFind({instanceID}): Citizen " +
                                     $"has CurrentPathMode={extInstance.pathMode}. Change to " +
                                     "'CalculatingWalkingPathToTarget'.");
@@ -610,7 +610,7 @@ namespace TrafficManager.Manager.Impl {
                                 // Citizen wants to drive to target but parked vehicle is not present
                                 // -> Reset path mode
                                 if (logParkingAi) {
-                                    Log._Debug(
+                                    Log.Info(
                                         $"CustomCitizenAI.ExtStartPathFind({instanceID}): " +
                                         $"Citizen has CurrentPathMode={extInstance.pathMode} but " +
                                         "no parked vehicle present. Change to 'None'.");
@@ -621,7 +621,7 @@ namespace TrafficManager.Manager.Impl {
                                 // Citizen wants to drive to target and parked vehicle is present
                                 // -> Force parked car usage
                                 if (extendedLogParkingAi) {
-                                    Log._Debug(
+                                    Log.Info(
                                         $"CustomCitizenAI.ExtStartPathFind({instanceID}): " +
                                         $"Citizen has CurrentPathMode={extInstance.pathMode}.  " +
                                         "Change to 'RequiresCarPath'.");
@@ -638,7 +638,7 @@ namespace TrafficManager.Manager.Impl {
 
                         default: {
                             if (logParkingAi) {
-                                Log._Debug(
+                                Log.Info(
                                     $"CustomCitizenAI.ExtStartPathFind({instanceID}): Citizen has " +
                                     $"CurrentPathMode={extInstance.pathMode}. Change to 'None'.");
                             }
@@ -663,7 +663,7 @@ namespace TrafficManager.Manager.Impl {
                             // Citizen is on a walking tour or is a mascot
                             // -> Prohibit car usage
                             if (logParkingAi) {
-                                Log._Debug(
+                                Log.Info(
                                     $"CustomCitizenAI.ExtStartPathFind({instanceID}): Citizen ignores " +
                                     $"cost ({ignoreCost}) or is on a walking tour ({isOnTour}): Setting " +
                                     "path mode to 'CalculatingWalkingPathToTarget'");
@@ -687,7 +687,7 @@ namespace TrafficManager.Manager.Impl {
                                             // Citizen is located at a road outside connection and can spawn a car
                                             // -> Force car usage
                                             if (logParkingAi) {
-                                                Log._Debug(
+                                                Log.Info(
                                                     $"CustomCitizenAI.ExtStartPathFind({instanceID}): " +
                                                     "Citizen is located at a road outside connection: " +
                                                     "Setting path mode to 'RequiresCarPath' and carUsageMode " +
@@ -701,7 +701,7 @@ namespace TrafficManager.Manager.Impl {
                                             // cannot spawn a car
                                             // -> Path-finding fails
                                             if (logParkingAi) {
-                                                Log._Debug(
+                                                Log.Info(
                                                     $"CustomCitizenAI.ExtStartPathFind({instanceID}): " +
                                                     "Citizen is located at a road outside connection but " +
                                                     "does not have a car template: ABORTING PATH-FINDING");
@@ -714,7 +714,7 @@ namespace TrafficManager.Manager.Impl {
                                         // Citizen is located at a non-road outside connection
                                         // -> Prohibit car usage
                                         if (logParkingAi) {
-                                            Log._Debug(
+                                            Log.Info(
                                                 $"CustomCitizenAI.ExtStartPathFind({instanceID}): " +
                                                 "Citizen is located at a non-road outside connection: " +
                                                 "Setting path mode to 'CalculatingWalkingPathToTarget'");
@@ -750,7 +750,7 @@ namespace TrafficManager.Manager.Impl {
                                 carUsageMode = CarUsagePolicy.Forbidden;
 
                                 if (extendedLogParkingAi) {
-                                    Log._Debug(
+                                    Log.Info(
                                         $"CustomCitizenAI.ExtStartPathFind({instanceID}): Citizen used " +
                                         "their car before and is not at home. Forcing to walk to parked car.");
                                 }
@@ -769,7 +769,7 @@ namespace TrafficManager.Manager.Impl {
                                     carUsageMode = CarUsagePolicy.Forbidden;
 
                                     if (extendedLogParkingAi) {
-                                        Log._Debug(
+                                        Log.Info(
                                             $"CustomCitizenAI.ExtStartPathFind({instanceID}): Citizen " +
                                             "wants to go home and parked car is too far away " +
                                             $"({distHomeToParked}). Forcing walking to parked car.");
@@ -801,7 +801,7 @@ namespace TrafficManager.Manager.Impl {
                             // -> end position is parked car
                             endPos = parkedVehiclesBuffer[parkedVehicleId].m_position;
                             if (extendedLogParkingAi) {
-                                Log._Debug(
+                                Log.Info(
                                     $"CustomCitizenAI.ExtStartPathFind({instanceID}): Citizen shall " +
                                     $"go to parked vehicle @ {endPos}");
                             }
@@ -810,10 +810,11 @@ namespace TrafficManager.Manager.Impl {
                 } // if Options.ParkingAi
             } // end benchmark
 
-            Log._DebugIf(
-                extendedLogParkingAi,
-                () => $"CustomCitizenAI.ExtStartPathFind({instanceID}): Citizen is allowed to " +
-                $"drive their car? {carUsageMode}");
+            if (extendedLogParkingAi) {
+                Log.Info(
+                    $"CustomCitizenAI.ExtStartPathFind({instanceID}): Citizen is allowed to " +
+                    $"drive their car? {carUsageMode}");
+            }
 
             // NON-STOCK CODE END
             //------------------------------------------------------------------
@@ -888,7 +889,7 @@ namespace TrafficManager.Manager.Impl {
                     // Parking AI
                     if (extInstance.pathMode == ExtPathMode.RequiresCarPath) {
                         if (logParkingAi) {
-                            Log._Debug(
+                            Log.Info(
                                 $"CustomCitizenAI.ExtStartPathFind({instanceID}): Setting " +
                                 $"startPos={startPos} for citizen instance {instanceID}. " +
                                 $"CurrentDepartureMode={extInstance.pathMode}");
@@ -901,7 +902,7 @@ namespace TrafficManager.Manager.Impl {
                             // connection
                             // -> find a suitable parking space near the target
                             if (logParkingAi) {
-                                Log._Debug(
+                                Log.Info(
                                     $"CustomCitizenAI.ExtStartPathFind({instanceID}): Finding parking " +
                                     $"space at target for citizen instance {instanceID}. " +
                                     $"CurrentDepartureMode={extInstance.pathMode} parkedVehicleId={parkedVehicleId}");
@@ -932,7 +933,7 @@ namespace TrafficManager.Manager.Impl {
                                 // find a direct path to the calculated parking position
                                 allowRandomParking = false;
                                 if (logParkingAi) {
-                                    Log._Debug(
+                                    Log.Info(
                                         $"CustomCitizenAI.ExtStartPathFind({instanceID}): Finding " +
                                         $"known parking space for citizen instance {instanceID}, parked " +
                                         $"vehicle {parkedVehicleId} succeeded and return path " +
@@ -957,7 +958,7 @@ namespace TrafficManager.Manager.Impl {
                             // no known parking space found (pathMode has not been updated in the block above)
                             // -> calculate direct path to target
                             if (logParkingAi) {
-                                Log._Debug(
+                                Log.Info(
                                     $"CustomCitizenAI.ExtStartPathFind({instanceID}): Citizen instance " +
                                     $"{instanceID} is still at CurrentPathMode={extInstance.pathMode} " +
                                     "(no parking space found?). Setting it to CalculatingCarPath. " +
@@ -1021,7 +1022,7 @@ namespace TrafficManager.Manager.Impl {
                 CitizenInstance.Flags.None;
 
             if (logParkingAi) {
-                Log._Debug($"CustomCitizenAI.ExtStartPathFind({instanceID}): Requesting path-finding " +
+                Log.Info($"CustomCitizenAI.ExtStartPathFind({instanceID}): Requesting path-finding " +
                            $"for citizen instance {instanceID}, citizen {instanceData.m_citizen}, " +
                            $"extVehicleType={extVehicleType}, extPathType={extPathType}, startPos={startPos}, " +
                            $"endPos={endPos}, sourceBuilding={instanceData.m_sourceBuilding}, " +
@@ -1099,7 +1100,7 @@ namespace TrafficManager.Manager.Impl {
                         // -> add public transport demand for source building
                         if (instanceData.m_sourceBuilding != 0) {
                             if (logParkingAi) {
-                                Log._Debug(
+                                Log.Info(
                                     $"CustomCitizenAI.ExtStartPathFind({instanceID}): Citizen instance " +
                                     $"{instanceID} cannot uses public transport from building " +
                                     $"{instanceData.m_sourceBuilding} to {instanceData.m_targetBuilding}. " +
@@ -1159,7 +1160,7 @@ namespace TrafficManager.Manager.Impl {
                 // NON-STOCK CODE END
                 if (res) {
                     if (logParkingAi) {
-                        Log._DebugFormat(
+                        Log.InfoFormat(
                             "CustomCitizenAI.ExtStartPathFind({0}): Path-finding starts for citizen " +
                             "instance {1}, path={2}, extVehicleType={3}, extPathType={4}, " +
                             "startPosA.segment={5}, startPosA.lane={6}, laneType={7}, vehicleType={8}, " +
@@ -1181,23 +1182,21 @@ namespace TrafficManager.Manager.Impl {
                 }
             }
 
+            if (logParkingAi && Options.parkingAI) {
+                Log.InfoFormat(
+                    "CustomCitizenAI.ExtStartPathFind({0}): CustomCitizenAI.CustomStartPathFind: " +
+                    "[PFFAIL] failed for citizen instance {1} (CurrentPathMode={2}). " +
+                    "startPosA.segment={3}, startPosA.lane={4}, startPosA.offset={5}, " +
+                    "endPosA.segment={6}, endPosA.lane={7}, endPosA.offset={8}, " +
+                    "foundStartPos={9}, foundEndPos={10}",
+                    instanceID, instanceID, extInstance.pathMode, startPosA.m_segment,
+                    startPosA.m_lane, startPosA.m_offset, endPosA.m_segment, endPosA.m_lane,
+                    endPosA.m_offset, foundStartPos, foundEndPos);
 #if DEBUG
-            if (Options.parkingAI) {
-                if (logParkingAi) {
-                    Log._DebugFormat(
-                        "CustomCitizenAI.ExtStartPathFind({0}): CustomCitizenAI.CustomStartPathFind: " +
-                        "[PFFAIL] failed for citizen instance {1} (CurrentPathMode={2}). " +
-                        "startPosA.segment={3}, startPosA.lane={4}, startPosA.offset={5}, " +
-                        "endPosA.segment={6}, endPosA.lane={7}, endPosA.offset={8}, " +
-                        "foundStartPos={9}, foundEndPos={10}",
-                        instanceID, instanceID, extInstance.pathMode, startPosA.m_segment,
-                        startPosA.m_lane, startPosA.m_offset, endPosA.m_segment, endPosA.m_lane,
-                        endPosA.m_offset, foundStartPos, foundEndPos);
-                }
-
                 Reset(ref extInstance);
-            }
 #endif
+            }
+
             return false;
         }
 

--- a/TLM/TLM/Manager/Impl/ExtCitizenInstanceManager.cs
+++ b/TLM/TLM/Manager/Impl/ExtCitizenInstanceManager.cs
@@ -455,39 +455,32 @@ namespace TrafficManager.Manager.Impl {
             }
             catch (Exception ex) {
 
-                // make sure we have copy of exception in TMPE.log
-                Log.Info(ex.ToString());
+                if (pathFindAdHocDebug == TernaryBool.Undefined) {
+                    // make sure we have copy of exception in TMPE.log
+                    Log.Info(ex.ToString());
 
-                switch (pathFindAdHocDebug) {
+                    // enable debug logging
+                    pathFindAdHocDebug = TernaryBool.True;
 
-                    case TernaryBool.False:
-                        break;
+                    // run the code again, this time with full debug logging
+                    try {
+                        InternalStartPathFind(
+                            instanceID,
+                            ref instanceData,
+                            ref extInstance,
+                            ref extCitizen,
+                            startPos,
+                            endPos,
+                            vehicleInfo,
+                            enableTransport,
+                            ignoreCost);
+                    }
+                    catch {
+                        // ignore
+                    }
 
-                    case TernaryBool.Undefined:
-                        pathFindAdHocDebug = TernaryBool.True;
-
-                        try {
-                            // run the code again, this time with full debug logging
-                            InternalStartPathFind(
-                                instanceID,
-                                ref instanceData,
-                                ref extInstance,
-                                ref extCitizen,
-                                startPos,
-                                endPos,
-                                vehicleInfo,
-                                enableTransport,
-                                ignoreCost);
-                        }
-                        catch {
-                            // ignore
-                        }
-
-                        pathFindAdHocDebug = TernaryBool.False;
-                        break;
-
-                    default:
-                        break;
+                    // prevent future logging
+                    pathFindAdHocDebug = TernaryBool.False;
                 }
 
                 throw;
@@ -528,7 +521,7 @@ namespace TrafficManager.Manager.Impl {
 #endif
 
             if (logParkingAi) {
-                Log.Warning(
+                Log.Info(
                     $"CustomCitizenAI.ExtStartPathFind({instanceID}): called for citizen " +
                     $"{instanceData.m_citizen}, startPos={startPos}, endPos={endPos}, " +
                     $"sourceBuilding={instanceData.m_sourceBuilding}, " +


### PR DESCRIPTION
Fixes #840

If an exception occurs in `StartPathFind()` we don't get much information in the logs to help us determine what specifically caused it.

This commit tries to remedy that by intercepting the exception, then repeating the `StartPathFind()` only this time with full debug logging. The original exception is then rethrown.

The only performance overheads during normal operation should be:

* Adding a token to the stack for the `try .. catch`
* An additional method call, that will likely be inlined by the jitter
* Setting two bools `true|false` on each invocation (previously they were `const` and `false` in `RELEASE` builds.)
* A bunch of conditional checks (eg. `if (logParkingAi) { ... }`), one for each log call
    * Due to branching in `InternalStartPathFind()` only a few will be encountered.
    * I assume branch predication will quickly optimise things for nromal operation

Hopefully the performance impacts will be negligible, but that remains to be tested.

This PR is result of by Nijamods (ninjanoobslayer) issue report in https://github.com/CitiesSkylinesMods/TMPE/issues/825#issuecomment-612538582 and subsequent log files in https://github.com/CitiesSkylinesMods/TMPE/issues/825#issuecomment-612545514 . I've sent a build of TMPE with this modification to Ninja to test so we should know if it works with followup in #825.