### PR TITLE
Fixed: lane arrows don't get reset if the lane arrow window is not focused

### DIFF
--- a/TLM/TLM/UI/SubTools/LaneArrows/LaneArrowTool.cs
+++ b/TLM/TLM/UI/SubTools/LaneArrows/LaneArrowTool.cs
@@ -403,7 +403,7 @@ namespace TrafficManager.UI.SubTools.LaneArrows {
                 return;
             }
 
-            if (KeybindSettingsBase.LaneConnectorDelete.IsPressed(Event.current)) {
+            if (Event.current.type == EventType.KeyDown && KeybindSettingsBase.LaneConnectorDelete.IsPressed(Event.current)) {
                 OnResetToDefaultPressed();
             }
 

--- a/TLM/TLM/UI/SubTools/LaneArrows/LaneArrowTool.cs
+++ b/TLM/TLM/UI/SubTools/LaneArrows/LaneArrowTool.cs
@@ -190,13 +190,6 @@ namespace TrafficManager.UI.SubTools.LaneArrows {
 
                 ToolWindow.SetupControls(builder, numLanes);
 
-                // On Delete being pressed
-                ToolWindow.eventKeyDown += (component, param) => {
-                    if (KeybindSettingsBase.LaneConnectorDelete.IsPressed(param)) {
-                        OnResetToDefaultPressed();
-                    }
-                };
-
                 // Resize everything correctly
                 // builder.Control.SetTransparency(GlobalConfig.Instance.Main.GuiTransparency);
                 builder.Done();
@@ -408,6 +401,10 @@ namespace TrafficManager.UI.SubTools.LaneArrows {
                 fsm_.State != State.EditLaneArrows)
             {
                 return;
+            }
+
+            if (KeybindSettingsBase.LaneConnectorDelete.IsPressed(Event.current)) {
+                OnResetToDefaultPressed();
             }
 
             RepositionWindowToNode();


### PR DESCRIPTION
Fixes #738

### Bug: 
Lane Arrows do not respond to reset button if the lane arrow tool does not have focus.

### Steps to reproduce:
1- change lane arrows for a segment.
2- select another segment and the select the original segment.
3- press delete => lane arrows are not reset.
4- click somewhere inside the window and then press delete => lane arrows are not reset.
5- click a lane arrow button and then press delete => lane arrows (for the segment) are reset.
### Why:
`ToolWIndow.EventClicked` is not triggered until we click a button in the window.

### My solution:
Check for key press in every frame

### Other Solutions
calling `ToolWindow.Focus()` after `ToolWindow` is started in response to `EventVisibalityChanged` but I think that route is too complicated.

