### PR TITLE
Fix `CalculateCorner()` exception when `NetInfo` is `null`

### DIFF
--- a/TLM/TLM/Manager/Impl/ExtSegmentEndManager.cs
+++ b/TLM/TLM/Manager/Impl/ExtSegmentEndManager.cs
@@ -296,6 +296,8 @@ namespace TrafficManager.Manager.Impl {
         /// <param name="segmentId"></param>
         /// <param name="startNode"></param>
         public void CalculateCorners(ushort segmentId, bool startNode) {
+            if (!Shortcuts.netService.IsSegmentValid(segmentId))
+                return;
             ref ExtSegmentEnd segEnd = ref ExtSegmentEnds[GetIndex(segmentId, startNode)];
             segmentId.ToSegment().CalculateCorner(
                 segmentID: segmentId,


### PR DESCRIPTION
fixes #881

Bug: when assets are missing, Calculate corner throws null reference exception.

How  to reproduce:
- sub to some road assets.
- use it in a city.
- unsub from the road assets
- restart CS (exit to desktop -be careful not to loose you save if you are using instant return to desktop ... you need to wait a bit)
- run CS and load the saved game.

Fix: Check for if segment is valid. 

the previous method `private void Recalculate(ref ExtSegmentEnd segEnd)` checks for `IsSegmentValid()` so I figured I should do the same.

Test Result: 
no exceptions or errors in `output_log.txt` or `TMPE.log`

