### PR TITLE
fixed SA1413 UseTrailingCommasInMultiLineInitializers

### DIFF
--- a/TLM/CSUtil.Commons/Log.cs
+++ b/TLM/CSUtil.Commons/Log.cs
@@ -1,4 +1,4 @@
-﻿namespace CSUtil.Commons {
+namespace CSUtil.Commons {
     using System;
     using System.Diagnostics;
     using System.IO;

--- a/TLM/CSUtil.Commons/TernaryBool.cs
+++ b/TLM/CSUtil.Commons/TernaryBool.cs
@@ -1,10 +1,10 @@
-﻿namespace CSUtil.Commons {
+namespace CSUtil.Commons {
     /// <summary>
     /// Tri-bool: a boolean value which can also be undefined
     /// </summary>
     public enum TernaryBool {
         Undefined = 0,
         False = 1,
-        True = 2
+        True = 2,
     }
 }

--- a/TLM/TLM/Manager/Impl/ExtCitizenInstanceManager.cs
+++ b/TLM/TLM/Manager/Impl/ExtCitizenInstanceManager.cs
@@ -1311,7 +1311,7 @@ namespace TrafficManager.Manager.Impl {
                     ignoreCosts = false,
                     randomParking = false,
                     stablePath = false,
-                    skipQueue = false
+                    skipQueue = false,
                 };
 
                 if (CustomPathManager._instance.CustomCreatePath(
@@ -1359,7 +1359,7 @@ namespace TrafficManager.Manager.Impl {
                         var pos = new PathUnit.Position {
                             m_segment = item.parkingPathStartPositionSegment,
                             m_lane = item.parkingPathStartPositionLane,
-                            m_offset = item.parkingPathStartPositionOffset
+                            m_offset = item.parkingPathStartPositionOffset,
                         };
                         ExtInstances[instanceId].parkingPathStartPosition = pos;
                     } else {
@@ -1400,7 +1400,7 @@ namespace TrafficManager.Manager.Impl {
                         pathMode = (int)ExtInstances[instanceId].pathMode,
                         failedParkingAttempts = ExtInstances[instanceId].failedParkingAttempts,
                         parkingSpaceLocationId = ExtInstances[instanceId].parkingSpaceLocationId,
-                        parkingSpaceLocation = (int)ExtInstances[instanceId].parkingSpaceLocation
+                        parkingSpaceLocation = (int)ExtInstances[instanceId].parkingSpaceLocation,
                     };
 
                     if (ExtInstances[instanceId].parkingPathStartPosition != null) {

--- a/TLM/TLM/Manager/Impl/ExtNodeManager.cs
+++ b/TLM/TLM/Manager/Impl/ExtNodeManager.cs
@@ -67,7 +67,7 @@ namespace TrafficManager.Manager.Impl {
                     oldSegmentEndId = ExtNodes[nodeId].removedSegmentEndId,
                     newSegmentEndId = new SegmentEndId(
                         segmentId,
-                        (bool)Services.NetService.IsStartNode(segmentId, nodeId))
+                        (bool)Services.NetService.IsStartNode(segmentId, nodeId)),
                 };
                 ExtNodes[nodeId].removedSegmentEndId = null;
                 Constants.ManagerFactory.GeometryManager.OnSegmentEndReplacement(replacement);

--- a/TLM/TLM/Manager/Impl/ParkingRestrictionsManager.cs
+++ b/TLM/TLM/Manager/Impl/ParkingRestrictionsManager.cs
@@ -170,7 +170,7 @@ namespace TrafficManager.Manager.Impl {
 
                     var restr = new Configuration.ParkingRestriction((ushort)segmentId) {
                         forwardParkingAllowed = parkingAllowed[segmentId][0],
-                        backwardParkingAllowed = parkingAllowed[segmentId][1]
+                        backwardParkingAllowed = parkingAllowed[segmentId][1],
                     };
 
                     Log._Trace(

--- a/TLM/TLM/Manager/Impl/RoutingManager.cs
+++ b/TLM/TLM/Manager/Impl/RoutingManager.cs
@@ -1950,7 +1950,7 @@ namespace TrafficManager.Manager.Impl {
                         type = newTransitions[i].type,
                         distance = newTransitions[i].distance,
                         segmentId = segmentId,
-                        startNode = startNode
+                        startNode = startNode,
                     };
 
                     LaneEndForwardRoutings[sourceIndex].AddTransition(forwardTransition);

--- a/TLM/TLM/Manager/Impl/TrafficLightSimulationManager.cs
+++ b/TLM/TLM/Manager/Impl/TrafficLightSimulationManager.cs
@@ -770,7 +770,7 @@ namespace TrafficManager.Manager.Impl {
                     var cnfTimedLights = new Configuration.TimedTrafficLights {
                         nodeId = timedNode.NodeId,
                         nodeGroup = new List<ushort>(timedNode.NodeGroup),
-                        started = timedNode.IsStarted()
+                        started = timedNode.IsStarted(),
                     };
                     ret.Add(cnfTimedLights);
 
@@ -794,7 +794,7 @@ namespace TrafficManager.Manager.Impl {
                             maxTime = timedStep.MaxTime,
                             changeMetric = (int)timedStep.ChangeMetric,
                             waitFlowBalance = timedStep.WaitFlowBalance,
-                            segmentLights = new Dictionary<ushort, Configuration.CustomSegmentLights>()
+                            segmentLights = new Dictionary<ushort, Configuration.CustomSegmentLights>(),
                         };
                         cnfTimedLights.timedSteps.Add(cnfTimedStep);
 
@@ -812,7 +812,7 @@ namespace TrafficManager.Manager.Impl {
                                 segmentId = segLights.SegmentId, // TODO not needed
                                 customLights = new Dictionary<ExtVehicleType, Configuration.CustomSegmentLight>(),
                                 pedestrianLightState = segLights.PedestrianLightState,
-                                manualPedestrianMode = segLights.ManualPedestrianMode
+                                manualPedestrianMode = segLights.ManualPedestrianMode,
                             };
 
                             if (lightsNodeId == 0 || lightsNodeId != timedNode.NodeId) {
@@ -843,7 +843,7 @@ namespace TrafficManager.Manager.Impl {
                                     currentMode = (int)segLight.CurrentMode,
                                     leftLight = segLight.LightLeft,
                                     mainLight = segLight.LightMain,
-                                    rightLight = segLight.LightRight
+                                    rightLight = segLight.LightRight,
                                 };
 
                                 cnfSegLights.customLights.Add(

--- a/TLM/TLM/Manager/Impl/VehicleBehaviorManager.cs
+++ b/TLM/TLM/Manager/Impl/VehicleBehaviorManager.cs
@@ -46,7 +46,7 @@ namespace TrafficManager.Manager.Impl {
             1u << 16, 1u << 17, 1u << 18, 1u << 19,
             1u << 20, 1u << 21, 1u << 22, 1u << 23,
             1u << 24, 1u << 25, 1u << 26, 1u << 27,
-            1u << 28, 1u << 29, 1u << 30, 1u << 31
+            1u << 28, 1u << 29, 1u << 30, 1u << 31,
         };
 
         public static readonly VehicleBehaviorManager Instance = new VehicleBehaviorManager();
@@ -913,7 +913,7 @@ namespace TrafficManager.Manager.Impl {
                     ignoreCosts = false,
                     randomParking = randomParking,
                     stablePath = false,
-                    skipQueue = (vehicleData.m_flags & Vehicle.Flags.Spawned) != 0
+                    skipQueue = (vehicleData.m_flags & Vehicle.Flags.Spawned) != 0,
                 };
 
                 if (CustomPathManager._instance.CustomCreatePath(

--- a/TLM/TLM/State/OptionsTabs/OptionsGameplayTab.cs
+++ b/TLM/TLM/State/OptionsTabs/OptionsGameplayTab.cs
@@ -31,7 +31,7 @@ namespace TrafficManager.State {
                                 Translation.Options.Get("Gameplay.Dropdown.Option:Path Of Evil (10%)"),
                                 Translation.Options.Get("Gameplay.Dropdown.Option:Rush Hour (5%)"),
                                 Translation.Options.Get("Gameplay.Dropdown.Option:Minor Complaints (2%)"),
-                                Translation.Options.Get("Gameplay.Dropdown.Option:Holy City (0%)")
+                                Translation.Options.Get("Gameplay.Dropdown.Option:Holy City (0%)"),
                       },
                       Options.recklessDrivers,
                       OnRecklessDriversChanged) as UIDropDown;

--- a/TLM/TLM/State/OptionsTabs/OptionsVehicleRestrictionsTab.cs
+++ b/TLM/TLM/State/OptionsTabs/OptionsVehicleRestrictionsTab.cs
@@ -88,7 +88,7 @@ namespace TrafficManager.State {
                                 Translation.Options.Get("VR.Dropdown.Option:Low Aggression"),
                                 Translation.Options.Get("VR.Dropdown.Option:Medium Aggression"),
                                 Translation.Options.Get("VR.Dropdown.Option:High Aggression"),
-                                Translation.Options.Get("VR.Dropdown.Option:Strict")
+                                Translation.Options.Get("VR.Dropdown.Option:Strict"),
                             },
                       (int)Options.vehicleRestrictionsAggression,
                       OnVehicleRestrictionsAggressionChanged) as UIDropDown;

--- a/TLM/TLM/Traffic/ExtVehicleType.cs
+++ b/TLM/TLM/Traffic/ExtVehicleType.cs
@@ -1,4 +1,4 @@
-﻿namespace TrafficManager.Traffic {
+namespace TrafficManager.Traffic {
     using System;
     using JetBrains.Annotations;
 
@@ -64,7 +64,7 @@
         Ferry = PassengerFerry,
 
         [UsedImplicitly]
-        Blimp = PassengerBlimp
+        Blimp = PassengerBlimp,
     }
 
     public static class LegacyExtVehicleType {

--- a/TLM/TLM/UI/Localization/Translation.cs
+++ b/TLM/TLM/UI/Localization/Translation.cs
@@ -241,7 +241,7 @@ namespace TrafficManager.UI {
 
                 var key = new Locale.Key() {
                     m_Identifier = identifier,
-                    m_Key = tutorialKey
+                    m_Key = tutorialKey,
                 };
 
                 resetFun?.Invoke(locale, new object[] { key });
@@ -290,7 +290,7 @@ namespace TrafficManager.UI {
 
                 var key = new Locale.Key() {
                     m_Identifier = identifier,
-                    m_Key = guideKey
+                    m_Key = guideKey,
                 };
 
                 resetFun?.Invoke(locale, new object[] { key });

--- a/TLM/TLM/UI/RemoveCitizenInstanceButtonExtender.cs
+++ b/TLM/TLM/UI/RemoveCitizenInstanceButtonExtender.cs
@@ -1,4 +1,4 @@
-﻿namespace TrafficManager.UI {
+namespace TrafficManager.UI {
     using ColossalFramework.UI;
     using CSUtil.Commons;
     using System.Collections.Generic;
@@ -59,7 +59,7 @@
                     BackgroundHovered = true,
                     BackgroundActive = true,
                     ForegroundHovered = true,
-                    ForegroundActive = true
+                    ForegroundActive = true,
                 };
                 this.atlas = this.Skin.CreateAtlas(
                     "Clear",

--- a/TLM/TLM/UI/SubTools/SpeedLimits/SpeedUnit.cs
+++ b/TLM/TLM/UI/SubTools/SpeedLimits/SpeedUnit.cs
@@ -2,6 +2,6 @@ namespace TrafficManager.UI.SubTools.SpeedLimits {
     public enum SpeedUnit {
         CurrentlyConfigured, // Currently selected in the options menu
         Kmph,
-        Mph
+        Mph,
     }
 }

--- a/TLM/TLM/UI/SubTools/TimedTrafficLights/TimedTrafficLightsTool.cs
+++ b/TLM/TLM/UI/SubTools/TimedTrafficLights/TimedTrafficLightsTool.cs
@@ -1024,7 +1024,7 @@ namespace TrafficManager.UI.SubTools.TimedTrafficLights {
                 GUILayout.BeginHorizontal();
                 GUIStyle style = new GUIStyle {
                                                   normal = { textColor = Color.white },
-                                                  alignment = TextAnchor.LowerLeft
+                                                  alignment = TextAnchor.LowerLeft,
                                               };
                 GUILayout.Label(
                     T("TTL.Label:Low"),

--- a/TLM/TLM/UI/SubTools/VehicleRestrictionsTool.cs
+++ b/TLM/TLM/UI/SubTools/VehicleRestrictionsTool.cs
@@ -19,12 +19,17 @@ namespace TrafficManager.UI.SubTools {
           UI.MainMenu.IOnscreenDisplayProvider
     {
         private static readonly ExtVehicleType[] RoadVehicleTypes = {
-            ExtVehicleType.PassengerCar, ExtVehicleType.Bus, ExtVehicleType.Taxi, ExtVehicleType.CargoTruck,
-            ExtVehicleType.Service, ExtVehicleType.Emergency
+            ExtVehicleType.PassengerCar,
+            ExtVehicleType.Bus,
+            ExtVehicleType.Taxi,
+            ExtVehicleType.CargoTruck,
+            ExtVehicleType.Service,
+            ExtVehicleType.Emergency,
         };
 
         private static readonly ExtVehicleType[] RailVehicleTypes = {
-            ExtVehicleType.PassengerTrain, ExtVehicleType.CargoTrain
+            ExtVehicleType.PassengerTrain,
+            ExtVehicleType.CargoTrain,
         };
 
         private readonly float vehicleRestrictionsSignSize = 80f;

--- a/TLM/TLM/UI/TrafficManagerMode.cs
+++ b/TLM/TLM/UI/TrafficManagerMode.cs
@@ -1,6 +1,6 @@
 namespace TrafficManager.UI {
     public enum TrafficManagerMode {
         None = 0,
-        Activated = 1
+        Activated = 1,
     }
 }

--- a/TLM/TLM/UI/TrafficManagerTool.cs
+++ b/TLM/TLM/UI/TrafficManagerTool.cs
@@ -1097,10 +1097,10 @@ namespace TrafficManager.UI {
                     m_netService = {
                         // find road segments
                         m_itemLayers = ItemClass.Layer.Default | ItemClass.Layer.MetroTunnels,
-                        m_service = ItemClass.Service.Road
+                        m_service = ItemClass.Service.Road,
                     },
                     m_ignoreTerrain = true,
-                    m_ignoreSegmentFlags = NetSegment.Flags.None
+                    m_ignoreSegmentFlags = NetSegment.Flags.None,
                 };
                 // segmentInput.m_ignoreSegmentFlags = NetSegment.Flags.Untouchable;
 

--- a/TLM/TLM/UI/TransportDemandViewMode.cs
+++ b/TLM/TLM/UI/TransportDemandViewMode.cs
@@ -1,6 +1,6 @@
-﻿namespace TrafficManager.UI {
+namespace TrafficManager.UI {
     public enum TransportDemandViewMode {
         Incoming,
-        Outgoing
+        Outgoing,
     }
 }

--- a/TLM/TLM/Util/AutoTimedTrafficLights.cs
+++ b/TLM/TLM/Util/AutoTimedTrafficLights.cs
@@ -45,7 +45,7 @@ namespace TrafficManager.Util {
         private enum GreenDir {
             AllRed,
             AllGreen,
-            ShortOnly
+            ShortOnly,
         }
 
         public enum ErrorResult {

--- a/TLM/TLM/Util/SegmentLaneTraverser.cs
+++ b/TLM/TLM/Util/SegmentLaneTraverser.cs
@@ -17,7 +17,7 @@ namespace TrafficManager.Util {
             /// <summary>
             /// Traversal stops when a segment consists of a different number of filtered lanes than the initial segment
             /// </summary>
-            LaneCount = 1
+            LaneCount = 1,
         }
 
         public class SegmentLaneVisitData {

--- a/TLM/TLM/Util/SegmentTraverser.cs
+++ b/TLM/TLM/Util/SegmentTraverser.cs
@@ -12,7 +12,7 @@ namespace TrafficManager.Util {
             None = 0,
             Incoming = 1,
             Outgoing = 1 << 1,
-            AnyDirection = Incoming | Outgoing
+            AnyDirection = Incoming | Outgoing,
         }
 
         [Flags]
@@ -21,7 +21,7 @@ namespace TrafficManager.Util {
             Left = 1,
             Straight = 1 << 1,
             Right = 1 << 2,
-            AnySide = Left | Straight | Right
+            AnySide = Left | Straight | Right,
         }
 
         public delegate bool SegmentVisitor(SegmentVisitData data);

--- a/TLM/TMPE.API/Traffic/Enums/CarUsagePolicy.cs
+++ b/TLM/TMPE.API/Traffic/Enums/CarUsagePolicy.cs
@@ -1,4 +1,4 @@
-﻿namespace TrafficManager.API.Traffic.Enums {
+namespace TrafficManager.API.Traffic.Enums {
     /// <summary>
     /// Indicates if a private car [may]/[shall]/[must not] be used
     /// </summary>
@@ -18,6 +18,6 @@
         /// <summary>
         /// Citizens are forbidden to use their car
         /// </summary>
-        Forbidden
+        Forbidden,
     }
 }

--- a/TLM/TMPE.API/Traffic/Enums/EmergencyBehavior.cs
+++ b/TLM/TMPE.API/Traffic/Enums/EmergencyBehavior.cs
@@ -1,4 +1,4 @@
-﻿namespace TrafficManager.API.Traffic.Enums {
+namespace TrafficManager.API.Traffic.Enums {
     public enum EmergencyBehavior {
         /// <summary>
         /// No custom behavior
@@ -24,6 +24,6 @@
         /// <summary>
         /// Regular vehicles evade on the parking lane
         /// </summary>
-        EvadeOnParkingLane
+        EvadeOnParkingLane,
     }
 }

--- a/TLM/TMPE.API/Traffic/Enums/ExtParkingSpaceLocation.cs
+++ b/TLM/TMPE.API/Traffic/Enums/ExtParkingSpaceLocation.cs
@@ -1,4 +1,4 @@
-﻿namespace TrafficManager.API.Traffic.Enums {
+namespace TrafficManager.API.Traffic.Enums {
     public enum ExtParkingSpaceLocation {
         /// <summary>
         /// No parking space location
@@ -11,6 +11,6 @@
         /// <summary>
         /// Building parking space
         /// </summary>
-        Building = 2
+        Building = 2,
     }
 }

--- a/TLM/TMPE.API/Traffic/Enums/ExtPathState.cs
+++ b/TLM/TMPE.API/Traffic/Enums/ExtPathState.cs
@@ -1,4 +1,4 @@
-﻿namespace TrafficManager.API.Traffic.Enums {
+namespace TrafficManager.API.Traffic.Enums {
     public enum ExtPathState {
         /// <summary>
         /// No path
@@ -15,6 +15,6 @@
         /// <summary>
         /// Path-finding has failed
         /// </summary>
-        Failed = 3
+        Failed = 3,
     }
 }

--- a/TLM/TMPE.API/Traffic/Enums/ExtPathType.cs
+++ b/TLM/TMPE.API/Traffic/Enums/ExtPathType.cs
@@ -1,4 +1,4 @@
-﻿namespace TrafficManager.API.Traffic.Enums {
+namespace TrafficManager.API.Traffic.Enums {
     public enum ExtPathType {
         /// <summary>
         /// Mixed path
@@ -13,6 +13,6 @@
         /// <summary>
         /// Driving path
         /// </summary>
-        DrivingOnly = 2
+        DrivingOnly = 2,
     }
 }

--- a/TLM/TMPE.API/Traffic/Enums/ExtSoftPathState.cs
+++ b/TLM/TMPE.API/Traffic/Enums/ExtSoftPathState.cs
@@ -1,4 +1,4 @@
-﻿namespace TrafficManager.API.Traffic.Enums {
+namespace TrafficManager.API.Traffic.Enums {
     public enum ExtSoftPathState {
         /// <summary>
         /// No path
@@ -28,6 +28,6 @@
         /// <summary>
         /// Path-finding result must not be handled by the citizen because the path will be transferred to a vehicle
         /// </summary>
-        Ignore = 5
+        Ignore = 5,
     }
 }

--- a/TLM/TMPE.API/Traffic/Enums/ExtTransportMode.cs
+++ b/TLM/TMPE.API/Traffic/Enums/ExtTransportMode.cs
@@ -1,4 +1,4 @@
-﻿namespace TrafficManager.API.Traffic.Enums {
+namespace TrafficManager.API.Traffic.Enums {
     using System;
 
     [Flags]
@@ -16,6 +16,6 @@
         /// <summary>
         /// Travelling by means of public transport
         /// </summary>
-        PublicTransport = 2
+        PublicTransport = 2,
     }
 }

--- a/TLM/TMPE.API/Traffic/Enums/ExtVehicleFlags.cs
+++ b/TLM/TMPE.API/Traffic/Enums/ExtVehicleFlags.cs
@@ -1,4 +1,4 @@
-﻿namespace TrafficManager.API.Traffic.Enums {
+namespace TrafficManager.API.Traffic.Enums {
     using System;
 
     // TODO why do we need this?
@@ -6,6 +6,6 @@
     public enum ExtVehicleFlags {
         None = 0,
         Created = 1,
-        Spawned = 1 << 1
+        Spawned = 1 << 1,
     }
 }

--- a/TLM/TMPE.API/Traffic/Enums/FlowWaitCalcMode.cs
+++ b/TLM/TMPE.API/Traffic/Enums/FlowWaitCalcMode.cs
@@ -1,4 +1,4 @@
-﻿namespace TrafficManager.API.Traffic.Enums {
+namespace TrafficManager.API.Traffic.Enums {
     // TODO this enum should be moved to TrafficManager.Traffic.Enums but deserialization fails if we just do that now.
     public enum FlowWaitCalcMode {
         /// <summary>
@@ -8,6 +8,6 @@
         /// <summary>
         /// traffic measurements are summed up
         /// </summary>
-        Total
+        Total,
     }
 }

--- a/TLM/TMPE.API/Traffic/Enums/GeometryCalculationMode.cs
+++ b/TLM/TMPE.API/Traffic/Enums/GeometryCalculationMode.cs
@@ -1,7 +1,7 @@
-﻿namespace TrafficManager.API.Traffic.Enums {
+namespace TrafficManager.API.Traffic.Enums {
     public enum GeometryCalculationMode {
         Init,
         Propagate,
-        NoPropagate
+        NoPropagate,
     }
 }

--- a/TLM/TMPE.API/Traffic/Enums/LaneEndTransitionType.cs
+++ b/TLM/TMPE.API/Traffic/Enums/LaneEndTransitionType.cs
@@ -1,4 +1,4 @@
-﻿namespace TrafficManager.API.Traffic.Enums {
+namespace TrafficManager.API.Traffic.Enums {
     public enum LaneEndTransitionType {
         /// <summary>
         /// No connection
@@ -15,6 +15,6 @@
         /// <summary>
         /// Relaxed connection for road vehicles [!] that do not have to follow lane arrows
         /// </summary>
-        Relaxed
+        Relaxed,
     }
 }

--- a/TLM/TMPE.API/Traffic/Enums/LightMode.cs
+++ b/TLM/TMPE.API/Traffic/Enums/LightMode.cs
@@ -1,8 +1,8 @@
-﻿namespace TrafficManager.API.Traffic.Enums {
+namespace TrafficManager.API.Traffic.Enums {
     public enum LightMode {
         Simple = 1, // ↑
         SingleLeft = 2, // ←, ↑→
         SingleRight = 3, // ←↑, →
-        All = 4 // ←, ↑, →
+        All = 4, // ←, ↑, →
     }
 }

--- a/TLM/TMPE.API/Traffic/Enums/ParkedCarApproachState.cs
+++ b/TLM/TMPE.API/Traffic/Enums/ParkedCarApproachState.cs
@@ -1,4 +1,4 @@
-﻿namespace TrafficManager.API.Traffic.Enums {
+namespace TrafficManager.API.Traffic.Enums {
     /// <summary>
     /// Indicates the current state while approaching a private car
     /// </summary>
@@ -18,6 +18,6 @@
         /// <summary>
         /// Citizen failed to approach their parked car
         /// </summary>
-        Failure
+        Failure,
     }
 }

--- a/TLM/TMPE.API/Traffic/Enums/ParkingError.cs
+++ b/TLM/TMPE.API/Traffic/Enums/ParkingError.cs
@@ -1,4 +1,4 @@
-﻿namespace TrafficManager.API.Traffic.Enums {
+namespace TrafficManager.API.Traffic.Enums {
     /// <summary>
     /// Represents the reason why a parked car could not be spawned
     /// </summary>
@@ -16,6 +16,6 @@
         /// <summary>
         /// The maximum allowed number of parked vehicles has been reached
         /// </summary>
-        LimitHit
+        LimitHit,
     }
 }

--- a/TLM/TMPE.API/Traffic/Enums/PriorityType.cs
+++ b/TLM/TMPE.API/Traffic/Enums/PriorityType.cs
@@ -1,4 +1,4 @@
-﻿namespace TrafficManager.API.Traffic.Enums {
+namespace TrafficManager.API.Traffic.Enums {
     public enum PriorityType {
         None = 0,
 
@@ -15,6 +15,6 @@
         /// <summary>
         /// Yield sign
         /// </summary>
-        Yield = 3
+        Yield = 3,
     }
 }

--- a/TLM/TMPE.API/Traffic/Enums/SetLaneArrow_Result.cs
+++ b/TLM/TMPE.API/Traffic/Enums/SetLaneArrow_Result.cs
@@ -1,8 +1,8 @@
-﻿namespace TrafficManager.API.Traffic.Enums {
+namespace TrafficManager.API.Traffic.Enums {
     public enum SetLaneArrow_Result {
         Invalid,
         HighwayArrows,
         LaneConnection,
-        Success
+        Success,
     }
 }

--- a/TLM/TMPE.API/Traffic/Enums/SetPrioritySignError.cs
+++ b/TLM/TMPE.API/Traffic/Enums/SetPrioritySignError.cs
@@ -1,9 +1,9 @@
-﻿namespace TrafficManager.API.Traffic.Enums {
+namespace TrafficManager.API.Traffic.Enums {
     public enum SetPrioritySignError {
         None,
         NoJunction,
         HasTimedLight,
         InvalidSegment,
-        NotIncoming
+        NotIncoming,
     }
 }

--- a/TLM/TMPE.API/Traffic/Enums/SimulationAccuracy.cs
+++ b/TLM/TMPE.API/Traffic/Enums/SimulationAccuracy.cs
@@ -34,6 +34,6 @@ namespace TrafficManager.API.Traffic.Enums {
         /// <summary>
         /// Reference value of maximum allowed Simulation Accuracy
         /// </summary>
-        MaxValue = 4
+        MaxValue = 4,
     }
 }

--- a/TLM/TMPE.API/Traffic/Enums/ToggleTrafficLightError.cs
+++ b/TLM/TMPE.API/Traffic/Enums/ToggleTrafficLightError.cs
@@ -1,9 +1,9 @@
-﻿namespace TrafficManager.API.Traffic.Enums {
+namespace TrafficManager.API.Traffic.Enums {
     public enum ToggleTrafficLightError {
         None,
         NoJunction,
         HasTimedLight,
         IsLevelCrossing,
-        InsufficientSegments
+        InsufficientSegments,
     }
 }

--- a/TLM/TMPE.API/Traffic/Enums/TrafficLightSimulationType.cs
+++ b/TLM/TMPE.API/Traffic/Enums/TrafficLightSimulationType.cs
@@ -1,7 +1,7 @@
-﻿namespace TrafficManager.API.Traffic.Enums {
+namespace TrafficManager.API.Traffic.Enums {
     public enum TrafficLightSimulationType {
         None,
         Manual,
-        Timed
+        Timed,
     }
 }

--- a/TLM/TMPE.API/Traffic/Enums/VehicleJunctionTransitState.cs
+++ b/TLM/TMPE.API/Traffic/Enums/VehicleJunctionTransitState.cs
@@ -23,6 +23,6 @@ namespace TrafficManager.API.Traffic.Enums {
         /// <summary>
         /// Vehicle may leave but is blocked due to traffic ahead
         /// </summary>
-        Blocked
+        Blocked,
     }
 }

--- a/TLM/TMPE.API/Traffic/Enums/VehicleRestrictionsAggression.cs
+++ b/TLM/TMPE.API/Traffic/Enums/VehicleRestrictionsAggression.cs
@@ -1,4 +1,4 @@
-﻿namespace TrafficManager.API.Traffic.Enums {
+namespace TrafficManager.API.Traffic.Enums {
     using JetBrains.Annotations;
 
     /// <summary>
@@ -25,6 +25,6 @@
         /// <summary>
         /// Strict aggression
         /// </summary>
-        Strict = 3
+        Strict = 3,
     }
 }

--- a/TLM/TMPE.API/Traffic/Enums/VehicleRestrictionsMode.cs
+++ b/TLM/TMPE.API/Traffic/Enums/VehicleRestrictionsMode.cs
@@ -1,4 +1,4 @@
-﻿namespace TrafficManager.API.Traffic.Enums {
+namespace TrafficManager.API.Traffic.Enums {
     public enum VehicleRestrictionsMode {
         /// <summary>
         /// Interpret bus lanes as "free for all"
@@ -13,6 +13,6 @@
         /// <summary>
         /// Interpret bus lanes as restricted
         /// </summary>
-        Restricted
+        Restricted,
     }
 }

--- a/TLM/TMPE.GenericGameBridge/Service/INetService.cs
+++ b/TLM/TMPE.GenericGameBridge/Service/INetService.cs
@@ -38,7 +38,7 @@ namespace GenericGameBridge.Service {
     public enum ClockDirection {
         None,
         Clockwise,
-        CounterClockwise
+        CounterClockwise,
     }
 
     public interface INetService {

--- a/TLM/TMPE.UnitTest/Util/TinyDictionaryUnitTest.cs
+++ b/TLM/TMPE.UnitTest/Util/TinyDictionaryUnitTest.cs
@@ -75,19 +75,19 @@ namespace TMUnitTest.Util {
             dict1 = new TinyDictionary<string, int> {
                 { alice, 1 },
                 { bob, 2 },
-                { cedric, 3 }
+                { cedric, 3 },
             };
 
             dict2 = new TinyDictionary<string, IList<string>> {
                 { bob, bobsNicknames },
                 { cedric, cedricsNicknames },
                 { dora, dorasNicknames },
-                { alice, alicesNicknames }
+                { alice, alicesNicknames },
             };
 
             dict3 = new TinyDictionary<ICollection<string>, bool> {
                 { girls, true },
-                { boys, false }
+                { boys, false },
             };
         }
 


### PR DESCRIPTION
Fixed 59 warnings regarding UseTrailingCommasInMultiLineInitializers, and a closely related formatting issue in VehicleRestrictionsTool.