### PR TITLE
Bugfix floating vehicles when Parking AI disabled

### DIFF
--- a/TLM/TLM/Manager/Impl/AdvancedParkingManager.cs
+++ b/TLM/TLM/Manager/Impl/AdvancedParkingManager.cs
@@ -2896,6 +2896,50 @@ namespace TrafficManager.Manager.Impl {
                        out parkOffset) != 0;
         }
 
+        public bool VanillaFindParkingSpaceWithoutRestrictions(bool isElectric,
+                                                                ushort homeId,
+                                                                Vector3 refPos,
+                                                                Vector3 searchDir,
+                                                                ushort segment,
+                                                                float width,
+                                                                float length,
+                                                                out Vector3 parkPos,
+                                                                out Quaternion parkRot,
+                                                                out float parkOffset) {
+            if (!CustomPassengerCarAI.FindParkingSpace(isElectric,
+                                                       homeId,
+                                                       refPos,
+                                                       searchDir,
+                                                       segment,
+                                                       width,
+                                                       length,
+                                                       out parkPos,
+                                                       out parkRot,
+                                                       out parkOffset)) {
+                return false;
+            }
+
+            // in vanilla parkOffset is always >= 0 for RoadSideParkingSpace
+            if (Options.parkingRestrictionsEnabled && parkOffset >= 0) {
+                if (Singleton<NetManager>.instance.m_segments.m_buffer[segment].GetClosestLanePosition(
+                        refPos,
+                        NetInfo.LaneType.Parking,
+                        VehicleInfo.VehicleType.Car,
+                        out _,
+                        out _,
+                        out int laneIndex,
+                        out _)) {
+                    NetInfo.Direction direction
+                        = Singleton<NetManager>.instance.m_segments.m_buffer[segment].Info.m_lanes[laneIndex].m_finalDirection;
+                    if (!ParkingRestrictionsManager.Instance.IsParkingAllowed(segment, direction)) {
+                        return false;
+                    }
+                }
+            }
+
+            return true;
+        }
+
         public bool GetBuildingInfoViewColor(ushort buildingId,
                                              ref Building buildingData,
                                              ref ExtBuilding extBuilding,

--- a/TLM/TLM/Manager/Impl/VehicleBehaviorManager.cs
+++ b/TLM/TLM/Manager/Impl/VehicleBehaviorManager.cs
@@ -251,16 +251,16 @@ namespace TrafficManager.Manager.Impl {
                 }
 
                 if (!searchedParkingSpace) {
+                    bool isElectric = vehicleInfo.m_class.m_subService != ItemClass.SubService.ResidentialLow;
                     foundParkingSpace =
-                        Constants.ManagerFactory.AdvancedParkingManager.FindParkingSpaceInVicinity(
+                        Constants.ManagerFactory.AdvancedParkingManager.VanillaFindParkingSpaceWithoutRestrictions(
+                            isElectric,
+                            homeID,
                             refPos,
                             searchDir,
-                            vehicleInfo,
-                            homeID,
-                            vehicleID,
-                            GlobalConfig.Instance.ParkingAI.MaxBuildingToPedestrianLaneDistance,
-                            out ExtParkingSpaceLocation parkLoc,
-                            out ushort parkId,
+                            pathPos.m_segment,
+                            vehicleInfo.m_generatedInfo.m_size.x,
+                            vehicleInfo.m_generatedInfo.m_size.z,
                             out parkPos,
                             out parkRot,
                             out parkOffset);

--- a/TLM/TMPE.API/Manager/IAdvancedParkingManager.cs
+++ b/TLM/TMPE.API/Manager/IAdvancedParkingManager.cs
@@ -367,5 +367,30 @@
                                             out Vector3 parkPos,
                                             out Quaternion parkRot,
                                             out float parkOffset);
+
+        /// <summary>
+        /// Tries to find parking space using vanilla code, preserving parking restrictions
+        /// </summary>
+        /// <param name="isElectric">Is electric vehicle</param>
+        /// <param name="homeId">Home building id of the citizen (citizens are not allowed to park their car on foreign residential premises)</param>
+        /// <param name="refPos">Target position that is used as a center point for the search procedure</param>
+        /// <param name="searchDir">Search direction</param>
+        /// <param name="segment">If != 0, the building is forced to be "accessible" from this segment (where accessible means "close enough")</param>
+        /// <param name="width">Vehicle width</param>
+        /// <param name="length">Vehicle length</param>
+        /// <param name="parkPos">Identified parking space position (only valid if method returns true)</param>
+        /// <param name="parkRot">Identified parking space rotation (only valid if method returns true)</param>
+        /// <param name="parkOffset">Identified parking space offset (only valid if method returns true and a segment id was given)</param>
+        /// <returns></returns>
+        bool VanillaFindParkingSpaceWithoutRestrictions(bool isElectric,
+                                                         ushort homeId,
+                                                         Vector3 refPos,
+                                                         Vector3 searchDir,
+                                                         ushort segment,
+                                                         float width,
+                                                         float length,
+                                                         out Vector3 parkPos,
+                                                         out Quaternion parkRot,
+                                                         out float parkOffset);
     }
 }


### PR DESCRIPTION
- fixed floating vehicles if ParkingAI disabled
- if parkingAI is disabled, mod use vanilla code but preserve parking restrictions

**Latest build of this PR is available** [here](https://ci.appveyor.com/api/projects/krzychu124/tmpe/artifacts/TMPE.zip?branch=disabled-parking-ai--vehicles-floating-fix)

Closes #846 