### PR TITLE
Spiral bugfix and improvement

### DIFF
--- a/TLM/Benchmarks/SpiralLoopPerfTests.cs
+++ b/TLM/Benchmarks/SpiralLoopPerfTests.cs
@@ -5,9 +5,11 @@ using UnityEngine;
 
 namespace Benchmarks {
     public class SpiralLoopPerfTests {
-        private readonly Vector2[] spiralCacheRadius17 = LoopUtil.GenerateSpiralGridCoordsClockwise()
+        private readonly Vector2[] _spiralCacheRadius17 = LoopUtil.GenerateSpiralGridCoordsClockwise()
             .Take(17 * 17)
             .ToArray();
+
+        private readonly Spiral _spiral17 = new Spiral(17);
 
         [Benchmark]
         public void SpiralLoop_Once_Radius17() {
@@ -140,8 +142,57 @@ namespace Benchmarks {
                 return true;
             }
 
-            foreach (var position in spiralCacheRadius17) {
+            foreach (var position in _spiralCacheRadius17) {
                 var positionWithOffset = position + new Vector2(centerI, centerJ);
+                if (LoopHandler((int)positionWithOffset.x, (int)positionWithOffset.y)) {
+                    break;
+                }
+            }
+        }
+
+        [Benchmark]
+        public void SpiralGetCoords_Once_Radius17_Precached() {
+            var posX = 3621;
+            var posY = 2342;
+            var BUILDINGGRID_CELL_SIZE = 64;
+            var BUILDINGGRID_RESOLUTION = 270;
+
+            var centerI = (int)((posX / BUILDINGGRID_CELL_SIZE) +
+                                (BUILDINGGRID_RESOLUTION / 2f));
+            var centerJ = (int)((posY / BUILDINGGRID_CELL_SIZE) +
+                                (BUILDINGGRID_RESOLUTION / 2f));
+
+            int radius = 17;
+
+            ushort ignoreParked = 1;
+            Vector3 refPos = Vector3.back;
+            float width = 5f;
+            float length = 5f;
+            bool randomize = true;
+            ushort foundSegmentId = 0;
+            Vector3 myParkPos = Vector3.back;
+            Quaternion myParkRot = Quaternion.identity;
+            float myParkOffset = 10f;
+
+            bool LoopHandler(int x, int y) {
+                if (randomize) {
+                    width = ignoreParked
+                        + refPos.x
+                        + length
+                        + length
+                        + foundSegmentId
+                        + myParkPos.x
+                        + myParkPos.x
+                        + myParkRot.x
+                        + myParkOffset;
+                }
+
+                return true;
+            }
+
+            var loopCoords = _spiral17.GetCoords(17);
+            for (int i = 0; i < radius * radius; i++) {
+                var positionWithOffset = loopCoords[i] + new Vector2(centerI, centerJ);
                 if (LoopHandler((int)positionWithOffset.x, (int)positionWithOffset.y)) {
                     break;
                 }
@@ -284,8 +335,59 @@ namespace Benchmarks {
                     return true;
                 }
 
-                foreach (var position in spiralCacheRadius17) {
+                foreach (var position in _spiralCacheRadius17) {
                     var positionWithOffset = position + new Vector2(centerI, centerJ);
+                    if (LoopHandler((int)positionWithOffset.x, (int)positionWithOffset.y)) {
+                        break;
+                    }
+                }
+            }
+        }
+
+        [Benchmark]
+        public void SpiralGetCoords_10Times_Radius17_Precached() {
+            for (int i = 0; i < 10; i++) {
+                var posX = 3621;
+                var posY = 2342;
+                var BUILDINGGRID_CELL_SIZE = 64;
+                var BUILDINGGRID_RESOLUTION = 270;
+
+                var centerI = (int)((posX / BUILDINGGRID_CELL_SIZE) +
+                                    (BUILDINGGRID_RESOLUTION / 2f));
+                var centerJ = (int)((posY / BUILDINGGRID_CELL_SIZE) +
+                                    (BUILDINGGRID_RESOLUTION / 2f));
+
+                int radius = 17;
+
+                ushort ignoreParked = 1;
+                Vector3 refPos = Vector3.back;
+                float width = 5f;
+                float length = 5f;
+                bool randomize = true;
+                ushort foundSegmentId = 0;
+                Vector3 myParkPos = Vector3.back;
+                Quaternion myParkRot = Quaternion.identity;
+                float myParkOffset = 10f;
+
+                bool LoopHandler(int x, int y) {
+                    if (randomize) {
+                        width = ignoreParked
+                            + refPos.x
+                            + length
+                            + length
+                            + foundSegmentId
+                            + myParkPos.x
+                            + myParkPos.x
+                            + myParkRot.x
+                            + myParkOffset;
+                    }
+
+                    return true;
+                }
+
+                var loopCoords = _spiral17.GetCoords(17);
+                for (int j = 0; j < radius * radius; j++) {
+                    var positionWithOffset = loopCoords[j] + new Vector2(centerI, centerJ);
                     if (LoopHandler((int)positionWithOffset.x, (int)positionWithOffset.y)) {
                         break;
                     }

--- a/TLM/Benchmarks/SpiralLoopPerfTests.cs
+++ b/TLM/Benchmarks/SpiralLoopPerfTests.cs
@@ -5,7 +5,9 @@ using UnityEngine;
 
 namespace Benchmarks {
     public class SpiralLoopPerfTests {
-        private readonly Vector2[] spiralCacheRadius17 = LoopUtil.GenerateSpiralGridCoordsClockwise(17).ToArray();
+        private readonly Vector2[] spiralCacheRadius17 = LoopUtil.GenerateSpiralGridCoordsClockwise()
+            .Take(17 * 17)
+            .ToArray();
 
         [Benchmark]
         public void SpiralLoop_Once_Radius17() {
@@ -90,7 +92,7 @@ namespace Benchmarks {
                 return true;
             }
 
-            foreach (var position in LoopUtil.GenerateSpiralGridCoordsClockwise(radius)) {
+            foreach (var position in LoopUtil.GenerateSpiralGridCoordsClockwise().Take(radius * radius)) {
                 var positionWithOffset = position + new Vector2(centerI, centerJ);
                 if (LoopHandler((int)positionWithOffset.x, (int)positionWithOffset.y)) {
                     break;
@@ -232,7 +234,7 @@ namespace Benchmarks {
                     return true;
                 }
 
-                foreach (var position in LoopUtil.GenerateSpiralGridCoordsClockwise(radius)) {
+                foreach (var position in LoopUtil.GenerateSpiralGridCoordsClockwise().Take(radius * radius)) {
                     var positionWithOffset = position + new Vector2(centerI, centerJ);
                     if (LoopHandler((int)positionWithOffset.x, (int)positionWithOffset.y)) {
                         break;

--- a/TLM/TLM/Manager/Impl/AdvancedParkingManager.cs
+++ b/TLM/TLM/Manager/Impl/AdvancedParkingManager.cs
@@ -15,24 +15,18 @@ namespace TrafficManager.Manager.Impl {
     using TrafficManager.UI;
     using TrafficManager.Util;
     using UnityEngine;
-    using System.Linq;
 
     public class AdvancedParkingManager
         : AbstractFeatureManager,
           IAdvancedParkingManager
     {
-        private readonly Vector2[] _spiralGridCoordsCache;
+        private readonly Spiral _spiral;
 
-        public static readonly AdvancedParkingManager Instance = new AdvancedParkingManager();
+        public static readonly AdvancedParkingManager Instance
+            = new AdvancedParkingManager(SingletonLite<Spiral>.instance);
 
-        public AdvancedParkingManager() {
-            var radius = Math.Max(
-                1,
-                (int)(GlobalConfig.Instance.ParkingAI.MaxParkedCarDistanceToBuilding / (BuildingManager.BUILDINGGRID_CELL_SIZE / 2f)) + 1);
-
-            _spiralGridCoordsCache = LoopUtil.GenerateSpiralGridCoordsClockwise()
-                .Take(radius * radius)
-                .ToArray();
+        public AdvancedParkingManager(Spiral spiral) {
+            _spiral = spiral ?? throw new ArgumentNullException(nameof(spiral));
         }
 
         protected override void OnDisableFeatureInternal() {
@@ -2466,9 +2460,9 @@ namespace TrafficManager.Manager.Impl {
                 return true;
             }
 
+            var coords = _spiral.GetCoords(radius);
             for (int i = 0; i < radius * radius; i++) {
-                var coords = _spiralGridCoordsCache[i];
-                if (!LoopHandler((int)(centerI + coords.x), (int)(centerJ + coords.y))) {
+                if (!LoopHandler((int)(centerI + coords[i].x), (int)(centerJ + coords[i].y))) {
                     break;
                 }
             }
@@ -2575,9 +2569,9 @@ namespace TrafficManager.Manager.Impl {
                 return true;
             }
 
+            var coords = _spiral.GetCoords(radius);
             for (int i = 0; i < radius * radius; i++) {
-                var coords = _spiralGridCoordsCache[i];
-                if (!LoopHandler((int)(centerI + coords.x), (int)(centerJ + coords.y))) {
+                if (!LoopHandler((int)(centerI + coords[i].x), (int)(centerJ + coords[i].y))) {
                     break;
                 }
             }

--- a/TLM/TLM/Manager/Impl/AdvancedParkingManager.cs
+++ b/TLM/TLM/Manager/Impl/AdvancedParkingManager.cs
@@ -30,7 +30,9 @@ namespace TrafficManager.Manager.Impl {
                 1,
                 (int)(GlobalConfig.Instance.ParkingAI.MaxParkedCarDistanceToBuilding / (BuildingManager.BUILDINGGRID_CELL_SIZE / 2f)) + 1);
 
-            _spiralGridCoordsCache = LoopUtil.GenerateSpiralGridCoordsClockwise(radius).ToArray();
+            _spiralGridCoordsCache = LoopUtil.GenerateSpiralGridCoordsClockwise()
+                .Take(radius * radius)
+                .ToArray();
         }
 
         protected override void OnDisableFeatureInternal() {
@@ -2464,7 +2466,7 @@ namespace TrafficManager.Manager.Impl {
                 return true;
             }
 
-            for (int i = 0; i < _spiralGridCoordsCache.Length; i++) {
+            for (int i = 0; i < radius * radius; i++) {
                 var coords = _spiralGridCoordsCache[i];
                 if (!LoopHandler((int)(centerI + coords.x), (int)(centerJ + coords.y))) {
                     break;
@@ -2573,7 +2575,7 @@ namespace TrafficManager.Manager.Impl {
                 return true;
             }
 
-            for (int i = 0; i < _spiralGridCoordsCache.Length; i++) {
+            for (int i = 0; i < radius * radius; i++) {
                 var coords = _spiralGridCoordsCache[i];
                 if (!LoopHandler((int)(centerI + coords.x), (int)(centerJ + coords.y))) {
                     break;

--- a/TLM/TLM/Manager/Impl/ExtPathManager.cs
+++ b/TLM/TLM/Manager/Impl/ExtPathManager.cs
@@ -10,14 +10,13 @@ namespace TrafficManager.Manager.Impl {
         : AbstractCustomManager,
           IExtPathManager
     {
-        private readonly Vector2[] _spiralGridCoordsCache;
+        private readonly Spiral _spiral;
 
-        public static readonly ExtPathManager Instance = new ExtPathManager();
+        public static readonly ExtPathManager Instance =
+            new ExtPathManager(SingletonLite<Spiral>.instance);
 
-        private ExtPathManager() {
-            _spiralGridCoordsCache = LoopUtil.GenerateSpiralGridCoordsClockwise()
-                .Take(9)
-                .ToArray();
+        private ExtPathManager(Spiral spiral) {
+            _spiral = spiral ?? throw new ArgumentNullException(nameof(spiral));
         }
 
         public bool FindPathPositionWithSpiralLoop(Vector3 position,
@@ -208,6 +207,8 @@ namespace TrafficManager.Manager.Impl {
             int centerJ = (int)(position.x / NetManager.NODEGRID_CELL_SIZE +
                                 NetManager.NODEGRID_RESOLUTION / 2f);
 
+            int radius = Math.Max(1, (int)(maxDistance / (BuildingManager.BUILDINGGRID_CELL_SIZE / 2f)) + 1);
+
             NetManager netManager = Singleton<NetManager>.instance;
             /*pathPosA.m_segment = 0;
             pathPosA.m_lane = 0;
@@ -350,9 +351,9 @@ namespace TrafficManager.Manager.Impl {
                 return true;
             }
 
-            for (int i = 0; i < _spiralGridCoordsCache.Length; i++) {
-                var coords = _spiralGridCoordsCache[i];
-                if (!FindHelper((int)(centerI + coords.x), (int)(centerJ + coords.y))) {
+            var coords = _spiral.GetCoords(radius);
+            for (int i = 0; i < radius * radius; i++) {
+                if (!FindHelper((int)(centerI + coords[i].x), (int)(centerJ + coords[i].y))) {
                     break;
                 }
             }

--- a/TLM/TLM/Manager/Impl/ExtPathManager.cs
+++ b/TLM/TLM/Manager/Impl/ExtPathManager.cs
@@ -15,8 +15,9 @@ namespace TrafficManager.Manager.Impl {
         public static readonly ExtPathManager Instance = new ExtPathManager();
 
         private ExtPathManager() {
-            var radius = 3;
-            _spiralGridCoordsCache = LoopUtil.GenerateSpiralGridCoordsClockwise(3).ToArray();
+            _spiralGridCoordsCache = LoopUtil.GenerateSpiralGridCoordsClockwise()
+                .Take(9)
+                .ToArray();
         }
 
         public bool FindPathPositionWithSpiralLoop(Vector3 position,

--- a/TLM/TLM/TLM.csproj
+++ b/TLM/TLM/TLM.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -330,6 +330,7 @@
     <Compile Include="UI\TransportDemandViewMode.cs" />
     <Compile Include="UI\UITransportDemand.cs" />
     <Compile Include="Util\AutoTimedTrafficLights.cs" />
+    <Compile Include="Util\Spiral.cs" />
     <Compile Include="Util\Caching\CameraTransformValue.cs" />
     <Compile Include="Util\Caching\GenericArrayCache.cs" />
     <Compile Include="Util\GenericFsm.cs" />

--- a/TLM/TLM/Util/LoopUtil.cs
+++ b/TLM/TLM/Util/LoopUtil.cs
@@ -46,11 +46,10 @@ namespace TrafficManager.Util {
         }
 
         /// <summary>
-        /// Generates a non halting stream of spiral grid coordinates clockwise.
+        /// Generates a stream of spiral grid coordinates clockwise.
         /// </summary>
-        /// <param name="radius">Maximum grid width/height of the spiral.</param>
-        /// <returns>Non halting stream of spiral grid coordinates.</returns>
-        public static IEnumerable<Vector2> GenerateSpiralGridCoordsClockwise(int radius) {
+        /// <returns>Stream of spiral grid coordinates until int.MaxValue + 1 elements were returned.</returns>
+        public static IEnumerable<Vector2> GenerateSpiralGridCoordsClockwise() {
             var cursorX = 0;
             var cursorY = 0;
 
@@ -60,8 +59,7 @@ namespace TrafficManager.Util {
             var segmentLength = 1;
             var segmentsPassed = 0;
 
-            var maxSteps = radius * radius;
-            for (var n = 0; n < maxSteps; n++) {
+            for (var n = 0; n <= int.MaxValue; n++) {
                 yield return new Vector2(cursorX, cursorY);
 
                 cursorX += directionX;

--- a/TLM/TLM/Util/Spiral.cs
+++ b/TLM/TLM/Util/Spiral.cs
@@ -1,0 +1,80 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using UnityEngine;
+
+namespace TrafficManager.Util {
+    /// <summary>
+    /// A spiral coords generator that will cache all previously generated values,
+    /// and only generate new ones if necessary.
+    /// </summary>
+    public class Spiral {
+        private readonly string radiusOutOfRangeMessage = "Must be in the range [1,int.MaxValue]";
+
+        private int _maxRadius;
+        private IEnumerator<Vector2> _enumerator;
+        private List<Vector2> _spiralCoords;
+        private ReadOnlyCollection<Vector2> _spiralCoordsReadOnly;
+
+        /// <summary>
+        /// A spiral coords generator that will cache all previously generated values,
+        /// and only generate new ones if necessary.
+        /// </summary>
+        /// <param name="radius">Radius to start with.</param>
+        public Spiral(int radius) {
+            if (radius < 1) {
+                throw new ArgumentOutOfRangeException(nameof(radius), radiusOutOfRangeMessage);
+            }
+
+            _maxRadius = 0;
+            _enumerator = LoopUtil.GenerateSpiralGridCoordsClockwise()
+                .GetEnumerator();
+            _spiralCoords = new List<Vector2>(radius * radius);
+            _spiralCoordsReadOnly = new ReadOnlyCollection<Vector2>(_spiralCoords);
+
+            Ensure(radius);
+        }
+
+        /// <summary>
+        /// The largest radius the object was ever passed.
+        /// </summary>
+        public int MaxRadius => _maxRadius;
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="radius">Needed radius of the spiral.</param>
+        /// <returns>
+        /// Returns a readonly collection of spiral coords.
+        /// The result won't generate a new collection for performance reasons,
+        /// meaning it will return a reference to the same mutable underlying collection.
+        /// The returned collection will always contain the coords for 'MaxRadius',
+        /// the largest radius it was ever passed.
+        /// </returns>
+        public ReadOnlyCollection<Vector2> GetCoords(int radius) {
+            if (radius < 1) {
+                throw new ArgumentOutOfRangeException(nameof(radius), radiusOutOfRangeMessage);
+            }
+
+            Ensure(radius);
+            return _spiralCoordsReadOnly;
+        }
+
+        private void Ensure(int radius) {
+            if (radius <= _maxRadius) {
+                return;
+            }
+
+            var enumerateCount = radius * radius;
+            _spiralCoords.Capacity = enumerateCount;
+            for (int i = _spiralCoords.Count; i < enumerateCount; i++) {
+                var hasNext = _enumerator.MoveNext();
+                if (hasNext) {
+                    _spiralCoords.Add(_enumerator.Current);
+                }
+            }
+
+            _maxRadius = radius;
+        }
+    }
+}

--- a/TLM/TLM/Util/Spiral.cs
+++ b/TLM/TLM/Util/Spiral.cs
@@ -17,6 +17,17 @@ namespace TrafficManager.Util {
         private ReadOnlyCollection<Vector2> _spiralCoordsReadOnly;
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="Spiral"/> class.
+        /// A spiral coords generator that will cache all previously generated values,
+        /// and only generate new ones if necessary.
+        /// It will be initialized with a radius of 9.
+        /// </summary>
+        public Spiral()
+            : this(9) {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Spiral"/> class.
         /// A spiral coords generator that will cache all previously generated values,
         /// and only generate new ones if necessary.
         /// </summary>
@@ -36,16 +47,16 @@ namespace TrafficManager.Util {
         }
 
         /// <summary>
-        /// The largest radius the object was ever passed.
+        /// Gets the largest radius the object was ever passed.
         /// </summary>
         public int MaxRadius => _maxRadius;
 
         /// <summary>
-        /// 
+        /// Gets spiral coords and ensures that the given radius is satisfied.
         /// </summary>
-        /// <param name="radius">Needed radius of the spiral.</param>
+        /// <param name="radius">Needed radius for the spiral coords.</param>
         /// <returns>
-        /// Returns a readonly collection of spiral coords.
+        /// A readonly collection of spiral coords.
         /// The result won't generate a new collection for performance reasons,
         /// meaning it will return a reference to the same mutable underlying collection.
         /// The returned collection will always contain the coords for 'MaxRadius',

--- a/TLM/TMPE.UnitTest/TMPE.UnitTest.csproj
+++ b/TLM/TMPE.UnitTest/TMPE.UnitTest.csproj
@@ -97,6 +97,7 @@
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Translation\CsvParser.cs" />
+    <Compile Include="Util\SpiralTests.cs" />
     <Compile Include="Util\LoopUtilTests.cs" />
     <Compile Include="Util\TinyDictionaryUnitTest.cs" />
   </ItemGroup>

--- a/TLM/TMPE.UnitTest/Util/LoopUtilTests.cs
+++ b/TLM/TMPE.UnitTest/Util/LoopUtilTests.cs
@@ -17,7 +17,8 @@ namespace TMUnitTest.Util {
                 return true;
             });
 
-            var actual = LoopUtil.GenerateSpiralGridCoordsClockwise(radius)
+            var actual = LoopUtil.GenerateSpiralGridCoordsClockwise()
+                .Take(radius * radius)
                 .ToList();
 
             CollectionAssert.AreEqual(expected, actual);
@@ -33,7 +34,8 @@ namespace TMUnitTest.Util {
                 return true;
             });
 
-            var actual = LoopUtil.GenerateSpiralGridCoordsClockwise(radius)
+            var actual = LoopUtil.GenerateSpiralGridCoordsClockwise()
+                .Take(radius * radius)
                 .ToList();
 
             CollectionAssert.AreEqual(expected, actual);
@@ -49,7 +51,8 @@ namespace TMUnitTest.Util {
                 return true;
             });
 
-            var actual = LoopUtil.GenerateSpiralGridCoordsClockwise(radius)
+            var actual = LoopUtil.GenerateSpiralGridCoordsClockwise()
+                .Take(radius * radius)
                 .ToList();
 
             CollectionAssert.AreEqual(expected, actual);
@@ -66,7 +69,8 @@ namespace TMUnitTest.Util {
                 return true;
             });
 
-            var actual = LoopUtil.GenerateSpiralGridCoordsClockwise(radius)
+            var actual = LoopUtil.GenerateSpiralGridCoordsClockwise()
+                .Take(radius * radius)
                 .Select(p => p + new Vector2((int)offset.x, (int)offset.y))
                 .ToList();
 
@@ -88,7 +92,7 @@ namespace TMUnitTest.Util {
             });
 
             var actual = new List<Vector2>();
-            foreach (var item in LoopUtil.GenerateSpiralGridCoordsClockwise(radius)) {
+            foreach (var item in LoopUtil.GenerateSpiralGridCoordsClockwise().Take(radius * radius)) {
                 if (item.x == 4) {
                     break;
                 }

--- a/TLM/TMPE.UnitTest/Util/SpiralTests.cs
+++ b/TLM/TMPE.UnitTest/Util/SpiralTests.cs
@@ -1,0 +1,117 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using TrafficManager.Util;
+using UnityEngine;
+
+namespace TMUnitTest.Util {
+    [TestClass]
+    public class SpiralTests {
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentOutOfRangeException))]
+        public void Constructor_RadiusOutOfRange_Should_ThrowException() {
+            _ = new Spiral(0);
+        }
+
+        [TestMethod]
+        public void Constructor_Radius1_Should_Generate1SpiralCoords() {
+            var initialRadius = 1;
+            var expectedSpiralCoordsCount = initialRadius * initialRadius;
+
+            var cachedSpiral = new Spiral(initialRadius);
+
+            Assert.AreEqual(expectedSpiralCoordsCount, cachedSpiral.GetCoords(initialRadius).Count);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentOutOfRangeException))]
+        public void GetSpiralCoords_RadiusOutOfRange_Should_ThrowException() {
+            var spiral = new Spiral(1);
+            spiral.GetCoords(-1);
+        }
+
+        [TestMethod]
+        public void GetSpiralCoords_Should_IncreaseIfRadiusLargerInitialRadius() {
+            var initialRadius = 1;
+            var newRadius = 5;
+            var expectedSpiralCoordsCount = newRadius * newRadius;
+
+            var cachedSpiral = new Spiral(initialRadius);
+
+            Assert.AreEqual(expectedSpiralCoordsCount, cachedSpiral.GetCoords(newRadius).Count);
+        }
+
+        [TestMethod]
+        public void GetSpiralCoords_Should_BeCorrectAfterEachTime() {
+            var initialRadius = 1;
+            var initialRadiusExpectedResult = new ReadOnlyCollection<Vector2>(
+                new List<Vector2>() { new Vector2(0, 0) }
+            );
+
+            var firstRadiusIncrease = 2;
+            var firstRadiusIncreaseExpectedResult = new ReadOnlyCollection<Vector2>(
+                new List<Vector2>() {
+                    new Vector2(0, 0),
+                    new Vector2(1, 0),
+                    new Vector2(1, 1),
+                    new Vector2(0, 1),
+                }
+            );
+
+            var secondRadiusIncrease = 3;
+            var secondRadiusIncreaseExpectedResult = new ReadOnlyCollection<Vector2>(
+                new List<Vector2>() {
+                    new Vector2(0, 0),
+                    new Vector2(1, 0),
+                    new Vector2(1, 1),
+                    new Vector2(0, 1),
+                    new Vector2(-1, 1),
+                    new Vector2(-1, 0),
+                    new Vector2(-1, -1),
+                    new Vector2(0, -1),
+                    new Vector2(1, -1),
+                }
+            );
+
+            var cachedSpiral = new Spiral(initialRadius);
+            var initialRadiusActualResult = cachedSpiral.GetCoords(initialRadius);
+            CollectionAssert.AreEqual(initialRadiusExpectedResult, initialRadiusActualResult);
+
+            var firstRadiusIncreaseActualResult = cachedSpiral.GetCoords(firstRadiusIncrease);
+            CollectionAssert.AreEqual(firstRadiusIncreaseExpectedResult, firstRadiusIncreaseActualResult);
+
+            var secondRadiusIncreaseActualResult = cachedSpiral.GetCoords(secondRadiusIncrease);
+            CollectionAssert.AreEqual(secondRadiusIncreaseExpectedResult, secondRadiusIncreaseActualResult);
+        }
+
+        [TestMethod]
+        public void GetSpiralCoords_Should_ShareTheResult() {
+            var initialRadius = 1;
+            var firstRadiusIncrease = 2;
+            var secondRadiusIncrease = 3;
+            var sharedExpectedResult = new ReadOnlyCollection<Vector2>(
+                new List<Vector2>() {
+                    new Vector2(0, 0),
+                    new Vector2(1, 0),
+                    new Vector2(1, 1),
+                    new Vector2(0, 1),
+                    new Vector2(-1, 1),
+                    new Vector2(-1, 0),
+                    new Vector2(-1, -1),
+                    new Vector2(0, -1),
+                    new Vector2(1, -1),
+                }
+            );
+
+            var cachedSpiral = new Spiral(initialRadius);
+            var initialRadiusActualResult = cachedSpiral.GetCoords(initialRadius);
+            var firstRadiusIncreaseActualResult = cachedSpiral.GetCoords(firstRadiusIncrease);
+            var secondRadiusIncreaseActualResult = cachedSpiral.GetCoords(secondRadiusIncrease);
+
+            CollectionAssert.AreEqual(sharedExpectedResult, initialRadiusActualResult);
+            CollectionAssert.AreEqual(sharedExpectedResult, firstRadiusIncreaseActualResult);
+            CollectionAssert.AreEqual(sharedExpectedResult, secondRadiusIncreaseActualResult);
+        }
+    }
+}


### PR DESCRIPTION
A crap .. forgot to squash.

- Make the GenerateSpiralGridCoordsClockwise stream until int.MaxValue + 1 elements were returned.
- Added caching, zero allocation implementation of spiral coords and tests.
- Provided a default constructor so that it can be used as singleton.
- Used a hybrid approach of proper DI and singleton to ensure that both Managers get the same Spiral instance.
- Adjusted iteration inside Managers to use the non allocating Spiral method.
