### PR TITLE
post build script to create mdb file for file and line numbers

### DIFF
--- a/TLM/TLM/TLM.csproj
+++ b/TLM/TLM/TLM.csproj
@@ -74,6 +74,8 @@
     <CSPath>$(SteamPath)\steamapps\common\Cities_Skylines</CSPath>
     <MangedDLLPath>$(CSPath)\Cities_Data\Managed</MangedDLLPath>
     <MangedDLLPath Condition="!  Exists ('$(MangedDLLPath)')">..\dependencies</MangedDLLPath>
+    <UnityPath>$(MSBuildExtensionsPath64)\..\Unity\</UnityPath>
+    <UnityPath Condition="! Exists ('$(UnityPath)')">..\Unity\</UnityPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Benchmark|AnyCPU'">
     <OutputPath>bin\Benchmark\</OutputPath>
@@ -694,6 +696,7 @@
     </GetAssemblyIdentity>
     <ItemGroup>
       <VersionNumber Include="@(Targets->'%(Version)')" />
+      <UnityDir Include="$(UnityPath)" />
     </ItemGroup>
   </Target>
   <PropertyGroup>
@@ -701,7 +704,12 @@
       $(PostBuildEventDependsOn);
       PostBuildMacros;
     </PostBuildEventDependsOn>
-    <PostBuildEvent>set "DEPLOYDIR=$(LOCALAPPDATA)\Colossal Order\Cities_Skylines\Addons\Mods\$(TargetName)\"
+    <PostBuildEvent>set "MONODIR=@(UnityDir)Editor\Data\MonoBleedingEdge\"
+echo MONODIR is "%25MONODIR%25"
+"%25MONODIR%25bin\mono.exe" "%25MONODIR%25lib\mono\4.5\pdb2mdb.exe" "$(TargetPath)"
+
+set "DEPLOYDIR=$(LOCALAPPDATA)\Colossal Order\Cities_Skylines\Addons\Mods\$(TargetName)\"
+xcopy /y /v "$(TargetPath).mdb" "%25DEPLOYDIR%25"
 xcopy /y "$(TargetDir)TMPE.CitiesGameBridge.dll" "%25DEPLOYDIR%25"
 xcopy /y "$(TargetDir)TMPE.GenericGameBridge.dll" "%25DEPLOYDIR%25"
 xcopy /y "$(TargetDir)TMPE.API.dll" "%25DEPLOYDIR%25"
@@ -714,12 +722,15 @@ xcopy /y "$(TargetDir)CitiesHarmony.API.dll" "%25DEPLOYDIR%25"
 
 rem To avoid double hot reload, TrafficManager.dll must be replaced last and fast.
 rem Once TrafficManager.dll is re-loaded, all other dlls will be reloaded as well
-del  "%25DEPLOYDIR%25TrafficManager.dll"
-xcopy /y "$(TargetDir)TrafficManager.dll" "%25DEPLOYDIR%25"
+del  "%25DEPLOYDIR%25$(TargetFileName)"
+xcopy /y "$(TargetPath)" "%25DEPLOYDIR%25"
 
 echo THE ASSEMBLY VERSION IS: @(VersionNumber) created at %25time%25
-set DEPLOYDIR=
-</PostBuildEvent>
+set MONODIR=
+set DEPLOYDIR=</PostBuildEvent>
+  </PropertyGroup>
+  <PropertyGroup>
+    <PreBuildEvent>b</PreBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/TLM/TLM/TLM.csproj
+++ b/TLM/TLM/TLM.csproj
@@ -728,7 +728,8 @@ xcopy /y "$(TargetPath)" "%25DEPLOYDIR%25"
 echo THE ASSEMBLY VERSION IS: @(VersionNumber) created at %25time%25
 set MONODIR=
 set DEPLOYDIR=
-</PostBuildEvent>
+    </PostBuildEvent>
+  </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/TLM/TLM/TLM.csproj
+++ b/TLM/TLM/TLM.csproj
@@ -728,7 +728,7 @@ xcopy /y "$(TargetPath)" "%25DEPLOYDIR%25"
 echo THE ASSEMBLY VERSION IS: @(VersionNumber) created at %25time%25
 set MONODIR=
 set DEPLOYDIR=
-    </PostBuildEvent>
+</PostBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/TLM/TLM/TLM.csproj
+++ b/TLM/TLM/TLM.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -727,12 +727,8 @@ xcopy /y "$(TargetPath)" "%25DEPLOYDIR%25"
 
 echo THE ASSEMBLY VERSION IS: @(VersionNumber) created at %25time%25
 set MONODIR=
-set DEPLOYDIR=</PostBuildEvent>
-  </PropertyGroup>
-  <PropertyGroup>
-    <PreBuildEvent>
-    </PreBuildEvent>
-  </PropertyGroup>
+set DEPLOYDIR=
+</PostBuildEvent>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/TLM/TLM/TLM.csproj
+++ b/TLM/TLM/TLM.csproj
@@ -730,7 +730,8 @@ set MONODIR=
 set DEPLOYDIR=</PostBuildEvent>
   </PropertyGroup>
   <PropertyGroup>
