### PR TITLE
added Unofficial.Microsoft.Unity.Analyzers nuget package.

### DIFF
--- a/TLM/TLM/packages.config
+++ b/TLM/TLM/packages.config
@@ -6,4 +6,5 @@
   <package id="SkyTools.Common" version="2.1.0" targetFramework="net35" />
   <package id="SkyTools.Patching" version="2.1.0" targetFramework="net35" />
   <package id="StyleCop.Analyzers" version="1.1.118" targetFramework="net35" developmentDependency="true" />
+  <package id="Unofficial.Microsoft.Unity.Analyzers" version="1.0.0" targetFramework="net35" developmentDependency="true" />
 </packages>


### PR DESCRIPTION
> edited by @aubergine10 

Unity breaks how `null` works...

Specifically:

```cs
// UnityEngine.Object
public static bool operator ==(Object x, Object y)
{
	return CompareBaseObjects(x, y);
}

// UnityEngine.Object
public static implicit operator bool(Object exists)
{
	return !CompareBaseObjects(exists, null);
}

// UnityEngine.Object
public static bool operator !=(Object x, Object y)
{
	return !CompareBaseObjects(x, y);
}

// UnityEngine.Object
private static bool CompareBaseObjects(Object lhs, Object rhs)
{
	bool flag = (object)lhs == null;
	bool flag2 = (object)rhs == null;
	if (flag2 && flag)
	{
		return true;
	}
	if (flag2)
	{
		return !IsNativeObjectAlive(lhs);
	}
	if (flag)
	{
		return !IsNativeObjectAlive(rhs);
	}
	return lhs.m_InstanceID == rhs.m_InstanceID;
}
```

This means that `!= null`, `?.` and `??` no longer mean what we think they mean when used on anything based on `UnityEngine.Object`.

The `Microsoft.Unity.Analyzers` package (specifically `UNT0007` and `UNT0008`) warns when `?.` and `??` are used on something derived from `UnityEngine.Object`.

Note, however, it does not currently warn about `!= null` issues.

When testing a UE.Object replace:

```cs
if (something != null) ...
```

With:

```cs
if (!something) ...
```

More reliable/comprehensible alternatives might be:

```cs
(object)obj == null

// or...

Object.ReferenceEquals(myGameObj, null)
```