### PR TITLE
catch null segment info

### DIFF
--- a/TLM/TLM/Manager/Impl/ExtSegmentEndManager.cs
+++ b/TLM/TLM/Manager/Impl/ExtSegmentEndManager.cs
@@ -298,7 +298,7 @@ namespace TrafficManager.Manager.Impl {
         public void CalculateCorners(ushort segmentId, bool startNode) {
             if (!Shortcuts.netService.IsSegmentValid(segmentId))
                 return;
-            if (segmentId.ToSegment().Info == null) {
+            if (!segmentId.ToSegment().Info) {
                 Log.Warning($"segment {segmentId} has null info");
                 return;
             }
@@ -321,7 +321,7 @@ namespace TrafficManager.Manager.Impl {
                     cornerPos: out segEnd.LeftCorner,
                     cornerDirection: out segEnd.LeftCornerDir,
                     smooth: out _);
-            }catch (Exception e) {
+            } catch (Exception e) {
                 Log.Error($"failed calculating corner for segment:{segmentId}, info={segmentId.ToSegment().Info}\n"
                     + e.Message);
             }

--- a/TLM/TLM/Manager/Impl/ExtSegmentEndManager.cs
+++ b/TLM/TLM/Manager/Impl/ExtSegmentEndManager.cs
@@ -298,23 +298,33 @@ namespace TrafficManager.Manager.Impl {
         public void CalculateCorners(ushort segmentId, bool startNode) {
             if (!Shortcuts.netService.IsSegmentValid(segmentId))
                 return;
-            ref ExtSegmentEnd segEnd = ref ExtSegmentEnds[GetIndex(segmentId, startNode)];
-            segmentId.ToSegment().CalculateCorner(
-                segmentID: segmentId,
-                heightOffset: true,
-                start: startNode,
-                leftSide: false,
-                cornerPos: out segEnd.RightCorner,
-                cornerDirection: out segEnd.RightCornerDir,
-                smooth: out _);
-            segmentId.ToSegment().CalculateCorner(
-                segmentID: segmentId,
-                heightOffset: true,
-                start: startNode,
-                leftSide: true,
-                cornerPos: out segEnd.LeftCorner,
-                cornerDirection: out segEnd.LeftCornerDir,
-                smooth: out _);
+            if (segmentId.ToSegment().Info == null) {
+                Log.Warning($"segment {segmentId} has null info");
+                return;
+            }
+
+            try {
+                ref ExtSegmentEnd segEnd = ref ExtSegmentEnds[GetIndex(segmentId, startNode)];
+                segmentId.ToSegment().CalculateCorner(
+                    segmentID: segmentId,
+                    heightOffset: true,
+                    start: startNode,
+                    leftSide: false,
+                    cornerPos: out segEnd.RightCorner,
+                    cornerDirection: out segEnd.RightCornerDir,
+                    smooth: out _);
+                segmentId.ToSegment().CalculateCorner(
+                    segmentID: segmentId,
+                    heightOffset: true,
+                    start: startNode,
+                    leftSide: true,
+                    cornerPos: out segEnd.LeftCorner,
+                    cornerDirection: out segEnd.LeftCornerDir,
+                    smooth: out _);
+            }catch (Exception e) {
+                Log.Error($"failed calculating corner for segment:{segmentId}, info={segmentId.ToSegment().Info}\n"
+                    + e.Message);
+            }
         }
 
         private void CalculateIncomingOutgoing(ushort segmentId,


### PR DESCRIPTION
Bug:
sometimes segment Info is null if asset is missing resulting in `CalculateCorner()` to throw an exception.

Solution:
check for null segment Info.