### PR TITLE
Move IT support

### DIFF
--- a/TLM/SharedAssemblyInfo.cs
+++ b/TLM/SharedAssemblyInfo.cs
@@ -20,4 +20,4 @@ using System.Runtime.InteropServices;
 //      Minor Version
 //      Build Number
 //      Revision
-[assembly: AssemblyVersion("11.5.0.*")]
+[assembly: AssemblyVersion("11.5.1.*")]

--- a/TLM/TLM/TLM.csproj
+++ b/TLM/TLM/TLM.csproj
@@ -342,6 +342,7 @@
     <Compile Include="Util\Record\SegmentEndRecord.cs" />
     <Compile Include="Util\Record\SegmentRecord.cs" />
     <Compile Include="Util\SeparateTurningLanesUtil.cs" />
+    <Compile Include="Util\Record\RecordUtil.cs" />
     <Compile Include="Util\Shortcuts.cs" />
     <Compile Include="Util\FloatUtil.cs" />
     <Compile Include="Util\GenericObservable.cs" />

--- a/TLM/TLM/Util/Record/IRecordable.cs
+++ b/TLM/TLM/Util/Record/IRecordable.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 namespace TrafficManager.Util.Record {
@@ -17,5 +18,7 @@ namespace TrafficManager.Util.Record {
         /// </summary>
         /// <param name="map">maps old Instance IDs to new Instance IDs</param>
         void Transfer(Dictionary<InstanceID, InstanceID> map);
+
+        byte[] Serialize();
     }
 }

--- a/TLM/TLM/Util/Record/IRecordable.cs
+++ b/TLM/TLM/Util/Record/IRecordable.cs
@@ -2,7 +2,20 @@ using System.Collections.Generic;
 
 namespace TrafficManager.Util.Record {
     public interface IRecordable {
+        /// <summary>
+        /// records network state.
+        /// </summary>
         void Record();
+
+        /// <summary>
+        /// restores network state.
+        /// </summary>
         void Restore();
+
+        /// <summary>
+        /// Restores recorded network state to another network.
+        /// </summary>
+        /// <param name="map">maps old Instance IDs to new Instance IDs</param>
+        void Transfer(Dictionary<InstanceID, InstanceID> map);
     }
 }

--- a/TLM/TLM/Util/Record/LaneArrowsRecord.cs
+++ b/TLM/TLM/Util/Record/LaneArrowsRecord.cs
@@ -1,10 +1,12 @@
 namespace TrafficManager.Util.Record {
+    using System;
     using System.Collections.Generic;
     using TrafficManager.API.Traffic.Enums;
     using TrafficManager.Manager.Impl;
     using TrafficManager.State;
     using static TrafficManager.Util.Shortcuts;
 
+    [Serializable]
     public class LaneArrowsRecord : IRecordable {
         public uint LaneId;
         InstanceID InstanceID => new InstanceID { NetLane = LaneId };
@@ -44,5 +46,7 @@ namespace TrafficManager.Util.Record {
             }
             return ret;
         }
+
+        public byte[] Serialize() => RecordUtil.Serialize(this);
     }
 }

