### PR TITLE
GenericObservable - Use locks; Reuse existing list

### DIFF
--- a/TLM/TLM/State/GlobalConfig.cs
+++ b/TLM/TLM/State/GlobalConfig.cs
@@ -17,8 +17,8 @@ namespace TrafficManager.State {
             get => instance;
             private set {
                 if (value != null && instance != null) {
-                    value.Observers = instance.Observers;
-                    value.ObserverLock = instance.ObserverLock;
+                    value._observers = instance._observers;
+                    value._lock = instance._lock;
                 }
 
                 instance = value;


### PR DESCRIPTION
- no need to allocate a new List each time if we can work with locks instead.
- use of lock statement instead Monitor directly.
- removed commented out debug.log calls.
- formatting