### PR TITLE
Avoid null pointer exception in the UIScaler

### DIFF
--- a/TLM/TLM/U/UIScaler.cs
+++ b/TLM/TLM/U/UIScaler.cs
@@ -5,11 +5,46 @@ namespace TrafficManager.U {
     using UnityEngine;
 
     public static class UIScaler {
+        public const float GUI_WIDTH = 1920f;
+        public const float GUI_HEIGHT = 1080f;
+
+        /// <summary>Caching because UIView.Instance.uiCamera can be null sometimes.</summary>
+        private static float cachedGuiWidth = GUI_WIDTH;
+
+        /// <summary>Caching because UIView.Instance.uiCamera can be null sometimes.</summary>
+        private static float cachedGuiHeight = GUI_HEIGHT;
+
         /// <summary>Screen width for GUI is always fixed at 1920.</summary>
-        public static float GuiWidth => Singleton<UIView>.instance.uiCamera.pixelWidth;
+        public static float GuiWidth {
+            // TODO: Double check if GUI never changes width, the code below can be a const
+            get {
+                UIView uiView = Singleton<UIView>.instance;
+                if (uiView != null) {
+                    Camera uiCamera = uiView.uiCamera;
+                    if (uiCamera != null) {
+                        UIScaler.cachedGuiWidth = uiCamera.pixelWidth;
+                    }
+                }
+
+                return UIScaler.cachedGuiWidth;
+            }
+        }
 
         /// <summary>Screen height for GUI is always fixed at 1080.</summary>
-        public static float GuiHeight => Singleton<UIView>.instance.uiCamera.pixelHeight;
+        public static float GuiHeight {
+            // TODO: Double check if GUI never changes height, the code below can be a const
+            get {
+                UIView uiView = Singleton<UIView>.instance;
+                if (uiView != null) {
+                    Camera uiCamera = uiView.uiCamera;
+                    if (uiCamera != null) {
+                        UIScaler.cachedGuiHeight = uiCamera.pixelHeight;
+                    }
+                }
+
+                return UIScaler.cachedGuiHeight;
+            }
+        }
 
         /// <summary>
         /// Calculate UI scale based on GUI scale slider in options multiplied by uiView's scale.
@@ -26,8 +61,8 @@ namespace TrafficManager.U {
         /// <returns>GUI space position.</returns>
         internal static Vector2 ScreenPointToGuiPoint(Vector2 screenPos) {
             return new Vector2(
-                (screenPos.x * 1920f) / Screen.width,
-                (screenPos.y * 1080f) / Screen.height);
+                (screenPos.x * GUI_WIDTH) / Screen.width,
+                (screenPos.y * GUI_HEIGHT) / Screen.height);
         }
     }
 }

--- a/TLM/TLM/U/UIScaler.cs
+++ b/TLM/TLM/U/UIScaler.cs
@@ -18,12 +18,9 @@ namespace TrafficManager.U {
         public static float GuiWidth {
             // TODO: Double check if GUI never changes width, the code below can be a const
             get {
-                UIView uiView = Singleton<UIView>.instance;
+                UIView uiView = UIView.GetAView();
                 if (uiView != null) {
-                    Camera uiCamera = uiView.uiCamera;
-                    if (uiCamera != null) {
-                        UIScaler.cachedGuiWidth = uiCamera.pixelWidth;
-                    }
+                    UIScaler.cachedGuiWidth = uiView.uiCamera.pixelWidth;
                 }
 
                 return UIScaler.cachedGuiWidth;
@@ -34,12 +31,9 @@ namespace TrafficManager.U {
         public static float GuiHeight {
             // TODO: Double check if GUI never changes height, the code below can be a const
             get {
-                UIView uiView = Singleton<UIView>.instance;
+                UIView uiView = UIView.GetAView();
                 if (uiView != null) {
-                    Camera uiCamera = uiView.uiCamera;
-                    if (uiCamera != null) {
-                        UIScaler.cachedGuiHeight = uiCamera.pixelHeight;
-                    }
+                    UIScaler.cachedGuiHeight = uiView.uiCamera.pixelHeight;
                 }
 
                 return UIScaler.cachedGuiHeight;

--- a/TLM/TLM/Util/GeometryUtil.cs
+++ b/TLM/TLM/Util/GeometryUtil.cs
@@ -13,10 +13,13 @@ namespace TrafficManager.Util {
         /// <summary>Transforms a world point into a screen point.</summary>
         /// <param name="worldPos">Position in the world.</param>
         /// <param name="screenPos">2d position on screen.</param>
-        /// <returns>Screen point in pixels. Note: For use in UI transform to GUI coords.</returns>
+        /// <returns>
+        /// Screen point in pixels. Note: For use in UI transform to GUI coords
+        /// use <see cref="UIScaler.ScreenPointToGuiPoint"/>.
+        /// </returns>
         internal static bool WorldToScreenPoint(Vector3 worldPos, out Vector3 screenPos) {
             screenPos = Camera.main.WorldToScreenPoint(worldPos);
-            screenPos.y = UIScaler.GuiHeight - screenPos.y;
+            screenPos.y = Screen.height - screenPos.y;
 
             return screenPos.z >= 0;
         }


### PR DESCRIPTION
Fixes #838

# Bug

`UIScaler` was using `uiCamera`'s pixel size, while either `UIView.instance` or `UIView.instance.uiCamera` was null. This is now cached and double checked.
Potentially if UI never changes from 1920x1080, we can replace that entire code with a pair of `const`

# Solution

A null check was added for both `UIView.instance` and `UIView.instance.uiCamera`, cached width and height are stored in case those are ever null.
Also: Change to `WorldToScreenPoint` has been reverted as it always been using `Screen.height` not GUI height.