### PR TITLE
more precise lane connector overlays.

### DIFF
--- a/TLM/TLM/UI/SubTools/LaneConnectorTool.cs
+++ b/TLM/TLM/UI/SubTools/LaneConnectorTool.cs
@@ -1055,7 +1055,7 @@ namespace TrafficManager.UI.SubTools {
             int nodeMarkerColorIndex = 0;
             LaneConnectionManager connManager = LaneConnectionManager.Instance;
 
-            int offsetMultiplier = node.CountSegments() <= 2 ? 3 : 1;
+            float offset = node.CountSegments() <= 2 ? 3 : 1;
 
             for (int i = 0; i < 8; i++) {
                 ushort segmentId = node.GetSegment(i);
@@ -1066,10 +1066,9 @@ namespace TrafficManager.UI.SubTools {
 
                 NetSegment[] segmentsBuffer = NetManager.instance.m_segments.m_buffer;
                 bool startNode = segmentsBuffer[segmentId].m_startNode == nodeId;
-                Vector3 offset = segmentsBuffer[segmentId]
-                                     .FindDirection(segmentId, nodeId) * offsetMultiplier;
                 NetInfo.Lane[] lanes = segmentsBuffer[segmentId].Info.m_lanes;
                 uint laneId = segmentsBuffer[segmentId].m_lanes;
+                float offsetT = offset / segmentId.ToSegment().m_averageLength;
 
                 for (byte laneIndex = 0; (laneIndex < lanes.Length) && (laneId != 0); laneIndex++) {
                     NetInfo.Lane laneInfo = lanes[laneIndex];
@@ -1085,32 +1084,29 @@ namespace TrafficManager.UI.SubTools {
                             laneInfo: laneInfo,
                             outgoing: out bool isSource,
                             incoming: out bool isTarget,
-                            pos: out Vector3? pos))
+                            pos: out _))
                         {
-                            pos = pos.Value + offset;
-
-                            float terrainY =
-                                Singleton<TerrainManager>.instance.SampleDetailHeightSmooth(pos.Value);
-
-                            var terrainPos = new Vector3(pos.Value.x, terrainY, pos.Value.z);
-
-                            Color32 nodeMarkerColor
-                                = isSource
-                                      ? COLOR_CHOICES[nodeMarkerColorIndex % COLOR_CHOICES.Length]
-                                      : default; // or black (not used while rendering)
-
-                            NetLane lane = NetManager.instance.m_lanes.m_buffer[laneId];
-                            Bezier3 bezier = lane.m_bezier;
+                            Vector3 pos;
+                            Bezier3 bezier = laneId.ToLane().m_bezier;
                             if (startNode) {
-                                bezier.a = (Vector3)pos;
+                                bezier = bezier.Cut(offsetT, 1f);
+                                pos = bezier.a;
                             } else {
-                                bezier.d = (Vector3)pos;
+                                bezier = bezier.Cut(0, 1f-offsetT);
+                                pos = bezier.d;
                             }
+                            float terrainY = Singleton<TerrainManager>.instance.SampleDetailHeightSmooth(pos);
+                            var terrainPos = new Vector3(pos.x, terrainY, pos.z);
+
                             SegmentLaneMarker segmentMarker = new SegmentLaneMarker(bezier);
                             NodeLaneMarker nodeMarker = new NodeLaneMarker {
                                 TerrainPosition = terrainPos,
                                 Position = (Vector3)pos,
                             };
+
+                            Color32 nodeMarkerColor = isSource
+                                      ? COLOR_CHOICES[nodeMarkerColorIndex % COLOR_CHOICES.Length]
+                                      : default; // transparent
 
                             bool isFoward = (laneInfo.m_direction & NetInfo.Direction.Forward) != 0;
                             int innerSimilarLaneIndex;


### PR DESCRIPTION
Problem:
if lanes have sharp curves the bezier will not fit the road 
![image](https://user-images.githubusercontent.com/26344691/84383654-5b943c00-abf5-11ea-8b8a-096577c0a170.png)

Solution:
We need to cut beziers rather than merely moving its start point.

![image](https://user-images.githubusercontent.com/26344691/84383857-bded3c80-abf5-11ea-9b55-e560a32f30db.png)

[TrafficManager.zip](https://github.com/CitiesSkylinesMods/TMPE/files/4764717/TrafficManager.zip)