### PR TITLE
fixed typo in lane record

### DIFF
--- a/TLM/TLM/Util/Record/SegmentEndRecord.cs
+++ b/TLM/TLM/Util/Record/SegmentEndRecord.cs
@@ -32,7 +32,7 @@ namespace TrafficManager.Util.Record {
         private TernaryBool pedestrianCrossingAllowed_;
 
         private PriorityType prioirtySign_;
-        private List<LaneArrowsRecord> lanes_;
+        private List<LaneArrowsRecord> arrowLanes_;
 
         private static TrafficPriorityManager priorityMan => TrafficPriorityManager.Instance;
         private static JunctionRestrictionsManager JRMan => JunctionRestrictionsManager.Instance;
@@ -47,13 +47,13 @@ namespace TrafficManager.Util.Record {
 
             prioirtySign_ = priorityMan.GetPrioritySign(SegmentId, StartNode);
 
-            lanes_ = LaneArrowsRecord.GetLanes(SegmentId, StartNode);
-            foreach(IRecordable lane in lanes_) 
+            arrowLanes_ = LaneArrowsRecord.GetLanes(SegmentId, StartNode);
+            foreach(IRecordable lane in arrowLanes_) 
                 lane.Record();
         }
 
         public void Restore() {
-            foreach (IRecordable lane in lanes_)
+            foreach (IRecordable lane in arrowLanes_)
                 lane.Restore();
 
             if (priorityMan.MaySegmentHavePrioritySign(SegmentId, StartNode) &&
@@ -73,7 +73,7 @@ namespace TrafficManager.Util.Record {
 
         public void Transfer(Dictionary<InstanceID, InstanceID> map) {
             ushort segmentId = map[InstanceID].NetSegment;
-            foreach (IRecordable lane in lanes_)
+            foreach (IRecordable lane in arrowLanes_)
                 lane.Transfer(map);
 
             if (priorityMan.MaySegmentHavePrioritySign(segmentId, StartNode) &&
@@ -94,8 +94,8 @@ namespace TrafficManager.Util.Record {
             ushort segmentId = (ushort)mappedId;
 
             var mappedLanes = SpeedLimitLaneRecord.GetLanes(segmentId);
-            for (int i = 0; i == lanes_.Count; ++i) {
-                lanes_[i].Transfer(mappedLanes[i].LaneId);
+            for (int i = 0; i == arrowLanes_.Count; ++i) {
+                arrowLanes_[i].Transfer(mappedLanes[i].LaneId);
             }
         }
 

--- a/TLM/TLM/Util/Record/SegmentRecord.cs
+++ b/TLM/TLM/Util/Record/SegmentRecord.cs
@@ -17,7 +17,7 @@ namespace TrafficManager.Util.Record {
         private bool parkingForward_;
         private bool parkingBackward_;
 
-        private List<SpeedLimitLaneRecord> arrowLanes_; // lanes that can have lane arrows
+        private List<SpeedLimitLaneRecord> speedLanes_; // lanes that can have lane arrows
         private List<uint> allLaneIds_; // store lane ids to help with transfering lanes.
 
         private static ParkingRestrictionsManager pMan => ParkingRestrictionsManager.Instance;
@@ -25,8 +25,8 @@ namespace TrafficManager.Util.Record {
         public void Record() {
             parkingForward_ = pMan.IsParkingAllowed(SegmentId, NetInfo.Direction.Forward);
             parkingBackward_ = pMan.IsParkingAllowed(SegmentId, NetInfo.Direction.Backward);
-            arrowLanes_ = SpeedLimitLaneRecord.GetLanes(SegmentId);
-            foreach (var lane in arrowLanes_)
+            speedLanes_ = SpeedLimitLaneRecord.GetLanes(SegmentId);
+            foreach (var lane in speedLanes_)
                 lane.Record();
             allLaneIds_ = GetAllLanes(SegmentId);
         }
@@ -35,7 +35,7 @@ namespace TrafficManager.Util.Record {
             // TODO fix SetParkingAllowed 
             pMan.SetParkingAllowed(SegmentId, NetInfo.Direction.Forward, parkingForward_);
             pMan.SetParkingAllowed(SegmentId, NetInfo.Direction.Backward, parkingBackward_);
-            foreach (var lane in arrowLanes_)
+            foreach (var lane in speedLanes_)
                 lane.Restore();
         }
 
@@ -43,7 +43,7 @@ namespace TrafficManager.Util.Record {
             ushort segmentId = map[InstanceID].NetSegment;
             pMan.SetParkingAllowed(segmentId, NetInfo.Direction.Forward, parkingForward_);
             pMan.SetParkingAllowed(segmentId, NetInfo.Direction.Backward, parkingBackward_);
-            foreach (var lane in arrowLanes_)
+            foreach (var lane in speedLanes_)
                 lane.Transfer(map);
         }
 


### PR DESCRIPTION
In my last PR I used wrong variable name.  I fix it here.
Kind of important because this data is serialized. 