-    <PreBuildEvent>b</PreBuildEvent>
+    <PreBuildEvent>
+    </PreBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/docs/Debug_Symbols.md
+++ b/docs/Debug_Symbols.md
@@ -22,7 +22,7 @@ Download from [Unity website](https://unity3d.com/get-unity/download/archive?_ga
 if you do not install unity in program files then create a `\TLM\Unity` [symlink](https://github.com/git-for-windows/git/wiki/Symbolic-Links) to it.
 
 ## Build
-With Unity instaslled Building TMPE also generates the mdb file and copies it to the mod folder.
+With Unity installed, building TMPE also generates the mdb file and copies it to the mod folder.
 
 ## Replace CO
 

--- a/docs/Debug_Symbols.md
+++ b/docs/Debug_Symbols.md
@@ -26,6 +26,6 @@ With Unity installed, building TMPE also generates the mdb file and copies it to
 
 ## Replace CO
 
-I have modified CO dll (see https://github.com/kianzarrin/PedestrianBridge/issues/7#issuecomment-654776528) to automatically load `<FileName>.dll.mdb` if one exists in the same director as `<ModName>.dll` . Download it here:
+I have modified CO dll (see https://github.com/kianzarrin/PedestrianBridge/issues/7#issuecomment-654776528) to automatically load `<FileName>.dll.mdb` if one exists in the same directory as `<FileName>.dll` . Download it here:
 [ColossalManaged.zip](https://github.com/kianzarrin/PedestrianBridge/files/4884294/ColossalManaged.zip)
 Copy this in place of your ColossalManaged.dll located in `C:\Program Files (x86)\Steam\steamapps\common\Cities_Skylines\Cities_Data\Managed` (depending on your CS installation folder).

--- a/docs/Debug_Symbols.md
+++ b/docs/Debug_Symbols.md
@@ -1,5 +1,6 @@
 # Debug Symbols
-when debugging CS mods it would be useful to get file and line number in your exceptions stack trace like this:
+
+When debugging CS mods, it would be useful to get file and line number in your exceptions stack trace like this:
 ```
 Exception: test kian exception
   at NetworkDetective.Test.Factorial (Int32 n) [0x00025] in C:\Users\dell\source\repos\NetworkDetective\NetowrkDetective\NetworkDetectiveMod.cs:35 

--- a/docs/Debug_Symbols.md
+++ b/docs/Debug_Symbols.md
@@ -1,0 +1,31 @@
+# Debug Symbols
+when debugging CS mods it would be useful to get file and line number in your exceptions stack trace like this:
+```
+Exception: test kian exception
+  at NetworkDetective.Test.Factorial (Int32 n) [0x00025] in C:\Users\dell\source\repos\NetworkDetective\NetowrkDetective\NetworkDetectiveMod.cs:35 
+  at NetworkDetective.Test.Factorial (Int32 n) [0x0000a] in C:\Users\dell\source\repos\NetworkDetective\NetowrkDetective\NetworkDetectiveMod.cs:32 
+  at NetworkDetective.Test.Factorial (Int32 n) [0x0000a] in C:\Users\dell\source\repos\NetworkDetective\NetowrkDetective\NetworkDetectiveMod.cs:32 
+  at NetworkDetective.Test.Factorial (Int32 n) [0x0000a] in C:\Users\dell\source\repos\NetworkDetective\NetowrkDetective\NetworkDetectiveMod.cs:32 
+  at NetworkDetective.NetworkDetectiveMod.OnEnabled () [0x00001] in C:\Users\dell\source\repos\NetworkDetective\NetowrkDetective\NetworkDetectiveMod.cs:50 
+```
+Follow these steps to get file and line number (I am working to reduce these steps).
+
+# Generating MDB file
+
+mono cannot use pdb files. So we need to convert it to mdb file. Not every version of pdb2mdb.exe works for us. So follow these steps to convert pdb to mdb
+
+## Install unity 5.6.7 
+
+Download from [Unity website](https://unity3d.com/get-unity/download/archive?_ga=2.67679633.1897806993.1593985032-213511360.158022272)
+![image](https://user-images.githubusercontent.com/26344691/86768847-d74ba200-c056-11ea-8cfd-98921b079923.png)
+
+if you do not install unity in program files then create a `\TLM\Unity` [symlink](https://github.com/git-for-windows/git/wiki/Symbolic-Links) to it.
+
+## Build
+With Unity instaslled Building TMPE also generates the mdb file and copies it to the mod folder.
+
+## Replace CO
+
+I have modified CO dll (see https://github.com/kianzarrin/PedestrianBridge/issues/7#issuecomment-654776528) to automatically load `<FileName>.dll.mdb` if one exists in the same director as `<ModName>.dll` . Download it here:
+[ColossalManaged.zip](https://github.com/kianzarrin/PedestrianBridge/files/4884294/ColossalManaged.zip)
+Copy this in place of your ColossalManaged.dll located in `C:\Program Files (x86)\Steam\steamapps\common\Cities_Skylines\Cities_Data\Managed` (depending on your CS installation folder).


### PR DESCRIPTION
In https://github.com/kianzarrin/PedestrianBridge/issues/7 I have explained how to print out file and line numbers of stack trace to output log.

in this review, I generate the MDB file in the post-build script.
- locate unity install dir
- generate mdb file using pdb2mdb.exe
- copy mdb file to mod folder

Requirement:
- Unity 5.6.7 installation to generate the mdb file.
- if unity is not installed in program files, create a symlink to it.
- replace CO dll to see the file and line numbers.

PS: I think we should upload mdb file to the workshop so pro users would be able to generate file and line numbers in their logs.

