### PR TITLE
TMPE tool should behave when returning from free camera view

### DIFF
--- a/TLM/TLM/ThreadingExtension.cs
+++ b/TLM/TLM/ThreadingExtension.cs
@@ -44,17 +44,5 @@ namespace TrafficManager {
                 tlsMan.SimulationStep();
             }
         }
-
-        public override void OnUpdate(float realTimeDelta, float simulationTimeDelta) {
-            base.OnUpdate(realTimeDelta, simulationTimeDelta);
-
-            if (ToolsModifierControl.toolController == null || ModUI.Instance == null) {
-                return;
-            }
-
-            if (Input.GetKeyDown(KeyCode.Escape)) {
-                ModUI.Instance.CloseMainMenu();
-            }
-        }
     } // end class
 }

--- a/TLM/TLM/ThreadingExtension.cs
+++ b/TLM/TLM/ThreadingExtension.cs
@@ -52,12 +52,6 @@ namespace TrafficManager {
                 return;
             }
 
-            TrafficManagerTool tmTool = ModUI.GetTrafficManagerTool(false);
-            if (tmTool != null && ToolsModifierControl.toolController.CurrentTool != tmTool &&
-                ModUI.Instance.IsVisible()) {
-                ModUI.Instance.CloseMainMenu();
-            }
-
             if (Input.GetKeyDown(KeyCode.Escape)) {
                 ModUI.Instance.CloseMainMenu();
             }

--- a/TLM/TLM/UI/ModUI.cs
+++ b/TLM/TLM/UI/ModUI.cs
@@ -171,8 +171,8 @@ namespace TrafficManager.UI {
 #if DEBUG
             GetDebugMenu().Show();
 #endif
-            SetToolMode(TrafficManagerMode.Activated);
             _uiShown = true;
+            SetToolMode(TrafficManagerMode.Activated);
             MainMenuButton.UpdateButtonImageAndTooltip();
             UIView.SetFocus(MainMenu);
         }
@@ -187,8 +187,8 @@ namespace TrafficManager.UI {
             GetDebugMenu().Hide();
 #endif
 
-            SetToolMode(TrafficManagerMode.None);
             _uiShown = false;
+            SetToolMode(TrafficManagerMode.None);
             MainMenuButton.UpdateButtonImageAndTooltip();
         }
 

--- a/TLM/TLM/UI/TrafficManagerTool.cs
+++ b/TLM/TLM/UI/TrafficManagerTool.cs
@@ -510,6 +510,9 @@ namespace TrafficManager.UI {
                 if (!Input.GetMouseButtonDown(0)) {
                     _mouseClickProcessed = false;
                 }
+                if (e.type == EventType.keyDown && e.keyCode == KeyCode.Escape) {
+                    ModUI.Instance.CloseMainMenu();
+                }
 
                 if (Options.nodesOverlay) {
                     DebugGuiDisplaySegments();

--- a/TLM/TLM/UI/TrafficManagerTool.cs
+++ b/TLM/TLM/UI/TrafficManagerTool.cs
@@ -329,17 +329,24 @@ namespace TrafficManager.UI {
 
         // Overridden to disable base class behavior
         protected override void OnEnable() {
+            // If TMPE was enabled by switching back from another tool (eg: buldozer, free camera), show main menue panel.
+            if (ModUI.Instance != null && !ModUI.Instance.IsVisible())
+                ModUI.Instance.ShowMainMenu();
+
             if (legacySubTools_ != null) {
                 Log._Debug("TrafficManagerTool.OnEnable(): Performing cleanup");
                 foreach (KeyValuePair<ToolMode, LegacySubTool> e in legacySubTools_) {
                     e.Value.Cleanup();
                 }
             }
-            // disable base class behavior
+            // no call to base method to disable base class behavior
         }
 
         protected override void OnDisable() {
-            // Overridden to disable base class behavior
+            // If TMPE was disabled by switching to another tool, hide main menue panel.
+            if (ModUI.Instance != null && ModUI.Instance.IsVisible())
+                ModUI.Instance.CloseMainMenu();
+            // no call to base method to disable base class behavior
         }
 
         public override void RenderGeometry(RenderManager.CameraInfo cameraInfo) {
@@ -497,7 +504,6 @@ namespace TrafficManager.UI {
                 DefaultOnToolGUI(e);
             }
         }
-
 
         /// <summary>
         /// Immediate mode GUI (IMGUI) handler called every frame for input and IMGUI rendering (persistent overlay).


### PR DESCRIPTION
User presses Escape to return from the free camera view. This switches current tool is set to whatever it was before entering the free camera view.

### Problem:
This can re-enable TMPE tool without displaying the TMPE panel. This behaviour confuses Biffa:
https://cdn.discordapp.com/attachments/545066674605391882/712986161936728124/CS_Fixit_-_TMPE2a.mp4

### Reason:
~~Threading extension hides TMPE menu if TMPE is not the tool.~~
We do not view the Panel when TMPE tool is enabled.

### Need:
TMPE must act like other tools and TMPE panel should be visible when returning from free camera view.

### Solution:
Threading extension is the wrong place to show/hide TMPE panel.
this must be done from inside TMPE tool.

### Problem2:
TMPE panel disappears when user presses escape in free camera view.

### Reason:
Threading extension captures the Escape key and closes TMPE.

### Need:
TMPE must ignore Escape key when in free camera mod.

### Solution:
Handle Escape the same way other tools handle it: from `TrafficManagerTool.OnToolGUI()` 

PS: I deleted `ThreadingExtension.OnUpdate()` because it does not do anything anymore.