### PR TITLE
Fixed SA1003SymbolsMustBeSpacedCorrectly warnings.

### DIFF
--- a/TLM/TLM/Custom/PathFinding/CustomPathFind.cs
+++ b/TLM/TLM/Custom/PathFinding/CustomPathFind.cs
@@ -341,7 +341,7 @@
                 (queueItem_.vehicleType & ExtVehicleType.RoadVehicle) != ExtVehicleType.None;
 
             isLaneArrowObeyingEntity_ =
-                (! Options.relaxedBusses || queueItem_.vehicleType != ExtVehicleType.Bus) &&
+                (!Options.relaxedBusses || queueItem_.vehicleType != ExtVehicleType.Bus) &&
                 (vehicleTypes_ & LaneArrowManager.VEHICLE_TYPES) != VehicleInfo.VehicleType.None &&
                 (queueItem_.vehicleType & LaneArrowManager.EXT_VEHICLE_TYPES) != ExtVehicleType.None;
 #if DEBUG
@@ -3092,7 +3092,7 @@
                             (nextLaneInfo.m_vehicleType & vehicleTypes_) !=
                             VehicleInfo.VehicleType.None) {
 #if ADVANCEDAI && ROUTING
-                            if (! enableAdvancedAI) {
+                            if (!enableAdvancedAI) {
 #endif
                                 int firstTarget = netManager.m_lanes.m_buffer[nextLaneId].m_firstTarget;
                                 int lastTarget = netManager.m_lanes.m_buffer[nextLaneId].m_lastTarget;

--- a/TLM/TLM/Manager/Impl/JunctionRestrictionsManager.cs
+++ b/TLM/TLM/Manager/Impl/JunctionRestrictionsManager.cs
@@ -567,7 +567,7 @@ namespace TrafficManager.Manager.Impl {
 #else
             const bool logLogic = false;
 #endif
-            if (! Services.NetService.IsSegmentValid(segmentId)) {
+            if (!Services.NetService.IsSegmentValid(segmentId)) {
                 return false;
             }
 

--- a/TLM/TLM/Manager/Impl/ParkingRestrictionsManager.cs
+++ b/TLM/TLM/Manager/Impl/ParkingRestrictionsManager.cs
@@ -106,7 +106,7 @@ namespace TrafficManager.Manager.Impl {
         }
 
         protected override void HandleValidSegment(ref ExtSegment seg) {
-            if (! MayHaveParkingRestriction(seg.segmentId)) {
+            if (!MayHaveParkingRestriction(seg.segmentId)) {
                 parkingAllowed[seg.segmentId][0] = true;
                 parkingAllowed[seg.segmentId][1] = true;
             }

--- a/TLM/TLM/Manager/Impl/SegmentEndManager.cs
+++ b/TLM/TLM/Manager/Impl/SegmentEndManager.cs
@@ -106,7 +106,7 @@ namespace TrafficManager.Manager.Impl {
             const bool logPriority = false;
 #endif
 
-            if (! Services.NetService.IsSegmentValid(segmentId)) {
+            if (!Services.NetService.IsSegmentValid(segmentId)) {
                 if (logPriority) {
                     Log._Debug(
                         $"SegmentEndManager.UpdateSegmentEnd({segmentId}, {startNode}): Segment " +

--- a/TLM/TLM/Manager/Impl/TrafficLightSimulationManager.cs
+++ b/TLM/TLM/Manager/Impl/TrafficLightSimulationManager.cs
@@ -46,7 +46,7 @@ namespace TrafficManager.Manager.Impl {
             Log._Debug($"Traffic light simulations:");
 
             for (int i = 0; i < TrafficLightSimulations.Length; ++i) {
-                if (! TrafficLightSimulations[i].HasSimulation()) {
+                if (!TrafficLightSimulations[i].HasSimulation()) {
                     continue;
                 }
 

--- a/TLM/TLM/Patch/_InfoManager/SetModePatch.cs
+++ b/TLM/TLM/Patch/_InfoManager/SetModePatch.cs
@@ -20,7 +20,7 @@ namespace TrafficManager.Patch._InfoManager
                     mode == InfoMode.None ||
                     RoadSelectionUtil.IsNetAdjustMode(mode, (int)subMode);
             }
-            if (RoadSelectionUtil.IsNetAdjustMode(mode,(int)subMode))
+            if (RoadSelectionUtil.IsNetAdjustMode(mode, (int)subMode))
             {
                 // UI to be handled by Default tool
                 ModUI.instance_.CloseMainMenu();

--- a/TLM/TLM/State/GlobalConfig.cs
+++ b/TLM/TLM/State/GlobalConfig.cs
@@ -105,7 +105,7 @@ namespace TrafficManager.State {
             return conf;
         }
 
-        private static DateTime WriteConfig(GlobalConfig config, string filename=FILENAME) {
+        private static DateTime WriteConfig(GlobalConfig config, string filename = FILENAME) {
             try {
                 Log.Info($"Writing global config to file '{filename}'...");
                 XmlSerializer serializer = new XmlSerializer(typeof(GlobalConfig));
@@ -183,7 +183,7 @@ namespace TrafficManager.State {
             }
         }
 
-        public static void Reload(bool checkVersion=true) {
+        public static void Reload(bool checkVersion = true) {
             DateTime modifiedTime;
             GlobalConfig conf = Load(out modifiedTime);
             if (checkVersion && conf.Version != -1 && conf.Version < LATEST_VERSION) {
@@ -208,7 +208,7 @@ namespace TrafficManager.State {
             }
         }
 
-        public static void Reset(GlobalConfig oldConfig, bool resetAll=false) {
+        public static void Reset(GlobalConfig oldConfig, bool resetAll = false) {
             Log.Info($"Resetting global config.");
             DateTime modifiedTime;
             Instance = WriteDefaultConfig(oldConfig, resetAll, out modifiedTime);

--- a/TLM/TLM/State/Keybinds/KeybindUI.cs
+++ b/TLM/TLM/State/Keybinds/KeybindUI.cs
@@ -210,7 +210,7 @@ namespace TrafficManager.State.Keybinds {
 
                 var keybindButton = evParam.source as UIButton;
                 var inputKey = SavedInputKey.Encode(evParam.keycode, evParam.control, evParam.shift, evParam.alt);
-                var editable = (KeybindSetting.Editable) evParam.source.objectUserData;
+                var editable = (KeybindSetting.Editable)evParam.source.objectUserData;
                 var category = editable.Target.Category;
 
                 if (evParam.keycode != KeyCode.Escape) {
@@ -233,7 +233,7 @@ namespace TrafficManager.State.Keybinds {
         }
 
         private void OnBindingMouseDown(UIComponent comp, UIMouseEventParameter evParam) {
-            var editable = (KeybindSetting.Editable) evParam.source.objectUserData;
+            var editable = (KeybindSetting.Editable)evParam.source.objectUserData;
             var keybindButton = evParam.source as UIButton;
 
             // This will only work if the user is not in the process of changing the shortcut
@@ -367,7 +367,7 @@ namespace TrafficManager.State.Keybinds {
 
             var obj = field.GetValue(null);
             if (obj is InputKey) {
-                return (InputKey) obj;
+                return (InputKey)obj;
             }
 
             return 0;

--- a/TLM/TLM/TrafficLight/Impl/CustomSegmentLights.cs
+++ b/TLM/TLM/TrafficLight/Impl/CustomSegmentLights.cs
@@ -419,7 +419,7 @@ namespace TrafficManager.TrafficLight.Impl {
             }
         }
 
-        public void CalculateAutoPedestrianLightState(ref NetNode node, bool propagate=true) {
+        public void CalculateAutoPedestrianLightState(ref NetNode node, bool propagate = true) {
 #if DEBUG
             bool logTrafficLights = DebugSwitch.TimedTrafficLights.Get()
                                     && DebugSettings.NodeId == NodeId;

--- a/TLM/TLM/UI/Helpers/CheckboxOption.cs
+++ b/TLM/TLM/UI/Helpers/CheckboxOption.cs
@@ -28,7 +28,7 @@ namespace TrafficManager.UI.Helpers {
                 T(Label),
                 Value,
                 this.OnValueChanged) as UICheckBox;
-            if (Tooltip!=null) {
+            if (Tooltip != null) {
                 _ui.tooltip = T(Tooltip);
             }
             if (Indent) {

--- a/TLM/TLM/UI/Helpers/ExtUITabStrip.cs
+++ b/TLM/TLM/UI/Helpers/ExtUITabStrip.cs
@@ -78,7 +78,7 @@ namespace TrafficManager.UI.Helpers {
             return scrollablePanel;
         }
 
-        public UIHelper AddTabPage(string name, bool scrollBars=true) {
+        public UIHelper AddTabPage(string name, bool scrollBars = true) {
             UIButton tabButton = base.AddTab(name);
             tabButton.normalBgSprite = "SubBarButtonBase";
             tabButton.disabledBgSprite = "SubBarButtonBaseDisabled";

--- a/TLM/TLM/UI/SubTools/LaneArrows/LaneArrowTool.cs
+++ b/TLM/TLM/UI/SubTools/LaneArrows/LaneArrowTool.cs
@@ -495,7 +495,7 @@ namespace TrafficManager.UI.SubTools.LaneArrows {
 #endif
             ExtSegmentEndManager segEndMan = ExtSegmentEndManager.Instance;
             int segmentEndId = segEndMan.GetIndex(segmentId, nodeId);
-            if (segmentEndId <0) {
+            if (segmentEndId < 0) {
                 Log._Debug($"Node {nodeId} is not connected to segment {segmentId}");
                 return false;
             }

--- a/TLM/TLM/UI/SubTools/LaneConnectorTool.cs
+++ b/TLM/TLM/UI/SubTools/LaneConnectorTool.cs
@@ -427,7 +427,7 @@ namespace TrafficManager.UI.SubTools {
             if (nodeId.ToNode().CountSegments() > 4)
                 return false;
             foreach (var segmentId in segments) {
-                if (segmentId!= 0 && !segMan.CalculateIsOneWay(segmentId))
+                if (segmentId != 0 && !segMan.CalculateIsOneWay(segmentId))
                     return false;
             }
             int sourceCount = segments

--- a/TLM/TLM/UI/SubTools/PrioritySigns/PrioritySignsTool.cs
+++ b/TLM/TLM/UI/SubTools/PrioritySigns/PrioritySignsTool.cs
@@ -25,7 +25,7 @@ namespace TrafficManager.UI.SubTools.PrioritySigns {
           UI.MainMenu.IOnscreenDisplayProvider
     {
         public enum PrioritySignsMassEditMode {
-            Min=0,
+            Min = 0,
             MainYield = 0,
             MainStop = 1,
             YieldMain = 2,
@@ -93,7 +93,7 @@ namespace TrafficManager.UI.SubTools.PrioritySigns {
                         TraverseDirection.AnyDirection,
                         TraverseSide.Straight,
                         SegmentStopCriterion.None,
-                        (_)=>true);
+                        (_) => true);
                     segmentList = new List<ushort>(segments);
                 }
 
@@ -299,7 +299,7 @@ namespace TrafficManager.UI.SubTools.PrioritySigns {
                 bool showRemoveButton = false;
 
                 foreach (ushort nodeId in currentPriorityNodeIds) {
-                    if (! Constants.ServiceFactory.NetService.IsNodeValid(nodeId)) {
+                    if (!Constants.ServiceFactory.NetService.IsNodeValid(nodeId)) {
                         continue;
                     }
 

--- a/TLM/TLM/UI/SubTools/SpeedLimits/SpeedLimitsTool.cs
+++ b/TLM/TLM/UI/SubTools/SpeedLimits/SpeedLimitsTool.cs
@@ -315,7 +315,7 @@ namespace TrafficManager.UI.SubTools.SpeedLimits {
                 }
 
                 // no speed limit overlay on selected segment when in vehicle restrictions mode
-                hover|= DrawSpeedLimitHandles(
+                hover |= DrawSpeedLimitHandles(
                     segmentId,
                     ref netManager.m_segments.m_buffer[segmentId],
                     viewOnly,
@@ -569,7 +569,7 @@ namespace TrafficManager.UI.SubTools.SpeedLimits {
 
             foreach (SpeedValue speedLimit in allSpeedLimits) {
                 // Highlight palette item if it is very close to its float speed
-                if (currentPaletteSpeedLimit !=null &&
+                if (currentPaletteSpeedLimit != null &&
                     FloatUtil.NearlyEqual(
                         (float)currentPaletteSpeedLimit?.GameUnits,
                         speedLimit.GameUnits)) {
@@ -897,7 +897,7 @@ namespace TrafficManager.UI.SubTools.SpeedLimits {
                     GeometryUtil.CalculateSegmentCenterByDir(
                         segmentId,
                         segCenter,
-                        speedLimitSignSize*TrafficManagerTool.MAX_ZOOM);
+                        speedLimitSignSize * TrafficManagerTool.MAX_ZOOM);
                 }
 
                 foreach (KeyValuePair<NetInfo.Direction, Vector3> e in segCenter) {

--- a/TLM/TLM/UI/SubTools/TimedTrafficLights/TimedTrafficLightsTool.cs
+++ b/TLM/TLM/UI/SubTools/TimedTrafficLights/TimedTrafficLightsTool.cs
@@ -1468,7 +1468,7 @@ namespace TrafficManager.UI.SubTools.TimedTrafficLights {
                                             liveSegmentLights.StartNode);
 
                     bool timedActive = timedNode.IsStarted();
-                    if (! timedActive) {
+                    if (!timedActive) {
                         liveSegmentLights.MakeRedOrGreen();
                     }
 

--- a/TLM/TLM/UI/TrafficManagerTool.cs
+++ b/TLM/TLM/UI/TrafficManagerTool.cs
@@ -350,7 +350,7 @@ namespace TrafficManager.UI {
 
         public override void RenderOverlay(RenderManager.CameraInfo cameraInfo) {
             RenderOverlayImpl(cameraInfo);
-            if (GetToolMode()==ToolMode.None) {
+            if (GetToolMode() == ToolMode.None) {
                 DefaultRenderOverlay(cameraInfo);
             }
         }

--- a/TLM/TLM/Util/AutoTimedTrafficLights.cs
+++ b/TLM/TLM/Util/AutoTimedTrafficLights.cs
@@ -368,7 +368,7 @@ namespace TrafficManager.Util {
                 return false;
             }
             if (nShort == 1) {
-                ushort nextSegmentId = RHT? seg.GetRightSegment(nodeId) : seg.GetLeftSegment(nodeId);
+                ushort nextSegmentId = RHT ? seg.GetRightSegment(nodeId) : seg.GetLeftSegment(nodeId);
                 return !segMan.CalculateIsOneWay(nextSegmentId);
             }
             int nForward = CountDirSegs(segmentId, nodeId, ArrowDirection.Forward);

--- a/TLM/TLM/Util/RoadSelectionUtil.cs
+++ b/TLM/TLM/Util/RoadSelectionUtil.cs
@@ -45,7 +45,7 @@ namespace TrafficManager.Util {
         /// </summary>
         public static void SetRoad(ushort segmentId, IEnumerable<ushort> segmentIDs) {
             foreach(var targetSegmentID in segmentIDs) {
-                if(targetSegmentID!= segmentId&& targetSegmentID != 0) {
+                if(targetSegmentID != segmentId && targetSegmentID != 0) {
                     CopySegmentName(segmentId, targetSegmentID);
                 }
             }

--- a/TLM/TLM/Util/Shortcuts.cs
+++ b/TLM/TLM/Util/Shortcuts.cs
@@ -126,7 +126,7 @@ namespace TrafficManager.Util {
         internal static string ToSTR(this List<LanePos> laneList) =>
             (from lanePos in laneList select lanePos.laneId).ToSTR();
 
-        internal static void AssertEq<T>(T a, T b, string m = "") where T:IComparable {
+        internal static void AssertEq<T>(T a, T b, string m = "") where T : IComparable {
             if (a.CompareTo(b) != 0) {
                 Log.Error($"Assertion failed. Expected {a} == {b} | " + m);
             }

--- a/TLM/TMPE.CitiesGameBridge/Service/NetService.cs
+++ b/TLM/TMPE.CitiesGameBridge/Service/NetService.cs
@@ -307,7 +307,7 @@ namespace CitiesGameBridge.Service {
                                              NetInfo.LaneType? laneTypeFilter = null,
                                              VehicleInfo.VehicleType? vehicleTypeFilter = null,
                                              bool reverse = false,
-                                             bool sort=true) {
+                                             bool sort = true) {
             // TODO refactor together with getSegmentNumVehicleLanes, especially the vehicle type and lane type checks
             NetManager netManager = Singleton<NetManager>.instance;
             var laneList = new List<LanePos>();

--- a/TLM/TMPE.UnitTest/Translation/CsvParser.cs
+++ b/TLM/TMPE.UnitTest/Translation/CsvParser.cs
@@ -24,8 +24,8 @@ namespace TMUnitTest.Translation {
         public static void InitializeClass(TestContext testContext) {
             testBlock_LF = File.ReadAllBytes("./Translation/TestFiles/TestBlock_LF.test");
             testBlock_CRLF = File.ReadAllBytes("./Translation/TestFiles/TestBlock_CRLF.test");
-            multilineTestBlock_LF =File.ReadAllBytes("./Translation/TestFiles/MultilineTestBlock_LF.test");
-            multilineTestBlock_CRLF =File.ReadAllBytes("./Translation/TestFiles/MultilineTestBlock_CRLF.test");
+            multilineTestBlock_LF = File.ReadAllBytes("./Translation/TestFiles/MultilineTestBlock_LF.test");
+            multilineTestBlock_CRLF = File.ReadAllBytes("./Translation/TestFiles/MultilineTestBlock_CRLF.test");
             PrepareData(testBlock_LF, out testBlock_LF_Columns, out testBlock_LF_DataBlock);
             PrepareData(testBlock_CRLF, out testBlock_CRLF_Columns, out testBlock_CRLF_DataBlock);
             PrepareData(multilineTestBlock_LF, out multilineTestBlock_LF_Columns, out multilineTestBlock_LF_DataBlock);
@@ -40,7 +40,7 @@ namespace TMUnitTest.Translation {
                 using (var sr = new StreamReader(m)) {
                     object[] args = {sr, null, null};
                     lookupTableType.InvokeStatic("ReadLines", args);
-                    columnsRow =(string)args[1];
+                    columnsRow = (string)args[1];
                     dataBlock = (string)args[2];
                 }
             }


### PR DESCRIPTION
Fixed 63 warnings with SA1003SymbolsMustBeSpacedCorrectly.
1 is still left, since its inside a #ifdef :/