### PR TITLE
Decruft citizen status

### DIFF
--- a/TLM/TLM/Manager/Impl/ExtCitizenInstanceManager.cs
+++ b/TLM/TLM/Manager/Impl/ExtCitizenInstanceManager.cs
@@ -256,43 +256,44 @@ namespace TrafficManager.Manager.Impl {
                 isStudent = (citizen.m_flags & Citizen.Flags.Student) != 0;
             }
 
-            if (targetIsNode) {
-                if (vehicleId != 0) {
-                    VehicleManager vehManager = Singleton<VehicleManager>.instance;
-                    VehicleInfo vehicleInfo = vehManager.m_vehicles.m_buffer[vehicleId].Info;
+            if (vehicleId != 0 && targetIsNode) {
+                VehicleManager vehManager = Singleton<VehicleManager>.instance;
+                VehicleInfo vehicleInfo = vehManager.m_vehicles.m_buffer[vehicleId].Info;
 
-                    switch (vehicleInfo.m_class.m_service) {
+                switch (vehicleInfo.m_class.m_service) {
 
-                        case ItemClass.Service.Residential
-                            when vehicleInfo.m_vehicleType != VehicleInfo.VehicleType.Bicycle &&
-                                 IsVehicleOwnedByCitizen(ref vehManager.m_vehicles.m_buffer[vehicleId], citizenId):
+                    case ItemClass.Service.Residential
+                        when vehicleInfo.m_vehicleType != VehicleInfo.VehicleType.Bicycle &&
+                             IsVehicleOwnedByCitizen(ref vehManager.m_vehicles.m_buffer[vehicleId], citizenId):
 
+                        target.NetNode = targetBuildingId;
+                        mayAddCustomStatus = true;
+                        return Locale.Get("CITIZEN_STATUS_DRIVINGTO");
+
+                    case ItemClass.Service.PublicTransport:
+                    case ItemClass.Service.Disaster: {
+
+                        ushort transportLine = Singleton<NetManager>
+                                               .instance.m_nodes.m_buffer[targetBuildingId]
+                                               .m_transportLine;
+                        if ((data.m_flags & CitizenInstance.Flags.WaitingTaxi) != 0) {
+                            mayAddCustomStatus = true;
+                            return Locale.Get("CITIZEN_STATUS_WAITING_TAXI");
+                        }
+
+                        if (vehManager.m_vehicles.m_buffer[vehicleId].m_transportLine !=
+                            transportLine) {
                             target.NetNode = targetBuildingId;
                             mayAddCustomStatus = true;
-                            return Locale.Get("CITIZEN_STATUS_DRIVINGTO");
-
-                        case ItemClass.Service.PublicTransport:
-                        case ItemClass.Service.Disaster: {
-
-                            ushort transportLine = Singleton<NetManager>
-                                                   .instance.m_nodes.m_buffer[targetBuildingId]
-                                                   .m_transportLine;
-                            if ((data.m_flags & CitizenInstance.Flags.WaitingTaxi) != 0) {
-                                mayAddCustomStatus = true;
-                                return Locale.Get("CITIZEN_STATUS_WAITING_TAXI");
-                            }
-
-                            if (vehManager.m_vehicles.m_buffer[vehicleId].m_transportLine !=
-                                transportLine) {
-                                target.NetNode = targetBuildingId;
-                                mayAddCustomStatus = true;
-                                return Locale.Get("CITIZEN_STATUS_TRAVELLINGTO");
-                            }
-
-                            break;
+                            return Locale.Get("CITIZEN_STATUS_TRAVELLINGTO");
                         }
+
+                        break;
                     }
                 }
+            }
+
+            if (targetIsNode) {
 
                 if ((data.m_flags & CitizenInstance.Flags.OnTour) != 0) {
                     target.NetNode = targetBuildingId;

--- a/TLM/TLM/Manager/Impl/ExtCitizenInstanceManager.cs
+++ b/TLM/TLM/Manager/Impl/ExtCitizenInstanceManager.cs
@@ -135,6 +135,7 @@ namespace TrafficManager.Manager.Impl {
             }
 
             if (vehicleId != 0) {
+
                 Vehicle vehicle = Singleton<VehicleManager>.instance.m_vehicles.m_buffer[vehicleId];
                 VehicleInfo info = vehicle.Info;
 
@@ -257,14 +258,15 @@ namespace TrafficManager.Manager.Impl {
             }
 
             if (vehicleId != 0 && targetIsNode) {
-                VehicleManager vehManager = Singleton<VehicleManager>.instance;
-                VehicleInfo vehicleInfo = vehManager.m_vehicles.m_buffer[vehicleId].Info;
 
-                switch (vehicleInfo.m_class.m_service) {
+                Vehicle vehicle = Singleton<VehicleManager>.instance.m_vehicles.m_buffer[vehicleId];
+                VehicleInfo info = vehicle.Info;
+
+                switch (info.m_class.m_service) {
 
                     case ItemClass.Service.Residential
-                        when vehicleInfo.m_vehicleType != VehicleInfo.VehicleType.Bicycle &&
-                             IsVehicleOwnedByCitizen(ref vehManager.m_vehicles.m_buffer[vehicleId], citizenId):
+                        when info.m_vehicleType != VehicleInfo.VehicleType.Bicycle &&
+                             IsVehicleOwnedByCitizen(ref vehicle, citizenId):
 
                         target.NetNode = targetBuildingId;
                         mayAddCustomStatus = true;
@@ -281,8 +283,7 @@ namespace TrafficManager.Manager.Impl {
                             return Locale.Get("CITIZEN_STATUS_WAITING_TAXI");
                         }
 
-                        if (vehManager.m_vehicles.m_buffer[vehicleId].m_transportLine !=
-                            transportLine) {
+                        if (vehicle.m_transportLine != transportLine) {
                             target.NetNode = targetBuildingId;
                             mayAddCustomStatus = true;
                             return Locale.Get("CITIZEN_STATUS_TRAVELLINGTO");

--- a/TLM/TLM/Manager/Impl/ExtCitizenInstanceManager.cs
+++ b/TLM/TLM/Manager/Impl/ExtCitizenInstanceManager.cs
@@ -84,7 +84,7 @@ namespace TrafficManager.Manager.Impl {
         /// <param name="citizenId">The citizen.</param>
         /// 
         /// <returns>Returns <c>true</c> if the vehicle is owned by the citizen, otherwise <c>false</c>.</returns>
-        internal bool IsVehicleOwnedByCitizen(Vehicle vehicle, uint citizenId) {
+        internal bool IsVehicleOwnedByCitizen(ref Vehicle vehicle, uint citizenId) {
             InstanceID id = InstanceID.Empty;
             id.Building = vehicle.m_sourceBuilding;
             return id.Citizen == citizenId;
@@ -132,7 +132,7 @@ namespace TrafficManager.Manager.Impl {
 
                     case ItemClass.Service.Residential
                         when info.m_vehicleType != VehicleInfo.VehicleType.Bicycle
-                             && IsVehicleOwnedByCitizen(vehicle, citizenId): {
+                             && IsVehicleOwnedByCitizen(ref vehicle, citizenId): {
 
                         if (targetIsNode) {
                             target.NetNode = targetBuildingId;
@@ -259,7 +259,7 @@ namespace TrafficManager.Manager.Impl {
 
                         case ItemClass.Service.Residential
                             when vehicleInfo.m_vehicleType != VehicleInfo.VehicleType.Bicycle &&
-                                 IsVehicleOwnedByCitizen(vehManager.m_vehicles.m_buffer[vehicleId], citizenId):
+                                 IsVehicleOwnedByCitizen(ref vehManager.m_vehicles.m_buffer[vehicleId], citizenId):
 
                             target.NetNode = targetBuildingId;
                             mayAddCustomStatus = true;
@@ -311,7 +311,7 @@ namespace TrafficManager.Manager.Impl {
 
                     case ItemClass.Service.Residential
                         when vehicleInfo.m_vehicleType != VehicleInfo.VehicleType.Bicycle &&
-                             IsVehicleOwnedByCitizen(vehicleMan.m_vehicles.m_buffer[vehicleId], citizenId): {
+                             IsVehicleOwnedByCitizen(ref vehicleMan.m_vehicles.m_buffer[vehicleId], citizenId): {
 
                         if (IsOutsideConnection(targetBuildingId)) {
                             mayAddCustomStatus = true;

--- a/TLM/TLM/Manager/Impl/ExtCitizenInstanceManager.cs
+++ b/TLM/TLM/Manager/Impl/ExtCitizenInstanceManager.cs
@@ -65,6 +65,20 @@ namespace TrafficManager.Manager.Impl {
         }
 
         /// <summary>
+        /// Check if a vehicle is owned by a certain citizen.
+        /// </summary>
+        /// 
+        /// <param name="vehicle">The vehicle.</param>
+        /// <param name="citizenId">The citizen.</param>
+        /// 
+        /// <returns>Returns <c>true</c> if the vehicle is owned by the citizen, otherwise <c>false</c>.</returns>
+        internal bool IsVehicleOwnedByCitizen(Vehicle vehicle, uint citizenId) {
+            InstanceID id = InstanceID.Empty;
+            id.Building = vehicle.m_sourceBuilding;
+            return id.Citizen == citizenId;
+        }
+
+        /// <summary>
         /// Check if a citizen is caught in a flood, tsunami or tornado.
         /// </summary>
         /// 
@@ -101,9 +115,7 @@ namespace TrafficManager.Manager.Impl {
                     VehicleInfo info = vehManager.m_vehicles.m_buffer[vehicleId].Info;
                     if (info.m_class.m_service == ItemClass.Service.Residential &&
                         info.m_vehicleType != VehicleInfo.VehicleType.Bicycle) {
-                        if (info.m_vehicleAI.GetOwnerID(
-                                vehicleId,
-                                ref vehManager.m_vehicles.m_buffer[vehicleId]).Citizen == citizenId) {
+                        if (IsVehicleOwnedByCitizen(vehManager.m_vehicles.m_buffer[vehicleId], citizenId)) {
                             target.NetNode = targetBuildingId;
                             mayAddCustomStatus = true;
                             return Locale.Get("CITIZEN_STATUS_DRIVINGTO");
@@ -153,10 +165,7 @@ namespace TrafficManager.Manager.Impl {
                 switch (vehicleInfo.m_class.m_service) {
                     case ItemClass.Service.Residential
                         when vehicleInfo.m_vehicleType != VehicleInfo.VehicleType.Bicycle
-                             && vehicleInfo.m_vehicleAI.GetOwnerID(
-                                               vehicleId,
-                                               ref vehManager.m_vehicles.m_buffer[vehicleId])
-                                           .Citizen == citizenId: {
+                             && IsVehicleOwnedByCitizen(vehManager.m_vehicles.m_buffer[vehicleId], citizenId): {
                         if (isOutsideConnection) {
                             mayAddCustomStatus = true;
                             return Locale.Get("CITIZEN_STATUS_DRIVINGTO_OUTSIDE");
@@ -234,10 +243,7 @@ namespace TrafficManager.Manager.Impl {
                     switch (vehicleInfo.m_class.m_service) {
                         case ItemClass.Service.Residential
                             when vehicleInfo.m_vehicleType != VehicleInfo.VehicleType.Bicycle &&
-                                 vehicleInfo.m_vehicleAI.GetOwnerID(
-                                                vehicleId,
-                                                ref vehManager.m_vehicles.m_buffer[vehicleId])
-                                            .Citizen == citizenId:
+                                 IsVehicleOwnedByCitizen(vehManager.m_vehicles.m_buffer[vehicleId], citizenId):
                             target.NetNode = targetBuildingId;
                             mayAddCustomStatus = true;
                             return Locale.Get("CITIZEN_STATUS_DRIVINGTO");
@@ -288,10 +294,7 @@ namespace TrafficManager.Manager.Impl {
                 switch (vehicleInfo.m_class.m_service) {
                     case ItemClass.Service.Residential
                         when vehicleInfo.m_vehicleType != VehicleInfo.VehicleType.Bicycle &&
-                             vehicleInfo.m_vehicleAI.GetOwnerID(
-                                            vehicleId,
-                                            ref vehicleMan.m_vehicles.m_buffer[vehicleId])
-                                        .Citizen == citizenId: {
+                             IsVehicleOwnedByCitizen(vehicleMan.m_vehicles.m_buffer[vehicleId], citizenId): {
                         if (isOutsideConnection) {
                             mayAddCustomStatus = true;
                             return Locale.Get("CITIZEN_STATUS_DRIVINGTO_OUTSIDE");

--- a/TLM/TLM/Manager/Impl/ExtCitizenInstanceManager.cs
+++ b/TLM/TLM/Manager/Impl/ExtCitizenInstanceManager.cs
@@ -100,6 +100,16 @@ namespace TrafficManager.Manager.Impl {
         internal bool IsSweaptAway(ref CitizenInstance citizen) =>
             (citizen.m_flags & (CitizenInstance.Flags.Blown | CitizenInstance.Flags.Floating)) != 0;
 
+        /// <summary>
+        /// Check if a citizen is loitering at their current location.
+        /// </summary>
+        /// 
+        /// <param name="citizen">The citizen to inspect.</param>
+        /// 
+        /// <returns>Returns <c>true</c> if hanging around, otherwise <c>false</c>.</returns>
+        internal bool IsHangingAround(ref CitizenInstance citizen) =>
+            citizen.m_path == 0u && (citizen.m_flags & CitizenInstance.Flags.HangAround) != 0;
+
         public string GetTouristLocalizedStatus(ushort instanceID,
                                                 ref CitizenInstance data,
                                                 out bool mayAddCustomStatus,
@@ -203,11 +213,7 @@ namespace TrafficManager.Manager.Impl {
                 return Locale.Get("CITIZEN_STATUS_GOINGTO_OUTSIDE");
             }
 
-            bool hangsAround = data.m_path == 0u &&
-                               (data.m_flags & CitizenInstance.Flags.HangAround) !=
-                               CitizenInstance.Flags.None;
-
-            if (hangsAround) {
+            if (IsHangingAround(ref data)) {
                 target.Building = targetBuildingId;
                 mayAddCustomStatus = false;
                 return Locale.Get("CITIZEN_STATUS_VISITING");
@@ -299,10 +305,6 @@ namespace TrafficManager.Manager.Impl {
                 return Locale.Get("CITIZEN_STATUS_GOINGTO");
             }
 
-            bool hangsAround = data.m_path == 0u &&
-                               (data.m_flags & CitizenInstance.Flags.HangAround) !=
-                               CitizenInstance.Flags.None;
-
             if (vehicleId != 0) {
                 VehicleManager vehicleMan = Singleton<VehicleManager>.instance;
                 VehicleInfo vehicleInfo = vehicleMan.m_vehicles.m_buffer[vehicleId].Info;
@@ -375,7 +377,7 @@ namespace TrafficManager.Manager.Impl {
             }
 
             if (targetBuildingId == homeId) {
-                if (hangsAround) {
+                if (IsHangingAround(ref data)) {
                     mayAddCustomStatus = false;
                     return Locale.Get("CITIZEN_STATUS_AT_HOME");
                 }
@@ -385,7 +387,7 @@ namespace TrafficManager.Manager.Impl {
             }
 
             if (targetBuildingId == workId) {
-                if (hangsAround) {
+                if (IsHangingAround(ref data)) {
                     mayAddCustomStatus = false;
                     return Locale.Get(
                         (!isStudent) ? "CITIZEN_STATUS_AT_WORK" : "CITIZEN_STATUS_AT_SCHOOL");
@@ -396,7 +398,7 @@ namespace TrafficManager.Manager.Impl {
                     (!isStudent) ? "CITIZEN_STATUS_GOINGTO_WORK" : "CITIZEN_STATUS_GOINGTO_SCHOOL");
             }
 
-            if (hangsAround) {
+            if (IsHangingAround(ref data)) {
                 target.Building = targetBuildingId;
                 mayAddCustomStatus = false;
                 return Locale.Get("CITIZEN_STATUS_VISITING");

--- a/TLM/TLM/Manager/Impl/ExtCitizenInstanceManager.cs
+++ b/TLM/TLM/Manager/Impl/ExtCitizenInstanceManager.cs
@@ -83,11 +83,12 @@ namespace TrafficManager.Manager.Impl {
                 return Locale.Get("CITIZEN_STATUS_CONFUSED");
             }
 
-            CitizenManager instance = Singleton<CitizenManager>.instance;
             uint citizenId = data.m_citizen;
             ushort vehicleId = 0;
+
             if (citizenId != 0u) {
-                vehicleId = instance.m_citizens.m_buffer[citizenId].m_vehicle;
+                Citizen citizen = Singleton<CitizenManager>.instance.m_citizens.m_buffer[citizenId];
+                vehicleId = citizen.m_vehicle;
             }
 
             if ((data.m_flags & CitizenInstance.Flags.TargetIsNode) != 0) {
@@ -212,20 +213,19 @@ namespace TrafficManager.Manager.Impl {
                 return Locale.Get("CITIZEN_STATUS_CONFUSED");
             }
 
-            CitizenManager citMan = Singleton<CitizenManager>.instance;
             uint citizenId = data.m_citizen;
+            Citizen citizen;
             var isStudent = false;
             ushort homeId = 0;
             ushort workId = 0;
             ushort vehicleId = 0;
 
             if (citizenId != 0u) {
-                homeId = citMan.m_citizens.m_buffer[citizenId].m_homeBuilding;
-                workId = citMan.m_citizens.m_buffer[citizenId].m_workBuilding;
-                vehicleId = citMan.m_citizens.m_buffer[citizenId].m_vehicle;
-                isStudent =
-                    (citMan.m_citizens.m_buffer[citizenId].m_flags & Citizen.Flags.Student) !=
-                     Citizen.Flags.None;
+                citizen = Singleton<CitizenManager>.instance.m_citizens.m_buffer[citizenId];
+                homeId = citizen.m_homeBuilding;
+                workId = citizen.m_workBuilding;
+                vehicleId = citizen.m_vehicle;
+                isStudent = (citizen.m_flags & Citizen.Flags.Student) != 0;
             }
 
             if ((data.m_flags & CitizenInstance.Flags.TargetIsNode) != CitizenInstance.Flags.None) {

--- a/TLM/TLM/Manager/Impl/ExtCitizenInstanceManager.cs
+++ b/TLM/TLM/Manager/Impl/ExtCitizenInstanceManager.cs
@@ -116,12 +116,15 @@ namespace TrafficManager.Manager.Impl {
             uint citizenId = data.m_citizen;
             ushort vehicleId = 0;
 
+            // if true, it means the targetBuildingId is actually a node, not a building
+            bool targetIsNode = (data.m_flags & CitizenInstance.Flags.TargetIsNode) != 0;
+
             if (citizenId != 0u) {
                 Citizen citizen = Singleton<CitizenManager>.instance.m_citizens.m_buffer[citizenId];
                 vehicleId = citizen.m_vehicle;
             }
 
-            if ((data.m_flags & CitizenInstance.Flags.TargetIsNode) != 0) {
+            if (targetIsNode) {
                 if (vehicleId != 0) {
                     VehicleManager vehManager = Singleton<VehicleManager>.instance;
                     VehicleInfo info = vehManager.m_vehicles.m_buffer[vehicleId].Info;
@@ -235,6 +238,9 @@ namespace TrafficManager.Manager.Impl {
             ushort workId = 0;
             ushort vehicleId = 0;
 
+            // if true, it means the targetBuildingId is actually a node, not a building
+            bool targetIsNode = (data.m_flags & CitizenInstance.Flags.TargetIsNode) != 0;
+
             if (citizenId != 0u) {
                 citizen = Singleton<CitizenManager>.instance.m_citizens.m_buffer[citizenId];
                 homeId = citizen.m_homeBuilding;
@@ -243,7 +249,7 @@ namespace TrafficManager.Manager.Impl {
                 isStudent = (citizen.m_flags & Citizen.Flags.Student) != 0;
             }
 
-            if ((data.m_flags & CitizenInstance.Flags.TargetIsNode) != CitizenInstance.Flags.None) {
+            if (targetIsNode) {
                 if (vehicleId != 0) {
                     VehicleManager vehManager = Singleton<VehicleManager>.instance;
                     VehicleInfo vehicleInfo = vehManager.m_vehicles.m_buffer[vehicleId].Info;

--- a/TLM/TLM/Manager/Impl/ExtCitizenInstanceManager.cs
+++ b/TLM/TLM/Manager/Impl/ExtCitizenInstanceManager.cs
@@ -59,7 +59,7 @@ namespace TrafficManager.Manager.Impl {
         }
 
         /// <summary>
-        /// Generates the localized status for a tourist.
+        /// Generates the localized status for a tourist, which is displayed on <c>TouristWorldInfoPanel</c>.
         /// </summary>
         /// 
         /// <param name="instanceID">Citizen instance id.</param>
@@ -172,7 +172,7 @@ namespace TrafficManager.Manager.Impl {
         }
 
         /// <summary>
-        /// Generates the localized status for a resident.
+        /// Generates the localized status for a resident, which is displayed on <c>CitizenWorldInfoPanel</c>.
         /// </summary>
         /// 
         /// <param name="instanceID">Citizen instance id.</param>

--- a/TLM/TLM/Manager/Impl/ExtCitizenInstanceManager.cs
+++ b/TLM/TLM/Manager/Impl/ExtCitizenInstanceManager.cs
@@ -257,7 +257,7 @@ namespace TrafficManager.Manager.Impl {
                 isStudent = (citizen.m_flags & Citizen.Flags.Student) != 0;
             }
 
-            if (vehicleId != 0 && targetIsNode) {
+            if (vehicleId != 0) {
 
                 Vehicle vehicle = Singleton<VehicleManager>.instance.m_vehicles.m_buffer[vehicleId];
                 VehicleInfo info = vehicle.Info;
@@ -268,25 +268,33 @@ namespace TrafficManager.Manager.Impl {
                         when info.m_vehicleType != VehicleInfo.VehicleType.Bicycle &&
                              IsVehicleOwnedByCitizen(ref vehicle, citizenId):
 
-                        target.NetNode = targetBuildingId;
-                        mayAddCustomStatus = true;
-                        return Locale.Get("CITIZEN_STATUS_DRIVINGTO");
+                        if (targetIsNode) {
+                            target.NetNode = targetBuildingId;
+                            mayAddCustomStatus = true;
+                            return Locale.Get("CITIZEN_STATUS_DRIVINGTO");
+                        }
+
+                        break;
 
                     case ItemClass.Service.PublicTransport:
                     case ItemClass.Service.Disaster: {
 
-                        ushort transportLine = Singleton<NetManager>
-                                               .instance.m_nodes.m_buffer[targetBuildingId]
-                                               .m_transportLine;
-                        if ((data.m_flags & CitizenInstance.Flags.WaitingTaxi) != 0) {
-                            mayAddCustomStatus = true;
-                            return Locale.Get("CITIZEN_STATUS_WAITING_TAXI");
-                        }
+                        if (targetIsNode) {
 
-                        if (vehicle.m_transportLine != transportLine) {
-                            target.NetNode = targetBuildingId;
-                            mayAddCustomStatus = true;
-                            return Locale.Get("CITIZEN_STATUS_TRAVELLINGTO");
+                            if ((data.m_flags & CitizenInstance.Flags.WaitingTaxi) != 0) {
+                                mayAddCustomStatus = true;
+                                return Locale.Get("CITIZEN_STATUS_WAITING_TAXI");
+                            }
+
+                            ushort transportLine = Singleton<NetManager>
+                                                   .instance.m_nodes.m_buffer[targetBuildingId]
+                                                   .m_transportLine;
+
+                            if (vehicle.m_transportLine != transportLine) {
+                                target.NetNode = targetBuildingId;
+                                mayAddCustomStatus = true;
+                                return Locale.Get("CITIZEN_STATUS_TRAVELLINGTO");
+                            }
                         }
 
                         break;

--- a/TLM/TLM/Manager/Impl/ExtCitizenInstanceManager.cs
+++ b/TLM/TLM/Manager/Impl/ExtCitizenInstanceManager.cs
@@ -128,28 +128,37 @@ namespace TrafficManager.Manager.Impl {
                 if (vehicleId != 0) {
                     VehicleManager vehManager = Singleton<VehicleManager>.instance;
                     VehicleInfo info = vehManager.m_vehicles.m_buffer[vehicleId].Info;
-                    if (info.m_class.m_service == ItemClass.Service.Residential &&
-                        info.m_vehicleType != VehicleInfo.VehicleType.Bicycle) {
-                        if (IsVehicleOwnedByCitizen(vehManager.m_vehicles.m_buffer[vehicleId], citizenId)) {
+
+                    switch (info.m_class.m_service) {
+
+                        case ItemClass.Service.Residential
+                            when info.m_vehicleType != VehicleInfo.VehicleType.Bicycle
+                                 && IsVehicleOwnedByCitizen(vehManager.m_vehicles.m_buffer[vehicleId], citizenId): {
+
                             target.NetNode = targetBuildingId;
                             mayAddCustomStatus = true;
                             return Locale.Get("CITIZEN_STATUS_DRIVINGTO");
                         }
-                    } else if (info.m_class.m_service == ItemClass.Service.PublicTransport ||
-                               info.m_class.m_service == ItemClass.Service.Disaster) {
-                        ushort transportLine = Singleton<NetManager>
+
+                        case ItemClass.Service.PublicTransport:
+                        case ItemClass.Service.Disaster: {
+
+                            ushort transportLine = Singleton<NetManager>
                                                .instance.m_nodes.m_buffer[targetBuildingId]
                                                .m_transportLine;
-                        if ((data.m_flags & CitizenInstance.Flags.WaitingTaxi) != 0) {
-                            mayAddCustomStatus = true;
-                            return Locale.Get("CITIZEN_STATUS_WAITING_TAXI");
-                        }
+                            if ((data.m_flags & CitizenInstance.Flags.WaitingTaxi) != 0) {
+                                mayAddCustomStatus = true;
+                                return Locale.Get("CITIZEN_STATUS_WAITING_TAXI");
+                            }
 
-                        if (vehManager.m_vehicles.m_buffer[vehicleId].m_transportLine !=
-                            transportLine) {
-                            target.NetNode = targetBuildingId;
-                            mayAddCustomStatus = true;
-                            return Locale.Get("CITIZEN_STATUS_TRAVELLINGTO");
+                            if (vehManager.m_vehicles.m_buffer[vehicleId].m_transportLine !=
+                                transportLine) {
+                                target.NetNode = targetBuildingId;
+                                mayAddCustomStatus = true;
+                                return Locale.Get("CITIZEN_STATUS_TRAVELLINGTO");
+                            }
+
+                            break;
                         }
                     }
                 }
@@ -174,9 +183,11 @@ namespace TrafficManager.Manager.Impl {
                 VehicleInfo vehicleInfo = vehManager.m_vehicles.m_buffer[vehicleId].Info;
 
                 switch (vehicleInfo.m_class.m_service) {
+
                     case ItemClass.Service.Residential
                         when vehicleInfo.m_vehicleType != VehicleInfo.VehicleType.Bicycle
                              && IsVehicleOwnedByCitizen(vehManager.m_vehicles.m_buffer[vehicleId], citizenId): {
+
                         if (IsOutsideConnection(targetBuildingId)) {
                             mayAddCustomStatus = true;
                             return Locale.Get("CITIZEN_STATUS_DRIVINGTO_OUTSIDE");
@@ -189,6 +200,7 @@ namespace TrafficManager.Manager.Impl {
 
                     case ItemClass.Service.PublicTransport:
                     case ItemClass.Service.Disaster: {
+
                         if (IsOutsideConnection(targetBuildingId)) {
                             mayAddCustomStatus = true;
                             return Locale.Get("CITIZEN_STATUS_TRAVELLINGTO_OUTSIDE");
@@ -255,14 +267,18 @@ namespace TrafficManager.Manager.Impl {
                     VehicleInfo vehicleInfo = vehManager.m_vehicles.m_buffer[vehicleId].Info;
 
                     switch (vehicleInfo.m_class.m_service) {
+
                         case ItemClass.Service.Residential
                             when vehicleInfo.m_vehicleType != VehicleInfo.VehicleType.Bicycle &&
                                  IsVehicleOwnedByCitizen(vehManager.m_vehicles.m_buffer[vehicleId], citizenId):
+
                             target.NetNode = targetBuildingId;
                             mayAddCustomStatus = true;
                             return Locale.Get("CITIZEN_STATUS_DRIVINGTO");
+
                         case ItemClass.Service.PublicTransport:
                         case ItemClass.Service.Disaster: {
+
                             ushort transportLine = Singleton<NetManager>
                                                    .instance.m_nodes.m_buffer[targetBuildingId]
                                                    .m_transportLine;
@@ -303,9 +319,11 @@ namespace TrafficManager.Manager.Impl {
                 VehicleInfo vehicleInfo = vehicleMan.m_vehicles.m_buffer[vehicleId].Info;
 
                 switch (vehicleInfo.m_class.m_service) {
+
                     case ItemClass.Service.Residential
                         when vehicleInfo.m_vehicleType != VehicleInfo.VehicleType.Bicycle &&
                              IsVehicleOwnedByCitizen(vehicleMan.m_vehicles.m_buffer[vehicleId], citizenId): {
+
                         if (IsOutsideConnection(targetBuildingId)) {
                             mayAddCustomStatus = true;
                             return Locale.Get("CITIZEN_STATUS_DRIVINGTO_OUTSIDE");
@@ -331,6 +349,7 @@ namespace TrafficManager.Manager.Impl {
 
                     case ItemClass.Service.PublicTransport:
                     case ItemClass.Service.Disaster: {
+
                         if ((data.m_flags & CitizenInstance.Flags.WaitingTaxi) != CitizenInstance.Flags.None) {
                             mayAddCustomStatus = true;
                             return Locale.Get("CITIZEN_STATUS_WAITING_TAXI");

--- a/TLM/TLM/Manager/Impl/ExtCitizenInstanceManager.cs
+++ b/TLM/TLM/Manager/Impl/ExtCitizenInstanceManager.cs
@@ -114,6 +114,7 @@ namespace TrafficManager.Manager.Impl {
                                                 ref CitizenInstance data,
                                                 out bool mayAddCustomStatus,
                                                 out InstanceID target) {
+            mayAddCustomStatus = true;
             target = InstanceID.Empty;
 
             ushort targetBuildingId = data.m_targetBuilding;
@@ -147,17 +148,14 @@ namespace TrafficManager.Manager.Impl {
 
                         if (targetIsNode) {
                             target.NetNode = targetBuildingId;
-                            mayAddCustomStatus = true;
                             return Locale.Get("CITIZEN_STATUS_DRIVINGTO");
                         }
 
                         if (IsOutsideConnection(targetBuildingId)) {
-                            mayAddCustomStatus = true;
                             return Locale.Get("CITIZEN_STATUS_DRIVINGTO_OUTSIDE");
                         }
 
                         target.Building = targetBuildingId;
-                        mayAddCustomStatus = true;
                         return Locale.Get("CITIZEN_STATUS_DRIVINGTO");
                     }
 
@@ -167,7 +165,6 @@ namespace TrafficManager.Manager.Impl {
                         if (targetIsNode) {
 
                             if ((data.m_flags & CitizenInstance.Flags.WaitingTaxi) != 0) {
-                                mayAddCustomStatus = true;
                                 return Locale.Get("CITIZEN_STATUS_WAITING_TAXI");
                             }
 
@@ -177,7 +174,6 @@ namespace TrafficManager.Manager.Impl {
 
                             if (vehicle.m_transportLine != transportLine) {
                                 target.NetNode = targetBuildingId;
-                                mayAddCustomStatus = true;
                                 return Locale.Get("CITIZEN_STATUS_TRAVELLINGTO");
                             }
 
@@ -185,12 +181,10 @@ namespace TrafficManager.Manager.Impl {
                         }
 
                         if (IsOutsideConnection(targetBuildingId)) {
-                            mayAddCustomStatus = true;
                             return Locale.Get("CITIZEN_STATUS_TRAVELLINGTO_OUTSIDE");
                         }
 
                         target.Building = targetBuildingId;
-                        mayAddCustomStatus = true;
                         return Locale.Get("CITIZEN_STATUS_TRAVELLINGTO");
                     }
                 }
@@ -200,17 +194,14 @@ namespace TrafficManager.Manager.Impl {
  
                 if ((data.m_flags & CitizenInstance.Flags.OnTour) != 0) {
                     target.NetNode = targetBuildingId;
-                    mayAddCustomStatus = true;
                     return Locale.Get("CITIZEN_STATUS_VISITING");
                 }
 
                 target.NetNode = targetBuildingId;
-                mayAddCustomStatus = true;
                 return Locale.Get("CITIZEN_STATUS_GOINGTO");
             }
 
             if (IsOutsideConnection(targetBuildingId)) {
-                mayAddCustomStatus = true;
                 return Locale.Get("CITIZEN_STATUS_GOINGTO_OUTSIDE");
             }
 
@@ -221,7 +212,6 @@ namespace TrafficManager.Manager.Impl {
             }
 
             target.Building = targetBuildingId;
-            mayAddCustomStatus = true;
             return Locale.Get("CITIZEN_STATUS_GOINGTO");
         }
 
@@ -230,6 +220,7 @@ namespace TrafficManager.Manager.Impl {
                                                  out bool mayAddCustomStatus,
                                                  out InstanceID target) {
 
+            mayAddCustomStatus = true;
             target = InstanceID.Empty;
 
             ushort targetBuildingId = data.m_targetBuilding;
@@ -268,8 +259,6 @@ namespace TrafficManager.Manager.Impl {
                         when info.m_vehicleType != VehicleInfo.VehicleType.Bicycle &&
                              IsVehicleOwnedByCitizen(ref vehicle, citizenId):
 
-                        mayAddCustomStatus = true;
-
                         if (targetIsNode) {
                             target.NetNode = targetBuildingId;
                             return Locale.Get("CITIZEN_STATUS_DRIVINGTO");
@@ -299,7 +288,6 @@ namespace TrafficManager.Manager.Impl {
                         if (targetIsNode) {
 
                             if ((data.m_flags & CitizenInstance.Flags.WaitingTaxi) != 0) {
-                                mayAddCustomStatus = true;
                                 return Locale.Get("CITIZEN_STATUS_WAITING_TAXI");
                             }
 
@@ -309,7 +297,6 @@ namespace TrafficManager.Manager.Impl {
 
                             if (vehicle.m_transportLine != transportLine) {
                                 target.NetNode = targetBuildingId;
-                                mayAddCustomStatus = true;
                                 return Locale.Get("CITIZEN_STATUS_TRAVELLINGTO");
                             }
 
@@ -317,22 +304,18 @@ namespace TrafficManager.Manager.Impl {
                         }
 
                         if ((data.m_flags & CitizenInstance.Flags.WaitingTaxi) != CitizenInstance.Flags.None) {
-                            mayAddCustomStatus = true;
                             return Locale.Get("CITIZEN_STATUS_WAITING_TAXI");
                         }
 
                         if (IsOutsideConnection(targetBuildingId)) {
-                            mayAddCustomStatus = true;
                             return Locale.Get("CITIZEN_STATUS_TRAVELLINGTO_OUTSIDE");
                         }
 
                         if (targetBuildingId == homeId) {
-                            mayAddCustomStatus = true;
                             return Locale.Get("CITIZEN_STATUS_TRAVELLINGTO_HOME");
                         }
 
                         if (targetBuildingId == workId) {
-                            mayAddCustomStatus = true;
                             return Locale.Get(
                                 (!isStudent)
                                     ? "CITIZEN_STATUS_TRAVELLINGTO_WORK"
@@ -340,7 +323,6 @@ namespace TrafficManager.Manager.Impl {
                         }
 
                         target.Building = targetBuildingId;
-                        mayAddCustomStatus = true;
                         return Locale.Get("CITIZEN_STATUS_TRAVELLINGTO");                    }
                 }
             }
@@ -349,17 +331,14 @@ namespace TrafficManager.Manager.Impl {
 
                 if ((data.m_flags & CitizenInstance.Flags.OnTour) != 0) {
                     target.NetNode = targetBuildingId;
-                    mayAddCustomStatus = true;
                     return Locale.Get("CITIZEN_STATUS_VISITING");
                 }
 
                 target.NetNode = targetBuildingId;
-                mayAddCustomStatus = true;
                 return Locale.Get("CITIZEN_STATUS_GOINGTO");
             }
 
             if (IsOutsideConnection(targetBuildingId)) {
-                mayAddCustomStatus = true;
                 return Locale.Get("CITIZEN_STATUS_GOINGTO_OUTSIDE");
             }
 
@@ -369,7 +348,6 @@ namespace TrafficManager.Manager.Impl {
                     return Locale.Get("CITIZEN_STATUS_AT_HOME");
                 }
 
-                mayAddCustomStatus = true;
                 return Locale.Get("CITIZEN_STATUS_GOINGTO_HOME");
             }
 
@@ -380,7 +358,6 @@ namespace TrafficManager.Manager.Impl {
                         (!isStudent) ? "CITIZEN_STATUS_AT_WORK" : "CITIZEN_STATUS_AT_SCHOOL");
                 }
 
-                mayAddCustomStatus = true;
                 return Locale.Get(
                     (!isStudent) ? "CITIZEN_STATUS_GOINGTO_WORK" : "CITIZEN_STATUS_GOINGTO_SCHOOL");
             }
@@ -392,7 +369,6 @@ namespace TrafficManager.Manager.Impl {
             }
 
             target.Building = targetBuildingId;
-            mayAddCustomStatus = true;
             return Locale.Get("CITIZEN_STATUS_GOINGTO");
         }
 

--- a/TLM/TLM/Manager/Impl/ExtCitizenInstanceManager.cs
+++ b/TLM/TLM/Manager/Impl/ExtCitizenInstanceManager.cs
@@ -124,45 +124,46 @@ namespace TrafficManager.Manager.Impl {
                 vehicleId = citizen.m_vehicle;
             }
 
-            if (targetIsNode) {
-                if (vehicleId != 0) {
-                    VehicleManager vehManager = Singleton<VehicleManager>.instance;
-                    VehicleInfo info = vehManager.m_vehicles.m_buffer[vehicleId].Info;
+            if (vehicleId != 0 && targetIsNode) {
+                VehicleManager vehManager = Singleton<VehicleManager>.instance;
+                VehicleInfo info = vehManager.m_vehicles.m_buffer[vehicleId].Info;
 
-                    switch (info.m_class.m_service) {
+                switch (info.m_class.m_service) {
 
-                        case ItemClass.Service.Residential
-                            when info.m_vehicleType != VehicleInfo.VehicleType.Bicycle
-                                 && IsVehicleOwnedByCitizen(vehManager.m_vehicles.m_buffer[vehicleId], citizenId): {
+                    case ItemClass.Service.Residential
+                        when info.m_vehicleType != VehicleInfo.VehicleType.Bicycle
+                             && IsVehicleOwnedByCitizen(vehManager.m_vehicles.m_buffer[vehicleId], citizenId): {
 
+                        target.NetNode = targetBuildingId;
+                        mayAddCustomStatus = true;
+                        return Locale.Get("CITIZEN_STATUS_DRIVINGTO");
+                    }
+
+                    case ItemClass.Service.PublicTransport:
+                    case ItemClass.Service.Disaster: {
+
+                        ushort transportLine = Singleton<NetManager>
+                                           .instance.m_nodes.m_buffer[targetBuildingId]
+                                           .m_transportLine;
+                        if ((data.m_flags & CitizenInstance.Flags.WaitingTaxi) != 0) {
+                            mayAddCustomStatus = true;
+                            return Locale.Get("CITIZEN_STATUS_WAITING_TAXI");
+                        }
+
+                        if (vehManager.m_vehicles.m_buffer[vehicleId].m_transportLine !=
+                            transportLine) {
                             target.NetNode = targetBuildingId;
                             mayAddCustomStatus = true;
-                            return Locale.Get("CITIZEN_STATUS_DRIVINGTO");
+                            return Locale.Get("CITIZEN_STATUS_TRAVELLINGTO");
                         }
 
-                        case ItemClass.Service.PublicTransport:
-                        case ItemClass.Service.Disaster: {
-
-                            ushort transportLine = Singleton<NetManager>
-                                               .instance.m_nodes.m_buffer[targetBuildingId]
-                                               .m_transportLine;
-                            if ((data.m_flags & CitizenInstance.Flags.WaitingTaxi) != 0) {
-                                mayAddCustomStatus = true;
-                                return Locale.Get("CITIZEN_STATUS_WAITING_TAXI");
-                            }
-
-                            if (vehManager.m_vehicles.m_buffer[vehicleId].m_transportLine !=
-                                transportLine) {
-                                target.NetNode = targetBuildingId;
-                                mayAddCustomStatus = true;
-                                return Locale.Get("CITIZEN_STATUS_TRAVELLINGTO");
-                            }
-
-                            break;
-                        }
+                        break;
                     }
                 }
+            }
 
+            if (targetIsNode) {
+ 
                 if ((data.m_flags & CitizenInstance.Flags.OnTour) != 0) {
                     target.NetNode = targetBuildingId;
                     mayAddCustomStatus = true;

--- a/TLM/TLM/Manager/Impl/ExtCitizenInstanceManager.cs
+++ b/TLM/TLM/Manager/Impl/ExtCitizenInstanceManager.cs
@@ -1,4 +1,4 @@
-﻿namespace TrafficManager.Manager.Impl {
+namespace TrafficManager.Manager.Impl {
     using ColossalFramework.Globalization;
     using ColossalFramework;
     using CSUtil.Commons.Benchmark;
@@ -68,10 +68,11 @@
                                                 ref CitizenInstance data,
                                                 out bool mayAddCustomStatus,
                                                 out InstanceID target) {
+            target = InstanceID.Empty;
+
             if ((data.m_flags & (CitizenInstance.Flags.Blown | CitizenInstance.Flags.Floating)) !=
                 CitizenInstance.Flags.None)
             {
-                target = InstanceID.Empty;
                 mayAddCustomStatus = false;
                 return Locale.Get("CITIZEN_STATUS_CONFUSED");
             }
@@ -85,7 +86,6 @@
 
             ushort targetBuilding = data.m_targetBuilding;
             if (targetBuilding == 0) {
-                target = InstanceID.Empty;
                 mayAddCustomStatus = false;
                 return Locale.Get("CITIZEN_STATUS_CONFUSED");
             }
@@ -99,7 +99,6 @@
                         if (info.m_vehicleAI.GetOwnerID(
                                 vehicleId,
                                 ref vehManager.m_vehicles.m_buffer[vehicleId]).Citizen == citizenId) {
-                            target = InstanceID.Empty;
                             target.NetNode = targetBuilding;
                             mayAddCustomStatus = true;
                             return Locale.Get("CITIZEN_STATUS_DRIVINGTO");
@@ -110,14 +109,12 @@
                                                .instance.m_nodes.m_buffer[targetBuilding]
                                                .m_transportLine;
                         if ((data.m_flags & CitizenInstance.Flags.WaitingTaxi) != 0) {
-                            target = InstanceID.Empty;
                             mayAddCustomStatus = true;
                             return Locale.Get("CITIZEN_STATUS_WAITING_TAXI");
                         }
 
                         if (vehManager.m_vehicles.m_buffer[vehicleId].m_transportLine !=
                             transportLine) {
-                            target = InstanceID.Empty;
                             target.NetNode = targetBuilding;
                             mayAddCustomStatus = true;
                             return Locale.Get("CITIZEN_STATUS_TRAVELLINGTO");
@@ -126,13 +123,11 @@
                 }
 
                 if ((data.m_flags & CitizenInstance.Flags.OnTour) != 0) {
-                    target = InstanceID.Empty;
                     target.NetNode = targetBuilding;
                     mayAddCustomStatus = true;
                     return Locale.Get("CITIZEN_STATUS_VISITING");
                 }
 
-                target = InstanceID.Empty;
                 target.NetNode = targetBuilding;
                 mayAddCustomStatus = true;
                 return Locale.Get("CITIZEN_STATUS_GOINGTO");
@@ -158,12 +153,10 @@
                                                ref vehManager.m_vehicles.m_buffer[vehicleId])
                                            .Citizen == citizenId: {
                         if (isOutsideConnection) {
-                            target = InstanceID.Empty;
                             mayAddCustomStatus = true;
                             return Locale.Get("CITIZEN_STATUS_DRIVINGTO_OUTSIDE");
                         }
 
-                        target = InstanceID.Empty;
                         target.Building = targetBuilding;
                         mayAddCustomStatus = true;
                         return Locale.Get("CITIZEN_STATUS_DRIVINGTO");
@@ -172,12 +165,10 @@
                     case ItemClass.Service.PublicTransport:
                     case ItemClass.Service.Disaster: {
                         if (isOutsideConnection) {
-                            target = InstanceID.Empty;
                             mayAddCustomStatus = true;
                             return Locale.Get("CITIZEN_STATUS_TRAVELLINGTO_OUTSIDE");
                         }
 
-                        target = InstanceID.Empty;
                         target.Building = targetBuilding;
                         mayAddCustomStatus = true;
                         return Locale.Get("CITIZEN_STATUS_TRAVELLINGTO");
@@ -186,19 +177,16 @@
             }
 
             if (isOutsideConnection) {
-                target = InstanceID.Empty;
                 mayAddCustomStatus = true;
                 return Locale.Get("CITIZEN_STATUS_GOINGTO_OUTSIDE");
             }
 
             if (hangsAround) {
-                target = InstanceID.Empty;
                 target.Building = targetBuilding;
                 mayAddCustomStatus = false;
                 return Locale.Get("CITIZEN_STATUS_VISITING");
             }
 
-            target = InstanceID.Empty;
             target.Building = targetBuilding;
             mayAddCustomStatus = true;
             return Locale.Get("CITIZEN_STATUS_GOINGTO");
@@ -208,10 +196,12 @@
                                                  ref CitizenInstance data,
                                                  out bool mayAddCustomStatus,
                                                  out InstanceID target) {
+
+            target = InstanceID.Empty;
+
             if ((data.m_flags & (CitizenInstance.Flags.Blown | CitizenInstance.Flags.Floating))
                 != CitizenInstance.Flags.None)
-            {
-                target = InstanceID.Empty;
+            {                
                 mayAddCustomStatus = false;
                 return Locale.Get("CITIZEN_STATUS_CONFUSED");
             }
@@ -234,7 +224,6 @@
 
             ushort targetBuilding = data.m_targetBuilding;
             if (targetBuilding == 0) {
-                target = InstanceID.Empty;
                 mayAddCustomStatus = false;
                 return Locale.Get("CITIZEN_STATUS_CONFUSED");
             }
@@ -251,7 +240,6 @@
                                                 vehicleId,
                                                 ref vehManager.m_vehicles.m_buffer[vehicleId])
                                             .Citizen == citizenId:
-                            target = InstanceID.Empty;
                             target.NetNode = targetBuilding;
                             mayAddCustomStatus = true;
                             return Locale.Get("CITIZEN_STATUS_DRIVINGTO");
@@ -261,14 +249,12 @@
                                                    .instance.m_nodes.m_buffer[targetBuilding]
                                                    .m_transportLine;
                             if ((data.m_flags & CitizenInstance.Flags.WaitingTaxi) != 0) {
-                                target = InstanceID.Empty;
                                 mayAddCustomStatus = true;
                                 return Locale.Get("CITIZEN_STATUS_WAITING_TAXI");
                             }
 
                             if (vehManager.m_vehicles.m_buffer[vehicleId].m_transportLine !=
                                 transportLine) {
-                                target = InstanceID.Empty;
                                 target.NetNode = targetBuilding;
                                 mayAddCustomStatus = true;
                                 return Locale.Get("CITIZEN_STATUS_TRAVELLINGTO");
@@ -280,13 +266,11 @@
                 }
 
                 if ((data.m_flags & CitizenInstance.Flags.OnTour) != 0) {
-                    target = InstanceID.Empty;
                     target.NetNode = targetBuilding;
                     mayAddCustomStatus = true;
                     return Locale.Get("CITIZEN_STATUS_VISITING");
                 }
 
-                target = InstanceID.Empty;
                 target.NetNode = targetBuilding;
                 mayAddCustomStatus = true;
                 return Locale.Get("CITIZEN_STATUS_GOINGTO");
@@ -311,19 +295,16 @@
                                             ref vehicleMan.m_vehicles.m_buffer[vehicleId])
                                         .Citizen == citizenId: {
                         if (isOutsideConnection) {
-                            target = InstanceID.Empty;
                             mayAddCustomStatus = true;
                             return Locale.Get("CITIZEN_STATUS_DRIVINGTO_OUTSIDE");
                         }
 
                         if (targetBuilding == homeId) {
-                            target = InstanceID.Empty;
                             mayAddCustomStatus = true;
                             return Locale.Get("CITIZEN_STATUS_DRIVINGTO_HOME");
                         }
 
                         if (targetBuilding == workId) {
-                            target = InstanceID.Empty;
                             mayAddCustomStatus = true;
                             return Locale.Get(
                                 (!isStudent)
@@ -331,7 +312,6 @@
                                     : "CITIZEN_STATUS_DRIVINGTO_SCHOOL");
                         }
 
-                        target = InstanceID.Empty;
                         target.Building = targetBuilding;
                         mayAddCustomStatus = true;
                         return Locale.Get("CITIZEN_STATUS_DRIVINGTO");
@@ -340,25 +320,21 @@
                     case ItemClass.Service.PublicTransport:
                     case ItemClass.Service.Disaster: {
                         if ((data.m_flags & CitizenInstance.Flags.WaitingTaxi) != CitizenInstance.Flags.None) {
-                            target = InstanceID.Empty;
                             mayAddCustomStatus = true;
                             return Locale.Get("CITIZEN_STATUS_WAITING_TAXI");
                         }
 
                         if (isOutsideConnection) {
-                            target = InstanceID.Empty;
                             mayAddCustomStatus = true;
                             return Locale.Get("CITIZEN_STATUS_TRAVELLINGTO_OUTSIDE");
                         }
 
                         if (targetBuilding == homeId) {
-                            target = InstanceID.Empty;
                             mayAddCustomStatus = true;
                             return Locale.Get("CITIZEN_STATUS_TRAVELLINGTO_HOME");
                         }
 
                         if (targetBuilding == workId) {
-                            target = InstanceID.Empty;
                             mayAddCustomStatus = true;
                             return Locale.Get(
                                 (!isStudent)
@@ -366,7 +342,6 @@
                                     : "CITIZEN_STATUS_TRAVELLINGTO_SCHOOL");
                         }
 
-                        target = InstanceID.Empty;
                         target.Building = targetBuilding;
                         mayAddCustomStatus = true;
                         return Locale.Get("CITIZEN_STATUS_TRAVELLINGTO");
@@ -375,45 +350,38 @@
             }
 
             if (isOutsideConnection) {
-                target = InstanceID.Empty;
                 mayAddCustomStatus = true;
                 return Locale.Get("CITIZEN_STATUS_GOINGTO_OUTSIDE");
             }
 
             if (targetBuilding == homeId) {
                 if (hangsAround) {
-                    target = InstanceID.Empty;
                     mayAddCustomStatus = false;
                     return Locale.Get("CITIZEN_STATUS_AT_HOME");
                 }
 
-                target = InstanceID.Empty;
                 mayAddCustomStatus = true;
                 return Locale.Get("CITIZEN_STATUS_GOINGTO_HOME");
             }
 
             if (targetBuilding == workId) {
                 if (hangsAround) {
-                    target = InstanceID.Empty;
                     mayAddCustomStatus = false;
                     return Locale.Get(
                         (!isStudent) ? "CITIZEN_STATUS_AT_WORK" : "CITIZEN_STATUS_AT_SCHOOL");
                 }
 
-                target = InstanceID.Empty;
                 mayAddCustomStatus = true;
                 return Locale.Get(
                     (!isStudent) ? "CITIZEN_STATUS_GOINGTO_WORK" : "CITIZEN_STATUS_GOINGTO_SCHOOL");
             }
 
             if (hangsAround) {
-                target = InstanceID.Empty;
                 target.Building = targetBuilding;
                 mayAddCustomStatus = false;
                 return Locale.Get("CITIZEN_STATUS_VISITING");
             }
 
-            target = InstanceID.Empty;
             target.Building = targetBuilding;
             mayAddCustomStatus = true;
             return Locale.Get("CITIZEN_STATUS_GOINGTO");

--- a/TLM/TLM/Manager/Impl/ExtCitizenInstanceManager.cs
+++ b/TLM/TLM/Manager/Impl/ExtCitizenInstanceManager.cs
@@ -77,8 +77,8 @@ namespace TrafficManager.Manager.Impl {
                 return Locale.Get("CITIZEN_STATUS_CONFUSED");
             }
 
-            ushort targetBuilding = data.m_targetBuilding;
-            if (targetBuilding == 0) {
+            ushort targetBuildingId = data.m_targetBuilding;
+            if (targetBuildingId == 0) {
                 mayAddCustomStatus = false;
                 return Locale.Get("CITIZEN_STATUS_CONFUSED");
             }
@@ -100,14 +100,14 @@ namespace TrafficManager.Manager.Impl {
                         if (info.m_vehicleAI.GetOwnerID(
                                 vehicleId,
                                 ref vehManager.m_vehicles.m_buffer[vehicleId]).Citizen == citizenId) {
-                            target.NetNode = targetBuilding;
+                            target.NetNode = targetBuildingId;
                             mayAddCustomStatus = true;
                             return Locale.Get("CITIZEN_STATUS_DRIVINGTO");
                         }
                     } else if (info.m_class.m_service == ItemClass.Service.PublicTransport ||
                                info.m_class.m_service == ItemClass.Service.Disaster) {
                         ushort transportLine = Singleton<NetManager>
-                                               .instance.m_nodes.m_buffer[targetBuilding]
+                                               .instance.m_nodes.m_buffer[targetBuildingId]
                                                .m_transportLine;
                         if ((data.m_flags & CitizenInstance.Flags.WaitingTaxi) != 0) {
                             mayAddCustomStatus = true;
@@ -116,7 +116,7 @@ namespace TrafficManager.Manager.Impl {
 
                         if (vehManager.m_vehicles.m_buffer[vehicleId].m_transportLine !=
                             transportLine) {
-                            target.NetNode = targetBuilding;
+                            target.NetNode = targetBuildingId;
                             mayAddCustomStatus = true;
                             return Locale.Get("CITIZEN_STATUS_TRAVELLINGTO");
                         }
@@ -124,19 +124,19 @@ namespace TrafficManager.Manager.Impl {
                 }
 
                 if ((data.m_flags & CitizenInstance.Flags.OnTour) != 0) {
-                    target.NetNode = targetBuilding;
+                    target.NetNode = targetBuildingId;
                     mayAddCustomStatus = true;
                     return Locale.Get("CITIZEN_STATUS_VISITING");
                 }
 
-                target.NetNode = targetBuilding;
+                target.NetNode = targetBuildingId;
                 mayAddCustomStatus = true;
                 return Locale.Get("CITIZEN_STATUS_GOINGTO");
             }
 
             bool isOutsideConnection =
                 (Singleton<BuildingManager>
-                 .instance.m_buildings.m_buffer[targetBuilding].m_flags &
+                 .instance.m_buildings.m_buffer[targetBuildingId].m_flags &
                  Building.Flags.IncomingOutgoing) != Building.Flags.None;
             bool hangsAround = data.m_path == 0u &&
                                (data.m_flags & CitizenInstance.Flags.HangAround) !=
@@ -158,7 +158,7 @@ namespace TrafficManager.Manager.Impl {
                             return Locale.Get("CITIZEN_STATUS_DRIVINGTO_OUTSIDE");
                         }
 
-                        target.Building = targetBuilding;
+                        target.Building = targetBuildingId;
                         mayAddCustomStatus = true;
                         return Locale.Get("CITIZEN_STATUS_DRIVINGTO");
                     }
@@ -170,7 +170,7 @@ namespace TrafficManager.Manager.Impl {
                             return Locale.Get("CITIZEN_STATUS_TRAVELLINGTO_OUTSIDE");
                         }
 
-                        target.Building = targetBuilding;
+                        target.Building = targetBuildingId;
                         mayAddCustomStatus = true;
                         return Locale.Get("CITIZEN_STATUS_TRAVELLINGTO");
                     }
@@ -183,12 +183,12 @@ namespace TrafficManager.Manager.Impl {
             }
 
             if (hangsAround) {
-                target.Building = targetBuilding;
+                target.Building = targetBuildingId;
                 mayAddCustomStatus = false;
                 return Locale.Get("CITIZEN_STATUS_VISITING");
             }
 
-            target.Building = targetBuilding;
+            target.Building = targetBuildingId;
             mayAddCustomStatus = true;
             return Locale.Get("CITIZEN_STATUS_GOINGTO");
         }
@@ -207,8 +207,8 @@ namespace TrafficManager.Manager.Impl {
                 return Locale.Get("CITIZEN_STATUS_CONFUSED");
             }
 
-            ushort targetBuilding = data.m_targetBuilding;
-            if (targetBuilding == 0) {
+            ushort targetBuildingId = data.m_targetBuilding;
+            if (targetBuildingId == 0) {
                 mayAddCustomStatus = false;
                 return Locale.Get("CITIZEN_STATUS_CONFUSED");
             }
@@ -240,13 +240,13 @@ namespace TrafficManager.Manager.Impl {
                                                 vehicleId,
                                                 ref vehManager.m_vehicles.m_buffer[vehicleId])
                                             .Citizen == citizenId:
-                            target.NetNode = targetBuilding;
+                            target.NetNode = targetBuildingId;
                             mayAddCustomStatus = true;
                             return Locale.Get("CITIZEN_STATUS_DRIVINGTO");
                         case ItemClass.Service.PublicTransport:
                         case ItemClass.Service.Disaster: {
                             ushort transportLine = Singleton<NetManager>
-                                                   .instance.m_nodes.m_buffer[targetBuilding]
+                                                   .instance.m_nodes.m_buffer[targetBuildingId]
                                                    .m_transportLine;
                             if ((data.m_flags & CitizenInstance.Flags.WaitingTaxi) != 0) {
                                 mayAddCustomStatus = true;
@@ -255,7 +255,7 @@ namespace TrafficManager.Manager.Impl {
 
                             if (vehManager.m_vehicles.m_buffer[vehicleId].m_transportLine !=
                                 transportLine) {
-                                target.NetNode = targetBuilding;
+                                target.NetNode = targetBuildingId;
                                 mayAddCustomStatus = true;
                                 return Locale.Get("CITIZEN_STATUS_TRAVELLINGTO");
                             }
@@ -266,18 +266,18 @@ namespace TrafficManager.Manager.Impl {
                 }
 
                 if ((data.m_flags & CitizenInstance.Flags.OnTour) != 0) {
-                    target.NetNode = targetBuilding;
+                    target.NetNode = targetBuildingId;
                     mayAddCustomStatus = true;
                     return Locale.Get("CITIZEN_STATUS_VISITING");
                 }
 
-                target.NetNode = targetBuilding;
+                target.NetNode = targetBuildingId;
                 mayAddCustomStatus = true;
                 return Locale.Get("CITIZEN_STATUS_GOINGTO");
             }
 
             bool isOutsideConnection =
-                (Singleton<BuildingManager>.instance.m_buildings.m_buffer[targetBuilding].m_flags &
+                (Singleton<BuildingManager>.instance.m_buildings.m_buffer[targetBuildingId].m_flags &
                  Building.Flags.IncomingOutgoing) != Building.Flags.None;
             bool hangsAround = data.m_path == 0u &&
                                (data.m_flags & CitizenInstance.Flags.HangAround) !=
@@ -299,12 +299,12 @@ namespace TrafficManager.Manager.Impl {
                             return Locale.Get("CITIZEN_STATUS_DRIVINGTO_OUTSIDE");
                         }
 
-                        if (targetBuilding == homeId) {
+                        if (targetBuildingId == homeId) {
                             mayAddCustomStatus = true;
                             return Locale.Get("CITIZEN_STATUS_DRIVINGTO_HOME");
                         }
 
-                        if (targetBuilding == workId) {
+                        if (targetBuildingId == workId) {
                             mayAddCustomStatus = true;
                             return Locale.Get(
                                 (!isStudent)
@@ -312,7 +312,7 @@ namespace TrafficManager.Manager.Impl {
                                     : "CITIZEN_STATUS_DRIVINGTO_SCHOOL");
                         }
 
-                        target.Building = targetBuilding;
+                        target.Building = targetBuildingId;
                         mayAddCustomStatus = true;
                         return Locale.Get("CITIZEN_STATUS_DRIVINGTO");
                     }
@@ -329,12 +329,12 @@ namespace TrafficManager.Manager.Impl {
                             return Locale.Get("CITIZEN_STATUS_TRAVELLINGTO_OUTSIDE");
                         }
 
-                        if (targetBuilding == homeId) {
+                        if (targetBuildingId == homeId) {
                             mayAddCustomStatus = true;
                             return Locale.Get("CITIZEN_STATUS_TRAVELLINGTO_HOME");
                         }
 
-                        if (targetBuilding == workId) {
+                        if (targetBuildingId == workId) {
                             mayAddCustomStatus = true;
                             return Locale.Get(
                                 (!isStudent)
@@ -342,7 +342,7 @@ namespace TrafficManager.Manager.Impl {
                                     : "CITIZEN_STATUS_TRAVELLINGTO_SCHOOL");
                         }
 
-                        target.Building = targetBuilding;
+                        target.Building = targetBuildingId;
                         mayAddCustomStatus = true;
                         return Locale.Get("CITIZEN_STATUS_TRAVELLINGTO");
                     }
@@ -354,7 +354,7 @@ namespace TrafficManager.Manager.Impl {
                 return Locale.Get("CITIZEN_STATUS_GOINGTO_OUTSIDE");
             }
 
-            if (targetBuilding == homeId) {
+            if (targetBuildingId == homeId) {
                 if (hangsAround) {
                     mayAddCustomStatus = false;
                     return Locale.Get("CITIZEN_STATUS_AT_HOME");
@@ -364,7 +364,7 @@ namespace TrafficManager.Manager.Impl {
                 return Locale.Get("CITIZEN_STATUS_GOINGTO_HOME");
             }
 
-            if (targetBuilding == workId) {
+            if (targetBuildingId == workId) {
                 if (hangsAround) {
                     mayAddCustomStatus = false;
                     return Locale.Get(
@@ -377,12 +377,12 @@ namespace TrafficManager.Manager.Impl {
             }
 
             if (hangsAround) {
-                target.Building = targetBuilding;
+                target.Building = targetBuildingId;
                 mayAddCustomStatus = false;
                 return Locale.Get("CITIZEN_STATUS_VISITING");
             }
 
-            target.Building = targetBuilding;
+            target.Building = targetBuildingId;
             mayAddCustomStatus = true;
             return Locale.Get("CITIZEN_STATUS_GOINGTO");
         }

--- a/TLM/TLM/Manager/Impl/ExtCitizenInstanceManager.cs
+++ b/TLM/TLM/Manager/Impl/ExtCitizenInstanceManager.cs
@@ -125,14 +125,14 @@ namespace TrafficManager.Manager.Impl {
             }
 
             if (vehicleId != 0 && targetIsNode) {
-                VehicleManager vehManager = Singleton<VehicleManager>.instance;
-                VehicleInfo info = vehManager.m_vehicles.m_buffer[vehicleId].Info;
+                Vehicle vehicle = Singleton<VehicleManager>.instance.m_vehicles.m_buffer[vehicleId];
+                VehicleInfo info = vehicle.Info;
 
                 switch (info.m_class.m_service) {
 
                     case ItemClass.Service.Residential
                         when info.m_vehicleType != VehicleInfo.VehicleType.Bicycle
-                             && IsVehicleOwnedByCitizen(vehManager.m_vehicles.m_buffer[vehicleId], citizenId): {
+                             && IsVehicleOwnedByCitizen(vehicle, citizenId): {
 
                         target.NetNode = targetBuildingId;
                         mayAddCustomStatus = true;
@@ -150,8 +150,7 @@ namespace TrafficManager.Manager.Impl {
                             return Locale.Get("CITIZEN_STATUS_WAITING_TAXI");
                         }
 
-                        if (vehManager.m_vehicles.m_buffer[vehicleId].m_transportLine !=
-                            transportLine) {
+                        if (vehicle.m_transportLine != transportLine) {
                             target.NetNode = targetBuildingId;
                             mayAddCustomStatus = true;
                             return Locale.Get("CITIZEN_STATUS_TRAVELLINGTO");

--- a/TLM/TLM/Manager/Impl/ExtCitizenInstanceManager.cs
+++ b/TLM/TLM/Manager/Impl/ExtCitizenInstanceManager.cs
@@ -65,6 +65,18 @@ namespace TrafficManager.Manager.Impl {
         }
 
         /// <summary>
+        /// Check if a building id refers to an outside connection.
+        /// </summary>
+        /// 
+        /// <param name="buildingId">The id of the building to check.</param>
+        /// 
+        /// <returns>Returns <c>true</c> if it's an outside connection, otherwise <c>false</c>.</returns>
+        internal bool IsOutsideConnection(ushort buildingId) {
+            Building building = Singleton<BuildingManager>.instance.m_buildings.m_buffer[buildingId];
+            return (building.m_flags & Building.Flags.IncomingOutgoing) != 0;
+        }
+
+        /// <summary>
         /// Check if a vehicle is owned by a certain citizen.
         /// </summary>
         /// 
@@ -150,10 +162,6 @@ namespace TrafficManager.Manager.Impl {
                 return Locale.Get("CITIZEN_STATUS_GOINGTO");
             }
 
-            bool isOutsideConnection =
-                (Singleton<BuildingManager>
-                 .instance.m_buildings.m_buffer[targetBuildingId].m_flags &
-                 Building.Flags.IncomingOutgoing) != Building.Flags.None;
             bool hangsAround = data.m_path == 0u &&
                                (data.m_flags & CitizenInstance.Flags.HangAround) !=
                                CitizenInstance.Flags.None;
@@ -166,7 +174,7 @@ namespace TrafficManager.Manager.Impl {
                     case ItemClass.Service.Residential
                         when vehicleInfo.m_vehicleType != VehicleInfo.VehicleType.Bicycle
                              && IsVehicleOwnedByCitizen(vehManager.m_vehicles.m_buffer[vehicleId], citizenId): {
-                        if (isOutsideConnection) {
+                        if (IsOutsideConnection(targetBuildingId)) {
                             mayAddCustomStatus = true;
                             return Locale.Get("CITIZEN_STATUS_DRIVINGTO_OUTSIDE");
                         }
@@ -178,7 +186,7 @@ namespace TrafficManager.Manager.Impl {
 
                     case ItemClass.Service.PublicTransport:
                     case ItemClass.Service.Disaster: {
-                        if (isOutsideConnection) {
+                        if (IsOutsideConnection(targetBuildingId)) {
                             mayAddCustomStatus = true;
                             return Locale.Get("CITIZEN_STATUS_TRAVELLINGTO_OUTSIDE");
                         }
@@ -190,7 +198,7 @@ namespace TrafficManager.Manager.Impl {
                 }
             }
 
-            if (isOutsideConnection) {
+            if (IsOutsideConnection(targetBuildingId)) {
                 mayAddCustomStatus = true;
                 return Locale.Get("CITIZEN_STATUS_GOINGTO_OUTSIDE");
             }
@@ -280,9 +288,6 @@ namespace TrafficManager.Manager.Impl {
                 return Locale.Get("CITIZEN_STATUS_GOINGTO");
             }
 
-            bool isOutsideConnection =
-                (Singleton<BuildingManager>.instance.m_buildings.m_buffer[targetBuildingId].m_flags &
-                 Building.Flags.IncomingOutgoing) != Building.Flags.None;
             bool hangsAround = data.m_path == 0u &&
                                (data.m_flags & CitizenInstance.Flags.HangAround) !=
                                CitizenInstance.Flags.None;
@@ -295,7 +300,7 @@ namespace TrafficManager.Manager.Impl {
                     case ItemClass.Service.Residential
                         when vehicleInfo.m_vehicleType != VehicleInfo.VehicleType.Bicycle &&
                              IsVehicleOwnedByCitizen(vehicleMan.m_vehicles.m_buffer[vehicleId], citizenId): {
-                        if (isOutsideConnection) {
+                        if (IsOutsideConnection(targetBuildingId)) {
                             mayAddCustomStatus = true;
                             return Locale.Get("CITIZEN_STATUS_DRIVINGTO_OUTSIDE");
                         }
@@ -325,7 +330,7 @@ namespace TrafficManager.Manager.Impl {
                             return Locale.Get("CITIZEN_STATUS_WAITING_TAXI");
                         }
 
-                        if (isOutsideConnection) {
+                        if (IsOutsideConnection(targetBuildingId)) {
                             mayAddCustomStatus = true;
                             return Locale.Get("CITIZEN_STATUS_TRAVELLINGTO_OUTSIDE");
                         }
@@ -350,7 +355,7 @@ namespace TrafficManager.Manager.Impl {
                 }
             }
 
-            if (isOutsideConnection) {
+            if (IsOutsideConnection(targetBuildingId)) {
                 mayAddCustomStatus = true;
                 return Locale.Get("CITIZEN_STATUS_GOINGTO_OUTSIDE");
             }

--- a/TLM/TLM/Manager/Impl/ExtCitizenInstanceManager.cs
+++ b/TLM/TLM/Manager/Impl/ExtCitizenInstanceManager.cs
@@ -287,7 +287,8 @@ namespace TrafficManager.Manager.Impl {
                         }
 
                         target.Building = targetBuildingId;
-                        return Locale.Get("CITIZEN_STATUS_TRAVELLINGTO");                    }
+                        return Locale.Get("CITIZEN_STATUS_TRAVELLINGTO");
+                }
             }
 
             if (targetIsNode) {

--- a/TLM/TLM/Manager/Impl/ExtCitizenInstanceManager.cs
+++ b/TLM/TLM/Manager/Impl/ExtCitizenInstanceManager.cs
@@ -77,17 +77,17 @@ namespace TrafficManager.Manager.Impl {
                 return Locale.Get("CITIZEN_STATUS_CONFUSED");
             }
 
+            ushort targetBuilding = data.m_targetBuilding;
+            if (targetBuilding == 0) {
+                mayAddCustomStatus = false;
+                return Locale.Get("CITIZEN_STATUS_CONFUSED");
+            }
+
             CitizenManager instance = Singleton<CitizenManager>.instance;
             uint citizenId = data.m_citizen;
             ushort vehicleId = 0;
             if (citizenId != 0u) {
                 vehicleId = instance.m_citizens.m_buffer[citizenId].m_vehicle;
-            }
-
-            ushort targetBuilding = data.m_targetBuilding;
-            if (targetBuilding == 0) {
-                mayAddCustomStatus = false;
-                return Locale.Get("CITIZEN_STATUS_CONFUSED");
             }
 
             if ((data.m_flags & CitizenInstance.Flags.TargetIsNode) != 0) {
@@ -206,6 +206,12 @@ namespace TrafficManager.Manager.Impl {
                 return Locale.Get("CITIZEN_STATUS_CONFUSED");
             }
 
+            ushort targetBuilding = data.m_targetBuilding;
+            if (targetBuilding == 0) {
+                mayAddCustomStatus = false;
+                return Locale.Get("CITIZEN_STATUS_CONFUSED");
+            }
+
             CitizenManager citMan = Singleton<CitizenManager>.instance;
             uint citizenId = data.m_citizen;
             var isStudent = false;
@@ -220,12 +226,6 @@ namespace TrafficManager.Manager.Impl {
                 isStudent =
                     (citMan.m_citizens.m_buffer[citizenId].m_flags & Citizen.Flags.Student) !=
                      Citizen.Flags.None;
-            }
-
-            ushort targetBuilding = data.m_targetBuilding;
-            if (targetBuilding == 0) {
-                mayAddCustomStatus = false;
-                return Locale.Get("CITIZEN_STATUS_CONFUSED");
             }
 
             if ((data.m_flags & CitizenInstance.Flags.TargetIsNode) != CitizenInstance.Flags.None) {

--- a/TLM/TLM/Manager/Impl/ExtCitizenInstanceManager.cs
+++ b/TLM/TLM/Manager/Impl/ExtCitizenInstanceManager.cs
@@ -268,13 +268,30 @@ namespace TrafficManager.Manager.Impl {
                         when info.m_vehicleType != VehicleInfo.VehicleType.Bicycle &&
                              IsVehicleOwnedByCitizen(ref vehicle, citizenId):
 
+                        mayAddCustomStatus = true;
+
                         if (targetIsNode) {
                             target.NetNode = targetBuildingId;
-                            mayAddCustomStatus = true;
                             return Locale.Get("CITIZEN_STATUS_DRIVINGTO");
                         }
 
-                        break;
+                        if (IsOutsideConnection(targetBuildingId)) {
+                            return Locale.Get("CITIZEN_STATUS_DRIVINGTO_OUTSIDE");
+                        }
+
+                        if (targetBuildingId == homeId) {
+                            return Locale.Get("CITIZEN_STATUS_DRIVINGTO_HOME");
+                        }
+
+                        if (targetBuildingId == workId) {
+                            return Locale.Get(
+                                (!isStudent)
+                                    ? "CITIZEN_STATUS_DRIVINGTO_WORK"
+                                    : "CITIZEN_STATUS_DRIVINGTO_SCHOOL");
+                        }
+
+                        target.Building = targetBuildingId;
+                        return Locale.Get("CITIZEN_STATUS_DRIVINGTO");
 
                     case ItemClass.Service.PublicTransport:
                     case ItemClass.Service.Disaster: {
@@ -295,61 +312,9 @@ namespace TrafficManager.Manager.Impl {
                                 mayAddCustomStatus = true;
                                 return Locale.Get("CITIZEN_STATUS_TRAVELLINGTO");
                             }
+
+                            break;
                         }
-
-                        break;
-                    }
-                }
-            }
-
-            if (targetIsNode) {
-
-                if ((data.m_flags & CitizenInstance.Flags.OnTour) != 0) {
-                    target.NetNode = targetBuildingId;
-                    mayAddCustomStatus = true;
-                    return Locale.Get("CITIZEN_STATUS_VISITING");
-                }
-
-                target.NetNode = targetBuildingId;
-                mayAddCustomStatus = true;
-                return Locale.Get("CITIZEN_STATUS_GOINGTO");
-            }
-
-            if (vehicleId != 0) {
-                VehicleManager vehicleMan = Singleton<VehicleManager>.instance;
-                VehicleInfo vehicleInfo = vehicleMan.m_vehicles.m_buffer[vehicleId].Info;
-
-                switch (vehicleInfo.m_class.m_service) {
-
-                    case ItemClass.Service.Residential
-                        when vehicleInfo.m_vehicleType != VehicleInfo.VehicleType.Bicycle &&
-                             IsVehicleOwnedByCitizen(ref vehicleMan.m_vehicles.m_buffer[vehicleId], citizenId): {
-
-                        if (IsOutsideConnection(targetBuildingId)) {
-                            mayAddCustomStatus = true;
-                            return Locale.Get("CITIZEN_STATUS_DRIVINGTO_OUTSIDE");
-                        }
-
-                        if (targetBuildingId == homeId) {
-                            mayAddCustomStatus = true;
-                            return Locale.Get("CITIZEN_STATUS_DRIVINGTO_HOME");
-                        }
-
-                        if (targetBuildingId == workId) {
-                            mayAddCustomStatus = true;
-                            return Locale.Get(
-                                (!isStudent)
-                                    ? "CITIZEN_STATUS_DRIVINGTO_WORK"
-                                    : "CITIZEN_STATUS_DRIVINGTO_SCHOOL");
-                        }
-
-                        target.Building = targetBuildingId;
-                        mayAddCustomStatus = true;
-                        return Locale.Get("CITIZEN_STATUS_DRIVINGTO");
-                    }
-
-                    case ItemClass.Service.PublicTransport:
-                    case ItemClass.Service.Disaster: {
 
                         if ((data.m_flags & CitizenInstance.Flags.WaitingTaxi) != CitizenInstance.Flags.None) {
                             mayAddCustomStatus = true;
@@ -376,9 +341,21 @@ namespace TrafficManager.Manager.Impl {
 
                         target.Building = targetBuildingId;
                         mayAddCustomStatus = true;
-                        return Locale.Get("CITIZEN_STATUS_TRAVELLINGTO");
-                    }
+                        return Locale.Get("CITIZEN_STATUS_TRAVELLINGTO");                    }
                 }
+            }
+
+            if (targetIsNode) {
+
+                if ((data.m_flags & CitizenInstance.Flags.OnTour) != 0) {
+                    target.NetNode = targetBuildingId;
+                    mayAddCustomStatus = true;
+                    return Locale.Get("CITIZEN_STATUS_VISITING");
+                }
+
+                target.NetNode = targetBuildingId;
+                mayAddCustomStatus = true;
+                return Locale.Get("CITIZEN_STATUS_GOINGTO");
             }
 
             if (IsOutsideConnection(targetBuildingId)) {

--- a/TLM/TLM/Manager/Impl/ExtCitizenInstanceManager.cs
+++ b/TLM/TLM/Manager/Impl/ExtCitizenInstanceManager.cs
@@ -124,7 +124,7 @@ namespace TrafficManager.Manager.Impl {
                 vehicleId = citizen.m_vehicle;
             }
 
-            if (vehicleId != 0 && targetIsNode) {
+            if (vehicleId != 0) {
                 Vehicle vehicle = Singleton<VehicleManager>.instance.m_vehicles.m_buffer[vehicleId];
                 VehicleInfo info = vehicle.Info;
 
@@ -134,26 +134,32 @@ namespace TrafficManager.Manager.Impl {
                         when info.m_vehicleType != VehicleInfo.VehicleType.Bicycle
                              && IsVehicleOwnedByCitizen(vehicle, citizenId): {
 
-                        target.NetNode = targetBuildingId;
-                        mayAddCustomStatus = true;
-                        return Locale.Get("CITIZEN_STATUS_DRIVINGTO");
+                        if (targetIsNode) {
+                            target.NetNode = targetBuildingId;
+                            mayAddCustomStatus = true;
+                            return Locale.Get("CITIZEN_STATUS_DRIVINGTO");
+                        }
+
+                        break;
                     }
 
                     case ItemClass.Service.PublicTransport:
                     case ItemClass.Service.Disaster: {
 
-                        ushort transportLine = Singleton<NetManager>
-                                           .instance.m_nodes.m_buffer[targetBuildingId]
-                                           .m_transportLine;
-                        if ((data.m_flags & CitizenInstance.Flags.WaitingTaxi) != 0) {
-                            mayAddCustomStatus = true;
-                            return Locale.Get("CITIZEN_STATUS_WAITING_TAXI");
-                        }
+                        if (targetIsNode) {
+                            ushort transportLine = Singleton<NetManager>
+                                               .instance.m_nodes.m_buffer[targetBuildingId]
+                                               .m_transportLine;
+                            if ((data.m_flags & CitizenInstance.Flags.WaitingTaxi) != 0) {
+                                mayAddCustomStatus = true;
+                                return Locale.Get("CITIZEN_STATUS_WAITING_TAXI");
+                            }
 
-                        if (vehicle.m_transportLine != transportLine) {
-                            target.NetNode = targetBuildingId;
-                            mayAddCustomStatus = true;
-                            return Locale.Get("CITIZEN_STATUS_TRAVELLINGTO");
+                            if (vehicle.m_transportLine != transportLine) {
+                                target.NetNode = targetBuildingId;
+                                mayAddCustomStatus = true;
+                                return Locale.Get("CITIZEN_STATUS_TRAVELLINGTO");
+                            }
                         }
 
                         break;

--- a/TLM/TLM/Manager/Impl/ExtCitizenInstanceManager.cs
+++ b/TLM/TLM/Manager/Impl/ExtCitizenInstanceManager.cs
@@ -140,29 +140,47 @@ namespace TrafficManager.Manager.Impl {
                             return Locale.Get("CITIZEN_STATUS_DRIVINGTO");
                         }
 
-                        break;
+                        if (IsOutsideConnection(targetBuildingId)) {
+                            mayAddCustomStatus = true;
+                            return Locale.Get("CITIZEN_STATUS_DRIVINGTO_OUTSIDE");
+                        }
+
+                        target.Building = targetBuildingId;
+                        mayAddCustomStatus = true;
+                        return Locale.Get("CITIZEN_STATUS_DRIVINGTO");
                     }
 
                     case ItemClass.Service.PublicTransport:
                     case ItemClass.Service.Disaster: {
 
                         if (targetIsNode) {
-                            ushort transportLine = Singleton<NetManager>
-                                               .instance.m_nodes.m_buffer[targetBuildingId]
-                                               .m_transportLine;
+
                             if ((data.m_flags & CitizenInstance.Flags.WaitingTaxi) != 0) {
                                 mayAddCustomStatus = true;
                                 return Locale.Get("CITIZEN_STATUS_WAITING_TAXI");
                             }
+
+                            ushort transportLine = Singleton<NetManager>
+                                               .instance.m_nodes.m_buffer[targetBuildingId]
+                                               .m_transportLine;
 
                             if (vehicle.m_transportLine != transportLine) {
                                 target.NetNode = targetBuildingId;
                                 mayAddCustomStatus = true;
                                 return Locale.Get("CITIZEN_STATUS_TRAVELLINGTO");
                             }
+
+                            break;
                         }
 
-                        break;
+                        if (IsOutsideConnection(targetBuildingId)) {
+                            mayAddCustomStatus = true;
+                            return Locale.Get("CITIZEN_STATUS_TRAVELLINGTO_OUTSIDE");
+                        }
+
+                        target.Building = targetBuildingId;
+                        mayAddCustomStatus = true;
+                        return Locale.Get("CITIZEN_STATUS_TRAVELLINGTO");
                     }
                 }
             }
@@ -180,49 +198,14 @@ namespace TrafficManager.Manager.Impl {
                 return Locale.Get("CITIZEN_STATUS_GOINGTO");
             }
 
-            bool hangsAround = data.m_path == 0u &&
-                               (data.m_flags & CitizenInstance.Flags.HangAround) !=
-                               CitizenInstance.Flags.None;
-
-            if (vehicleId != 0) {
-                VehicleManager vehManager = Singleton<VehicleManager>.instance;
-                VehicleInfo vehicleInfo = vehManager.m_vehicles.m_buffer[vehicleId].Info;
-
-                switch (vehicleInfo.m_class.m_service) {
-
-                    case ItemClass.Service.Residential
-                        when vehicleInfo.m_vehicleType != VehicleInfo.VehicleType.Bicycle
-                             && IsVehicleOwnedByCitizen(vehManager.m_vehicles.m_buffer[vehicleId], citizenId): {
-
-                        if (IsOutsideConnection(targetBuildingId)) {
-                            mayAddCustomStatus = true;
-                            return Locale.Get("CITIZEN_STATUS_DRIVINGTO_OUTSIDE");
-                        }
-
-                        target.Building = targetBuildingId;
-                        mayAddCustomStatus = true;
-                        return Locale.Get("CITIZEN_STATUS_DRIVINGTO");
-                    }
-
-                    case ItemClass.Service.PublicTransport:
-                    case ItemClass.Service.Disaster: {
-
-                        if (IsOutsideConnection(targetBuildingId)) {
-                            mayAddCustomStatus = true;
-                            return Locale.Get("CITIZEN_STATUS_TRAVELLINGTO_OUTSIDE");
-                        }
-
-                        target.Building = targetBuildingId;
-                        mayAddCustomStatus = true;
-                        return Locale.Get("CITIZEN_STATUS_TRAVELLINGTO");
-                    }
-                }
-            }
-
             if (IsOutsideConnection(targetBuildingId)) {
                 mayAddCustomStatus = true;
                 return Locale.Get("CITIZEN_STATUS_GOINGTO_OUTSIDE");
             }
+
+            bool hangsAround = data.m_path == 0u &&
+                               (data.m_flags & CitizenInstance.Flags.HangAround) !=
+                               CitizenInstance.Flags.None;
 
             if (hangsAround) {
                 target.Building = targetBuildingId;

--- a/TLM/TLM/Manager/Impl/ExtCitizenInstanceManager.cs
+++ b/TLM/TLM/Manager/Impl/ExtCitizenInstanceManager.cs
@@ -64,21 +64,25 @@ namespace TrafficManager.Manager.Impl {
             }
         }
 
+        /// <summary>
+        /// Check if a citizen is caught in a flood, tsunami or tornado.
+        /// </summary>
+        /// 
+        /// <param name="citizen">The citizen to inspect.</param>
+        /// 
+        /// <returns>Returns <c>true</c> if having a bad day, otherwise <c>false</c>.</returns>
+        internal bool IsSweaptAway(ref CitizenInstance citizen) =>
+            (citizen.m_flags & (CitizenInstance.Flags.Blown | CitizenInstance.Flags.Floating)) != 0;
+
         public string GetTouristLocalizedStatus(ushort instanceID,
                                                 ref CitizenInstance data,
                                                 out bool mayAddCustomStatus,
                                                 out InstanceID target) {
             target = InstanceID.Empty;
 
-            if ((data.m_flags & (CitizenInstance.Flags.Blown | CitizenInstance.Flags.Floating)) !=
-                CitizenInstance.Flags.None)
-            {
-                mayAddCustomStatus = false;
-                return Locale.Get("CITIZEN_STATUS_CONFUSED");
-            }
-
             ushort targetBuildingId = data.m_targetBuilding;
-            if (targetBuildingId == 0) {
+
+            if (IsSweaptAway(ref data) || targetBuildingId == 0) {
                 mayAddCustomStatus = false;
                 return Locale.Get("CITIZEN_STATUS_CONFUSED");
             }
@@ -200,15 +204,9 @@ namespace TrafficManager.Manager.Impl {
 
             target = InstanceID.Empty;
 
-            if ((data.m_flags & (CitizenInstance.Flags.Blown | CitizenInstance.Flags.Floating))
-                != CitizenInstance.Flags.None)
-            {                
-                mayAddCustomStatus = false;
-                return Locale.Get("CITIZEN_STATUS_CONFUSED");
-            }
-
             ushort targetBuildingId = data.m_targetBuilding;
-            if (targetBuildingId == 0) {
+
+            if (IsSweaptAway(ref data) || targetBuildingId == 0) {
                 mayAddCustomStatus = false;
                 return Locale.Get("CITIZEN_STATUS_CONFUSED");
             }


### PR DESCRIPTION
While looking at `ExtCitizenInstanceManager.cs` I noticed the methods that output localized citizen status (that gets shown on citizen world info panel) for residents and tourists was full of duplicate and extraneous code. This PR cleans it up - a lot.