### PR TITLE
fixed typo

### DIFF
--- a/TLM/TLM/Util/Record/SpeedLimitLaneRecord.cs
+++ b/TLM/TLM/Util/Record/SpeedLimitLaneRecord.cs
@@ -36,7 +36,7 @@ namespace TrafficManager.Util.Record {
                 segmentId: segmentId,
                 laneIndex: LaneIndex,
                 laneInfo: laneInfo,
-                laneId: LaneId,
+                laneId: laneId,
                 speedLimit: speedLimit_);
         }
 


### PR DESCRIPTION
Changed `LaneId` (original) to `laneId` to apply the speed limit to the new lane ID rather than the old one.
Note that `LaneId` stores the ID of the lane from which data is copied while `laneId` is the ID of the lane to which data is applied.

Test:
- use MoveIT to copy-paste segments with modified lanes.
![image](https://user-images.githubusercontent.com/26344691/88161470-b0759a00-cc18-11ea-9816-89cb7143c345.png)
