### PR TITLE
Careful updating of tooltips; Correct reset of timed TL UI

### DIFF
--- a/TLM/TLM/State/OptionsTabs/OptionsGeneralTab.cs
+++ b/TLM/TLM/State/OptionsTabs/OptionsGeneralTab.cs
@@ -243,7 +243,9 @@ namespace TrafficManager.State {
                 = string.Format(
                     T("General.Tooltip.Format:Window transparency: {0}%"),
                     GlobalConfig.Instance.Main.GuiOpacity);
-            _guiOpacitySlider.RefreshTooltip();
+            if (LoadingExtension.IsGameLoaded) {
+                _guiOpacitySlider.RefreshTooltip();
+            }
 
             GlobalConfig.WriteConfig();
             Log._Debug($"GuiTransparency changed to {GlobalConfig.Instance.Main.GuiOpacity}");
@@ -255,7 +257,9 @@ namespace TrafficManager.State {
                 = string.Format(
                     T("General.Tooltip.Format:GUI scale: {0}%"),
                     GlobalConfig.Instance.Main.GuiScale);
-            _guiScaleSlider.RefreshTooltip();
+            if (LoadingExtension.IsGameLoaded) {
+                _guiScaleSlider.RefreshTooltip();
+            }
 
             GlobalConfig.WriteConfig();
             Log._Debug($"GuiScale changed to {GlobalConfig.Instance.Main.GuiScale}");
@@ -271,7 +275,10 @@ namespace TrafficManager.State {
                 T("General.Tooltip.Format:Overlay transparency: {0}%"),
                 GlobalConfig.Instance.Main.OverlayTransparency);
             GlobalConfig.WriteConfig();
-            _overlayTransparencySlider.RefreshTooltip();
+            if (LoadingExtension.IsGameLoaded) {
+                _overlayTransparencySlider.RefreshTooltip();
+            }
+
             Log._Debug($"Overlay transparency changed to {GlobalConfig.Instance.Main.OverlayTransparency}");
         }
 

--- a/TLM/TLM/UI/SubTools/TimedTrafficLights/TimedTrafficLightsTool.cs
+++ b/TLM/TLM/UI/SubTools/TimedTrafficLights/TimedTrafficLightsTool.cs
@@ -86,6 +86,8 @@ namespace TrafficManager.UI.SubTools.TimedTrafficLights {
 
         public override void OnActivate() {
             base.OnActivate();
+
+            SetToolMode(TTLToolMode.SelectNode);
             TrafficLightSimulationManager tlsMan = TrafficLightSimulationManager.Instance;
 
             RefreshCurrentTimedNodeIds();


### PR DESCRIPTION
Fixes #879 UI sliders are not force-refreshed if the game is not loaded (causes hard crash)
Fixes #861 Closing timed TL UI is now correctly reset upon reentering timed TL UI