### PR TITLE
place intersection event

### DIFF
--- a/TLM/SharedAssemblyInfo.cs
+++ b/TLM/SharedAssemblyInfo.cs
@@ -20,4 +20,4 @@ using System.Runtime.InteropServices;
 //      Minor Version
 //      Build Number
 //      Revision
-[assembly: AssemblyVersion("11.5.1.*")]
+[assembly: AssemblyVersion("11.5.3.*")]

--- a/TLM/TLM/Util/PlaceIntersectionUtil.cs
+++ b/TLM/TLM/Util/PlaceIntersectionUtil.cs
@@ -21,12 +21,13 @@ namespace TrafficManager.Util {
             }
         }
 
-        public delegate void Handler(Dictionary<InstanceID, InstanceID> map);
+        public delegate void Handler(BuildingInfo info, Dictionary<InstanceID, InstanceID> map);
 
         /// <summary>
-        /// invoked when networkIDs are mapped and provides the user with dictionary of oldNetworkIds->newNetworkIds
+        /// invoked when networkIDs are mapped and pre-calculated.
+        /// provides the user with dictionary of oldNetworkIds->newNetworkIds
         /// </summary>
-        public static event Handler OnNetworksMapped;
+        public static event Handler OnPlaceIntersection;
 
         /// <summary>
         /// start mapping for <paramref name="intersectionInfo"/>
@@ -72,6 +73,8 @@ namespace TrafficManager.Util {
                 CalculateNetwork(item.Value);
 
             assetData.Record.Transfer(map);
+
+            OnPlaceIntersection?.Invoke(intersectionInfo, map);
         }
 
         /// <summary>


### PR DESCRIPTION
In my last commit, I forgot to call the event after placing asset. The event is useful for TMPE addons to save a ton of code storing and patching to create a map of "old instance IDs"->"new Instance IDs"

bumped version.build

TMPE ZIP:
 https://ci.appveyor.com/api/projects/krzychu124/tmpe/artifacts/TMPE.zip?branch=place-intersection-event