--- a/TLM/TLM/Util/Record/LaneArrowsRecord.cs
+++ b/TLM/TLM/Util/Record/LaneArrowsRecord.cs
@@ -1,4 +1,5 @@
 namespace TrafficManager.Util.Record {
+    using ColossalFramework;
     using System;
     using System.Collections.Generic;
     using TrafficManager.API.Traffic.Enums;
@@ -30,7 +31,8 @@ namespace TrafficManager.Util.Record {
         }
 
         public static List<LaneArrowsRecord> GetLanes(ushort segmentId, bool startNode) {
-            var ret = new List<LaneArrowsRecord>();
+            int maxLaneCount = segmentId.ToSegment().Info.m_lanes.Length;
+            var ret = new List<LaneArrowsRecord>(maxLaneCount); 
             var lanes = netService.GetSortedLanes(
                 segmentId,
                 ref segmentId.ToSegment(),
@@ -44,6 +46,7 @@ namespace TrafficManager.Util.Record {
                 };
                 ret.Add(laneData);
             }
+            ret.TrimExcess();
             return ret;
         }
 

--- a/TLM/TLM/Util/Record/LaneArrowsRecord.cs
+++ b/TLM/TLM/Util/Record/LaneArrowsRecord.cs
@@ -1,23 +1,30 @@
 namespace TrafficManager.Util.Record {
-    using ColossalFramework;
-    using CSUtil.Commons;
     using System.Collections.Generic;
     using TrafficManager.API.Traffic.Enums;
     using TrafficManager.Manager.Impl;
+    using TrafficManager.State;
     using static TrafficManager.Util.Shortcuts;
 
     public class LaneArrowsRecord : IRecordable {
         public uint LaneId;
+        InstanceID InstanceID => new InstanceID { NetLane = LaneId };
 
-        private LaneArrows arrows_;
+        private LaneArrows? arrows_;
 
         public void Record() {
-            arrows_ = LaneArrowManager.Instance.GetFinalLaneArrows(LaneId);
+            arrows_ = Flags.GetLaneArrowFlags(LaneId);
         }
 
-        public void Restore() {
+        public void Restore() => Transfer(LaneId);
+
+        public void Transfer(Dictionary<InstanceID, InstanceID> map) =>
+            Transfer(map[InstanceID].NetLane);
+
+        public void Transfer(uint laneId) {
             //Log._Debug($"Restore: SetLaneArrows({LaneId}, {arrows_})");
-            LaneArrowManager.Instance.SetLaneArrows(LaneId, arrows_);
+            if (arrows_ == null)
+                return;
+            LaneArrowManager.Instance.SetLaneArrows(laneId, arrows_.Value);
         }
 
         public static List<LaneArrowsRecord> GetLanes(ushort segmentId, bool startNode) {
@@ -29,7 +36,7 @@ namespace TrafficManager.Util.Record {
                 LaneArrowManager.LANE_TYPES,
                 LaneArrowManager.VEHICLE_TYPES,
                 sort: false);
-            foreach(var lane in lanes) {
+            foreach (var lane in lanes) {
                 LaneArrowsRecord laneData = new LaneArrowsRecord {
                     LaneId = lane.laneId,
                 };

--- a/TLM/TLM/Util/Record/LaneConnectionRecord.cs
+++ b/TLM/TLM/Util/Record/LaneConnectionRecord.cs
@@ -36,7 +36,7 @@ namespace TrafficManager.Util.Record {
             //Log._Debug($"connections_=" + connections_.ToSTR());
 
             foreach (uint targetLaneId in connections_) {
-                if (currentConnections ==  null || !currentConnections.Contains(targetLaneId)) {
+                if (currentConnections == null || !currentConnections.Contains(targetLaneId)) {
                     connMan.AddLaneConnection(LaneId, targetLaneId, StartNode);
                 }
             }
@@ -52,7 +52,7 @@ namespace TrafficManager.Util.Record {
                 var originalLaneInstanceID = new InstanceID { NetLane = originalLaneID };
                 if (map.TryGetValue(originalLaneInstanceID, out var ret))
                     return ret.NetLane;
-                Log.Warning($"Could not map {originalLaneID}. this is expected if move it has not copied several segments from an intersection"); 
+                Log._Debug($"Could not map lane:{originalLaneID}. this is expected if move it has not copied all segment[s] from an intersection"); 
                 return 0;
             }
             var mappedLaneId = MappedLaneId(LaneId);
@@ -65,14 +65,12 @@ namespace TrafficManager.Util.Record {
             if (mappedLaneId == 0)
                 return;
 
-            Log._Debug($"connections_=" + connections_.ToSTR());
-
-            //Log._Debug("TMPE A");
+            //Log._Debug($"connections_=" + connections_.ToSTR());
             foreach (uint targetLaneId in connections_) {
                 var mappedTargetLaneId = MappedLaneId(targetLaneId);
                 if (mappedTargetLaneId == 0)
                     continue;
-                Log._Debug($"connecting lanes: {mappedLaneId}->{mappedTargetLaneId}");
+                //Log._Debug($"connecting lanes: {mappedLaneId}->{mappedTargetLaneId}");
                 connMan.AddLaneConnection(mappedLaneId, mappedTargetLaneId, StartNode);
             }
         }

--- a/TLM/TLM/Util/Record/LaneConnectionRecord.cs
+++ b/TLM/TLM/Util/Record/LaneConnectionRecord.cs
@@ -1,12 +1,11 @@
 namespace TrafficManager.Util.Record {
-    using ColossalFramework;
-    using CSUtil.Commons;
-    using GenericGameBridge.Service;
+    using System;
     using System.Collections.Generic;
     using System.Linq;
     using TrafficManager.Manager.Impl;
     using static TrafficManager.Util.Shortcuts;
 
+    [Serializable]
     public class LaneConnectionRecord : IRecordable {
         public uint LaneId;
         public byte LaneIndex;
@@ -105,5 +104,8 @@ namespace TrafficManager.Util.Record {
             }
             return ret;
         }
+
+        public byte[] Serialize() => RecordUtil.Serialize(this);
+
     }
 }

--- a/TLM/TLM/Util/Record/LaneConnectionRecord.cs
+++ b/TLM/TLM/Util/Record/LaneConnectionRecord.cs
@@ -1,4 +1,5 @@
 namespace TrafficManager.Util.Record {
+    using CSUtil.Commons;
     using System;
     using System.Collections.Generic;
     using System.Linq;
@@ -51,7 +52,7 @@ namespace TrafficManager.Util.Record {
                 var originalLaneInstanceID = new InstanceID { NetLane = originalLaneID };
                 if (map.TryGetValue(originalLaneInstanceID, out var ret))
                     return ret.NetLane;
-                CSUtil.Commons.Log.Warning($"Could not map {originalLaneID}");
+                Log.Warning($"Could not map {originalLaneID}. this is expected if move it has not copied several segments from an intersection"); 
                 return 0;
             }
             var mappedLaneId = MappedLaneId(LaneId);
@@ -64,28 +65,15 @@ namespace TrafficManager.Util.Record {
             if (mappedLaneId == 0)
                 return;
 
-            var currentConnections = GetCurrentConnections();
-            //Log._Debug($"currentConnections=" + currentConnections.ToSTR());
-            //Log._Debug($"connections_=" + connections_.ToSTR());
+            Log._Debug($"connections_=" + connections_.ToSTR());
 
-            CSUtil.Commons.Log._Debug("TMPE A");
+            //Log._Debug("TMPE A");
             foreach (uint targetLaneId in connections_) {
                 var mappedTargetLaneId = MappedLaneId(targetLaneId);
                 if (mappedTargetLaneId == 0)
                     continue;
-                if (currentConnections == null || !currentConnections.Contains(mappedTargetLaneId)) {
-                    connMan.AddLaneConnection(mappedLaneId, mappedTargetLaneId, StartNode);
-                }
-            }
-
-            CSUtil.Commons.Log._Debug("TMPE B");
-            foreach (uint targetLaneId in currentConnections ?? Enumerable.Empty<uint>()) {
-                var mappedTargetLaneId = MappedLaneId(targetLaneId);
-                if (mappedTargetLaneId == 0)
-                    continue;
-                if (!connections_.Contains(mappedTargetLaneId)) {
-                    connMan.RemoveLaneConnection(mappedLaneId, mappedTargetLaneId, StartNode);
-                }
+                Log._Debug($"connecting lanes: {mappedLaneId}->{mappedTargetLaneId}");
+                connMan.AddLaneConnection(mappedLaneId, mappedTargetLaneId, StartNode);
             }
         }
 

--- a/TLM/TLM/Util/Record/NodeRecord.cs
+++ b/TLM/TLM/Util/Record/NodeRecord.cs
@@ -1,7 +1,7 @@
 namespace TrafficManager.Util.Record {
+    using System;
     using System.Collections.Generic;
     using TrafficManager.Manager.Impl;
-    using UnityEngine.Networking.Types;
     using static TrafficManager.Util.Shortcuts;
 
     [Serializable]
@@ -50,9 +50,8 @@ namespace TrafficManager.Util.Record {
                 return false;
             }
             return tlMan.SetTrafficLight(nodeId, flag, ref nodeId.ToNode());
-
-            public byte[] Serialize() => RecordUtil.Serialize(this);
-
         }
+
+        public byte[] Serialize() => RecordUtil.Serialize(this);
     }
 }

--- a/TLM/TLM/Util/Record/NodeRecord.cs
+++ b/TLM/TLM/Util/Record/NodeRecord.cs
@@ -4,7 +4,8 @@ namespace TrafficManager.Util.Record {
     using UnityEngine.Networking.Types;
     using static TrafficManager.Util.Shortcuts;
 
-    class NodeRecord : IRecordable {
+    [Serializable]
+    public class NodeRecord : IRecordable {
         public NodeRecord(ushort nodeId) => NodeId = nodeId;
 
         public ushort NodeId { get; private set; }
@@ -49,6 +50,9 @@ namespace TrafficManager.Util.Record {
                 return false;
             }
             return tlMan.SetTrafficLight(nodeId, flag, ref nodeId.ToNode());
+
+            public byte[] Serialize() => RecordUtil.Serialize(this);
+
         }
     }
 }

--- a/TLM/TLM/Util/Record/NodeRecord.cs
+++ b/TLM/TLM/Util/Record/NodeRecord.cs
@@ -1,13 +1,15 @@
 namespace TrafficManager.Util.Record {
     using System.Collections.Generic;
     using TrafficManager.Manager.Impl;
+    using UnityEngine.Networking.Types;
     using static TrafficManager.Util.Shortcuts;
 
     class NodeRecord : IRecordable {
         public NodeRecord(ushort nodeId) => NodeId = nodeId;
 
         public ushort NodeId { get; private set; }
-        
+        InstanceID InstanceID => new InstanceID { NetNode = NodeId};
+
         private bool trafficLight_;
         private List<LaneConnectionRecord> lanes_;
         private static TrafficLightManager tlMan => TrafficLightManager.Instance;
@@ -25,6 +27,12 @@ namespace TrafficManager.Util.Record {
             foreach (LaneConnectionRecord sourceLane in lanes_) {
                 sourceLane.Restore();
             }
+        }
+
+        public void Transfer(Dictionary<InstanceID, InstanceID> map) {
+            SetTrafficLight(map[InstanceID].NetNode, trafficLight_);
+            foreach (LaneConnectionRecord sourceLane in lanes_)
+                sourceLane.Transfer(map);
         }
 
         private static bool SetTrafficLight(ushort nodeId, bool flag) {

--- a/TLM/TLM/Util/Record/RecordUtil.cs
+++ b/TLM/TLM/Util/Record/RecordUtil.cs
@@ -1,0 +1,29 @@
+using System;
+using System.IO;
+using System.Runtime.Serialization.Formatters;
+using System.Runtime.Serialization.Formatters.Binary;
+
+namespace TrafficManager.Util.Record {
+    public static class RecordUtil {
+        static BinaryFormatter GetBinaryFormatter =>
+            new BinaryFormatter { AssemblyFormat = FormatterAssemblyStyle.Simple };
+
+        public static IRecordable Deserialize(byte[] data) {
+            if (data == null)
+                return null;
+            //Log.Debug($"SerializationUtil.Deserialize(data): data.Length={data?.Length}");
+
+            var memoryStream = new MemoryStream();
+            memoryStream.Write(data, 0, data.Length);
+            memoryStream.Position = 0;
+            return GetBinaryFormatter.Deserialize(memoryStream) as IRecordable;
+        }
+
+        public static byte[] Serialize(IRecordable obj) {
+            var memoryStream = new MemoryStream();
+            GetBinaryFormatter.Serialize(memoryStream, obj);
+            memoryStream.Position = 0; // redundant
+            return memoryStream.ToArray();
+        }
+    }
+}

--- a/TLM/TLM/Util/Record/SegmentEndRecord.cs
+++ b/TLM/TLM/Util/Record/SegmentEndRecord.cs
@@ -1,14 +1,21 @@
 namespace TrafficManager.Util.Record {
     using CSUtil.Commons;
+    using System;
     using System.Collections.Generic;
     using TrafficManager.API.Traffic;
     using TrafficManager.API.Traffic.Enums;
     using TrafficManager.Manager.Impl;
 
+    [Serializable]
     class SegmentEndRecord : IRecordable {
         public SegmentEndRecord(int segmentEndIndex) {
             SegmentEndManager.Instance.
                 GetSegmentAndNodeFromIndex(segmentEndIndex, out ushort segmentId, out bool startNode);
+            SegmentId = segmentId;
+            StartNode = startNode;
+        }
+
+        public SegmentEndRecord(ushort segmentId, bool startNode) {
             SegmentId = segmentId;
             StartNode = startNode;
         }
@@ -91,5 +98,7 @@ namespace TrafficManager.Util.Record {
                 lanes_[i].Transfer(mappedLanes[i].LaneId);
             }
         }
+
+        public byte[] Serialize() => RecordUtil.Serialize(this);
     }
 }

--- a/TLM/TLM/Util/Record/SegmentEndRecord.cs
+++ b/TLM/TLM/Util/Record/SegmentEndRecord.cs
@@ -15,6 +15,7 @@ namespace TrafficManager.Util.Record {
 
         public ushort SegmentId { get; private set; }
         public bool StartNode { get; private set; }
+        InstanceID InstanceID => new InstanceID { NetSegment = SegmentId };
 
         private TernaryBool uturnAllowed_;
         private TernaryBool nearTurnOnRedAllowed_;
@@ -50,7 +51,7 @@ namespace TrafficManager.Util.Record {
 
             if (priorityMan.MaySegmentHavePrioritySign(SegmentId, StartNode) &&
                 prioirtySign_ != priorityMan.GetPrioritySign(SegmentId, StartNode)) {
-                //TODO fix manager code.
+                //TODO fix manager code so that all necessary checks are performed internally. 
                 priorityMan.SetPrioritySign(SegmentId, StartNode, prioirtySign_);
             }
 
@@ -61,6 +62,34 @@ namespace TrafficManager.Util.Record {
             JRMan.SetLaneChangingAllowedWhenGoingStraight(SegmentId, StartNode, laneChangingAllowedWhenGoingStraight_);
             JRMan.SetEnteringBlockedJunctionAllowed(SegmentId, StartNode, enteringBlockedJunctionAllowed_);
             JRMan.SetPedestrianCrossingAllowed(SegmentId, StartNode, pedestrianCrossingAllowed_);
+        }
+
+        public void Transfer(Dictionary<InstanceID, InstanceID> map) {
+            ushort segmentId = map[InstanceID].NetSegment;
+            foreach (IRecordable lane in lanes_)
+                lane.Transfer(map);
+
+            if (priorityMan.MaySegmentHavePrioritySign(segmentId, StartNode) &&
+                prioirtySign_ != priorityMan.GetPrioritySign(segmentId, StartNode)) {
+                priorityMan.SetPrioritySign(segmentId, StartNode, prioirtySign_);
+            }
+
+            // all necessary checks are performed internally.
+            JRMan.SetUturnAllowed(segmentId, StartNode, uturnAllowed_);
+            JRMan.SetNearTurnOnRedAllowed(segmentId, StartNode, nearTurnOnRedAllowed_);
+            JRMan.SetFarTurnOnRedAllowed(segmentId, StartNode, farTurnOnRedAllowed_);
+            JRMan.SetLaneChangingAllowedWhenGoingStraight(segmentId, StartNode, laneChangingAllowedWhenGoingStraight_);
+            JRMan.SetEnteringBlockedJunctionAllowed(segmentId, StartNode, enteringBlockedJunctionAllowed_);
+            JRMan.SetPedestrianCrossingAllowed(segmentId, StartNode, pedestrianCrossingAllowed_);
+        }
+
+        public void Transfer(uint mappedId) {
+            ushort segmentId = (ushort)mappedId;
+
+            var mappedLanes = SpeedLimitLaneRecord.GetLanes(segmentId);
+            for (int i = 0; i == lanes_.Count; ++i) {
+                lanes_[i].Transfer(mappedLanes[i].LaneId);
+            }
         }
     }
 }

--- a/TLM/TLM/Util/Record/SegmentRecord.cs
+++ b/TLM/TLM/Util/Record/SegmentRecord.cs
@@ -1,11 +1,13 @@
 namespace TrafficManager.Util.Record {
     using CitiesGameBridge.Service;
     using GenericGameBridge.Service;
+    using System;
     using System.Collections.Generic;
     using System.Linq;
     using TrafficManager.Manager.Impl;
 
     // TODO record vehicle restrictions.
+    [Serializable]
     public class SegmentRecord : IRecordable {
         public SegmentRecord(ushort segmentId) => SegmentId = segmentId;
 
@@ -69,5 +71,8 @@ namespace TrafficManager.Util.Record {
                 sort: false);
             return lanes.Select(lane => lane.laneId).ToList();
         }
+
+        public byte[] Serialize() => RecordUtil.Serialize(this);
+
     }
 }

--- a/TLM/TLM/Util/Record/SegmentRecord.cs
+++ b/TLM/TLM/Util/Record/SegmentRecord.cs
@@ -6,7 +6,7 @@ namespace TrafficManager.Util.Record {
     using System.Linq;
     using TrafficManager.Manager.Impl;
 
-    // TODO record vehicle restrictions.
+    // TODO add record vehicle restrictions.
     [Serializable]
     public class SegmentRecord : IRecordable {
         public SegmentRecord(ushort segmentId) => SegmentId = segmentId;

--- a/TLM/TLM/Util/Record/SegmentRecord.cs
+++ b/TLM/TLM/Util/Record/SegmentRecord.cs
@@ -47,6 +47,8 @@ namespace TrafficManager.Util.Record {
                 lane.Transfer(map);
         }
 
+        public byte[] Serialize() => RecordUtil.Serialize(this);
+
         /// <summary>
         /// creates 1:1 map between lanes of original segment and new segment.
         /// Precondition: SegmentInfos must match.
@@ -71,8 +73,5 @@ namespace TrafficManager.Util.Record {
                 sort: false);
             return lanes.Select(lane => lane.laneId).ToList();
         }
-
-        public byte[] Serialize() => RecordUtil.Serialize(this);
-
     }
 }

--- a/TLM/TLM/Util/Record/SegmentRecord.cs
+++ b/TLM/TLM/Util/Record/SegmentRecord.cs
@@ -1,6 +1,8 @@
 namespace TrafficManager.Util.Record {
-    using CSUtil.Commons;
+    using CitiesGameBridge.Service;
+    using GenericGameBridge.Service;
     using System.Collections.Generic;
+    using System.Linq;
     using TrafficManager.Manager.Impl;
 
     // TODO record vehicle restrictions.
@@ -8,28 +10,64 @@ namespace TrafficManager.Util.Record {
         public SegmentRecord(ushort segmentId) => SegmentId = segmentId;
 
         public ushort SegmentId { get; private set; }
-        
+        InstanceID InstanceID => new InstanceID { NetSegment = SegmentId };
+
         private bool parkingForward_;
         private bool parkingBackward_;
 
-        private List<SpeedLimitLaneRecord> lanes_;
+        private List<SpeedLimitLaneRecord> arrowLanes_; // lanes that can have lane arrows
+        private List<uint> allLaneIds_; // store lane ids to help with transfering lanes.
 
         private static ParkingRestrictionsManager pMan => ParkingRestrictionsManager.Instance;
 
         public void Record() {
             parkingForward_ = pMan.IsParkingAllowed(SegmentId, NetInfo.Direction.Forward);
             parkingBackward_ = pMan.IsParkingAllowed(SegmentId, NetInfo.Direction.Backward);
-            lanes_ = SpeedLimitLaneRecord.GetLanes(SegmentId);
-            foreach (var lane in lanes_)
+            arrowLanes_ = SpeedLimitLaneRecord.GetLanes(SegmentId);
+            foreach (var lane in arrowLanes_)
                 lane.Record();
+            allLaneIds_ = GetAllLanes(SegmentId);
         }
 
         public void Restore() {
             // TODO fix SetParkingAllowed 
             pMan.SetParkingAllowed(SegmentId, NetInfo.Direction.Forward, parkingForward_);
             pMan.SetParkingAllowed(SegmentId, NetInfo.Direction.Backward, parkingBackward_);
-            foreach (var lane in lanes_)
+            foreach (var lane in arrowLanes_)
                 lane.Restore();
+        }
+
+        public void Transfer(Dictionary<InstanceID, InstanceID> map){
+            ushort segmentId = map[InstanceID].NetSegment;
+            pMan.SetParkingAllowed(segmentId, NetInfo.Direction.Forward, parkingForward_);
+            pMan.SetParkingAllowed(segmentId, NetInfo.Direction.Backward, parkingBackward_);
+            foreach (var lane in arrowLanes_)
+                lane.Transfer(map);
+        }
+
+        /// <summary>
+        /// creates 1:1 map between lanes of original segment and new segment.
+        /// Precondition: SegmentInfos must match.
+        /// Precondition: segment must have been recorded.
+        /// </summary>
+        /// <param name="target">required to exit</param>
+        public void MapLanes(Dictionary<InstanceID, InstanceID> map, ushort target) {
+            var mappedLanes = GetAllLanes(target);
+            Shortcuts.Assert(allLaneIds_ != null && allLaneIds_.Count == mappedLanes.Count);
+            for (int i = 0; i < mappedLanes.Count; ++i) {
+                var instaceID0 = new InstanceID { NetLane = allLaneIds_[i]};
+                var instaceID = new InstanceID { NetLane = mappedLanes[i]};
+                map[instaceID0] = instaceID;
+            }
+        }
+
+        public static List<uint> GetAllLanes(ushort segmentId) {
+            var lanes =  NetService.Instance.GetSortedLanes(
+                segmentId,
+                ref segmentId.ToSegment(),
+                startNode: null,
+                sort: false);
+            return lanes.Select(lane => lane.laneId).ToList();
         }
     }
 }

--- a/TLM/TLM/Util/Record/SpeedLimitLaneRecord.cs
+++ b/TLM/TLM/Util/Record/SpeedLimitLaneRecord.cs
@@ -1,8 +1,5 @@
 namespace TrafficManager.Util.Record {
-    using ColossalFramework;
-    using CSUtil.Commons;
     using System.Collections.Generic;
-    using TrafficManager.API.Traffic.Enums;
     using TrafficManager.Manager.Impl;
     using static TrafficManager.Util.Shortcuts;
 
@@ -15,7 +12,8 @@ namespace TrafficManager.Util.Record {
         public byte LaneIndex;
         public uint LaneId;
         NetInfo.Lane LaneInfo;
-        ushort SegmentId;
+        InstanceID InstanceID => new InstanceID { NetLane = LaneId };
+
 
         private float? speedLimit_; // game units
 
@@ -25,9 +23,14 @@ namespace TrafficManager.Util.Record {
                 speedLimit_ = null;
         }
 
-        public void Restore() {
+        public void Restore() => Transfer(LaneId);
+
+        public void Transfer(Dictionary<InstanceID, InstanceID> map) =>
+            Transfer(map[this.InstanceID].NetLane);
+
+        public void Transfer(uint laneId) {
             SpeedLimitManager.Instance.SetSpeedLimit(
-                SegmentId,
+                laneId.ToLane().m_segment,
                 LaneIndex,
                 LaneInfo,
                 LaneId,
@@ -43,11 +46,10 @@ namespace TrafficManager.Util.Record {
                 LANE_TYPES,
                 VEHICLE_TYPES,
                 sort: false);
-            foreach(var lane in lanes) {
+            foreach (var lane in lanes) {
                 SpeedLimitLaneRecord laneData = new SpeedLimitLaneRecord {
                     LaneId = lane.laneId,
                     LaneIndex = lane.laneIndex,
-                    SegmentId = segmentId,
                     LaneInfo = segmentId.ToSegment().Info.m_lanes[lane.laneIndex],
                 };
                 ret.Add(laneData);

--- a/TLM/TLM/Util/Record/SpeedLimitLaneRecord.cs
+++ b/TLM/TLM/Util/Record/SpeedLimitLaneRecord.cs
@@ -41,7 +41,8 @@ namespace TrafficManager.Util.Record {
         }
 
         public static List<SpeedLimitLaneRecord> GetLanes(ushort segmentId) {
-            var ret = new List<SpeedLimitLaneRecord>();
+            int maxLaneCount = segmentId.ToSegment().Info.m_lanes.Length;
+            var ret = new List<SpeedLimitLaneRecord>(maxLaneCount);
             var lanes = netService.GetSortedLanes(
                 segmentId,
                 ref segmentId.ToSegment(),
@@ -56,6 +57,7 @@ namespace TrafficManager.Util.Record {
                 };
                 ret.Add(laneData);
             }
+            ret.TrimExcess();
             return ret;
         }
 

--- a/TLM/TLM/Util/Record/SpeedLimitLaneRecord.cs
+++ b/TLM/TLM/Util/Record/SpeedLimitLaneRecord.cs
@@ -1,8 +1,10 @@
 namespace TrafficManager.Util.Record {
+    using System;
     using System.Collections.Generic;
     using TrafficManager.Manager.Impl;
     using static TrafficManager.Util.Shortcuts;
 
+    [Serializable]
     public class SpeedLimitLaneRecord : IRecordable {
         public const NetInfo.LaneType LANE_TYPES =
             LaneArrowManager.LANE_TYPES | SpeedLimitManager.LANE_TYPES;
@@ -56,5 +58,8 @@ namespace TrafficManager.Util.Record {
             }
             return ret;
         }
+
+        public byte[] Serialize() => RecordUtil.Serialize(this);
+
     }
 }

--- a/TLM/TLM/Util/Record/SpeedLimitLaneRecord.cs
+++ b/TLM/TLM/Util/Record/SpeedLimitLaneRecord.cs
@@ -13,11 +13,10 @@ namespace TrafficManager.Util.Record {
 
         public byte LaneIndex;
         public uint LaneId;
-        NetInfo.Lane LaneInfo;
-        InstanceID InstanceID => new InstanceID { NetLane = LaneId };
-
 
         private float? speedLimit_; // game units
+
+        InstanceID InstanceID => new InstanceID { NetLane = LaneId };
 
         public void Record() {
             speedLimit_ = SpeedLimitManager.Instance.GetCustomSpeedLimit(LaneId);
@@ -31,12 +30,14 @@ namespace TrafficManager.Util.Record {
             Transfer(map[this.InstanceID].NetLane);
 
         public void Transfer(uint laneId) {
+            ushort segmentId = laneId.ToLane().m_segment;
+            var laneInfo = GetLaneInfo(segmentId, LaneIndex);
             SpeedLimitManager.Instance.SetSpeedLimit(
-                laneId.ToLane().m_segment,
-                LaneIndex,
-                LaneInfo,
-                LaneId,
-                speedLimit_);
+                segmentId: segmentId,
+                laneIndex: LaneIndex,
+                laneInfo: laneInfo,
+                laneId: LaneId,
+                speedLimit: speedLimit_);
         }
 
         public static List<SpeedLimitLaneRecord> GetLanes(ushort segmentId) {
@@ -52,7 +53,6 @@ namespace TrafficManager.Util.Record {
                 SpeedLimitLaneRecord laneData = new SpeedLimitLaneRecord {
                     LaneId = lane.laneId,
                     LaneIndex = lane.laneIndex,
-                    LaneInfo = segmentId.ToSegment().Info.m_lanes[lane.laneIndex],
                 };
                 ret.Add(laneData);
             }

--- a/TLM/TLM/Util/Record/TrafficRulesRecord.cs
+++ b/TLM/TLM/Util/Record/TrafficRulesRecord.cs
@@ -1,9 +1,11 @@
 namespace TrafficManager.Util.Record {
+    using System;
     using System.Collections;
     using System.Collections.Generic;
     using TrafficManager.Manager.Impl;
     using static Shortcuts;
 
+    [Serializable]
     public class TrafficRulesRecord : IRecordable {
         public HashSet<ushort> NodeIDs = new HashSet<ushort>();
         public HashSet<ushort> SegmentIDs = new HashSet<ushort>();
@@ -68,5 +70,8 @@ namespace TrafficManager.Util.Record {
             foreach (IRecordable record in Records)
                 record.Transfer(map);
         }
+
+        public byte[] Serialize() => RecordUtil.Serialize(this);
+
     }
 }

--- a/TLM/TLM/Util/Record/TrafficRulesRecord.cs
+++ b/TLM/TLM/Util/Record/TrafficRulesRecord.cs
@@ -63,5 +63,10 @@ namespace TrafficManager.Util.Record {
             foreach (IRecordable record in Records)
                 record.Restore();
         }
+
+        public void Transfer(Dictionary<InstanceID,InstanceID> map) {
+            foreach (IRecordable record in Records)
+                record.Transfer(map);
+        }
     }
 }

--- a/TLM/TLM/Util/Shortcuts.cs
+++ b/TLM/TLM/Util/Shortcuts.cs
@@ -63,6 +63,9 @@ namespace TrafficManager.Util {
 
         internal static ref NetSegment ToSegment(this ushort segmentId) => ref GetSeg(segmentId);
 
+        internal static NetInfo.Lane GetLaneInfo(ushort segmentId, int laneIndex) =>
+            segmentId.ToSegment().Info.m_lanes[laneIndex];
+
         internal static ref ExtSegmentEnd GetSegEnd(ushort segmentId, ushort nodeId) =>
             ref _segEndBuff[segEndMan.GetIndex(segmentId, nodeId)];
 


### PR DESCRIPTION
To provide MoveIT support I added the following functionality to IRecordable:
- transfer: to paste rules recorder rules to new segments. I use a dictionary to map old network ids to new network ids.
- `[Serializable]` attribute.
- Serialize
- Deserialize (this is actually static so it was added to RecordUtil)

### Extra changes:
- `SegmentRecord` also stores lanes from the original segment so that MoveIT can use it to map old lanes to new lanes. This can be helpful to determine the target-lane when transferring lane connections
- I no longer store LaneInfo because it is not serializable and it is not necessary to store it anyways.
- bumped version to indicate MoveIT compatibility.
- I changed the way I store lane arrows so that only lane arrows that are forcibly changed by the user are copied.

### missing:
Record vehicle restrictions and Timed TL.

### Review Tip:
Implementations of `IRecoradable.Transfer()` is almost a copy of `IRecordable.Restore()`. So it is a good idea to compare with old code to be able to review the code faster.

PS: This also paves the path for Intersection editor.