### PR TITLE
fixed lane arrows reset check for lane connections on RHT

### DIFF
--- a/TLM/TLM/Manager/Impl/LaneConnectionManager.cs
+++ b/TLM/TLM/Manager/Impl/LaneConnectionManager.cs
@@ -76,7 +76,7 @@ namespace TrafficManager.Manager.Impl {
 
             foreach (var laneInfo in segment.Info.m_lanes) {
                 if (laneId == sourceLaneId) {
-                    return (laneInfo.m_direction == NetInfo.Direction.Forward) ^ !inverted;
+                    return (laneInfo.m_finalDirection == NetInfo.Direction.Forward) ^ !inverted;
                 }
                 laneId = laneBuffer[laneId].m_nextLane;
             }


### PR DESCRIPTION
Hint: the diff tiny diff is easier to read than the description!

![Screenshot (1069)](https://user-images.githubusercontent.com/26344691/81801633-6176fe80-951d-11ea-9a2e-3243a8427be5.png)Bug: 
When lane arrow tool reset lanes, it checks if the lanes have lane connections. But in RHT it gets the lane direction wrong. This coupled with #784 causes reset to do nothing if the segment has lane connections on the other side.

# Fix: 
checked for finalDirection rather than direction.

# Test:
create the scenario in the screenshot and press delete.

### Expected Result:
without this fix : nothign happens
with this fix: lane arrows are reset