### PR TITLE
Make it easier to debug harmony problems

### DIFF
--- a/TLM/TLM/Patcher.cs
+++ b/TLM/TLM/Patcher.cs
@@ -38,9 +38,9 @@ namespace TrafficManager {
                 Log.Info($"Harmony attribute-driven patching successfull!");
             }
             catch (Exception e) {
-                Log.Error("Could not deploy Harmony patches");
-                Log.Info(e.Message);
-                Log.Info(e.StackTrace);
+                Log.Error("Could not apply Harmony patches because the following exception occured:\n " +
+                    e +
+                    "\n   -- End of inner exception stack trace -- ");
                 fail = true;
             }
 
@@ -49,9 +49,9 @@ namespace TrafficManager {
                 AssemblyRedirector.Deploy();
             }
             catch (Exception e) {
-                Log.Error("Could not deploy attribute-driven detours");
-                Log.Info(e.ToString());
-                Log.Info(e.StackTrace);
+                Log.Error("Could not deploy attribute-driven detours because the following exception occured:\n "
+                    + e +
+                    "\n    -- End of inner exception stack trace -- ");
                 fail = true;
             }
 

--- a/TLM/TLM/TrafficManagerMod.cs
+++ b/TLM/TLM/TrafficManagerMod.cs
@@ -94,6 +94,12 @@ namespace TrafficManager {
             InGameHotReload = InGame();
 
             HarmonyHelper.EnsureHarmonyInstalled();
+
+#if DEBUG
+            const bool installHarmonyASAP = false; // set true for fast testing
+            if (installHarmonyASAP)
+                HarmonyHelper.DoOnHarmonyReady(delegate () { Patcher.Create().Install(); });
+#endif
         }
 
         [UsedImplicitly]


### PR DESCRIPTION
Problem: If an exception occurs in a harmony patch in TargetMethod, The exception is not printed. Also, I have to wait until the game is loaded to test if my harmony patch has an exception or not.

Solution: I added a conditional code to test harmony patches when mod is enabled. Also, I changed the code to print all layers of the exception log.