### PR TITLE
Removed ProcessBuilding method that used a closure.

### DIFF
--- a/TLM/TLM/Manager/Impl/RoutingManager.cs
+++ b/TLM/TLM/Manager/Impl/RoutingManager.cs
@@ -11,6 +11,7 @@ namespace TrafficManager.Manager.Impl {
     using TrafficManager.API.Traffic.Enums;
     using TrafficManager.State.ConfigData;
     using TrafficManager.State;
+    using TrafficManager.Util;
 
     public class RoutingManager
         : AbstractGeometryObservingManager,
@@ -470,15 +471,8 @@ namespace TrafficManager.Manager.Impl {
                     return true;
                 });
 
-            bool isTollBooth = false;
-            if (buildingId != 0) {
-                Constants.ServiceFactory.BuildingService.ProcessBuilding(
-                    buildingId,
-                    (ushort bId, ref Building building) => {
-                        isTollBooth = building.Info.m_buildingAI is TollBoothAI;
-                        return true;
-                    });
-            }
+            bool isTollBooth = buildingId != 0
+                && buildingId.ToBuilding().Info.m_buildingAI is TollBoothAI;
 
             bool nextIsSimpleJunction = false;
             bool nextIsSplitJunction = false;

--- a/TLM/TLM/Util/Shortcuts.cs
+++ b/TLM/TLM/Util/Shortcuts.cs
@@ -48,6 +48,8 @@ namespace TrafficManager.Util {
 
         private static NetLane[] _laneBuffer = Singleton<NetManager>.instance.m_lanes.m_buffer;
 
+        private static Building[] _buildingBuffer = Singleton<BuildingManager>.instance.m_buildings.m_buffer;
+
         private static ExtSegmentEnd[] _segEndBuff => segEndMan.ExtSegmentEnds;
 
         internal static IExtSegmentEndManager segEndMan => Constants.ManagerFactory.ExtSegmentEndManager;
@@ -65,6 +67,8 @@ namespace TrafficManager.Util {
         internal static ref NetSegment GetSeg(ushort segmentId) => ref _segBuffer[segmentId];
 
         internal static ref NetSegment ToSegment(this ushort segmentId) => ref _segBuffer[segmentId];
+
+        internal static ref Building ToBuilding(this ushort buildingId) => ref _buildingBuffer[buildingId];
 
         internal static NetInfo.Lane GetLaneInfo(ushort segmentId, int laneIndex) =>
             segmentId.ToSegment().Info.m_lanes[laneIndex];

--- a/TLM/TMPE.CitiesGameBridge/Service/BuildingService.cs
+++ b/TLM/TMPE.CitiesGameBridge/Service/BuildingService.cs
@@ -39,11 +39,5 @@ namespace CitiesGameBridge.Service {
 
             return expectedResult == null ? result != 0 : result == expectedResult;
         }
-
-        public void ProcessBuilding(ushort buildingId, BuildingHandler handler) {
-            handler(
-                buildingId,
-                ref Singleton<BuildingManager>.instance.m_buildings.m_buffer[buildingId]);
-        }
     }
 }

--- a/TLM/TMPE.GenericGameBridge/Service/IBuildingService.cs
+++ b/TLM/TMPE.GenericGameBridge/Service/IBuildingService.cs
@@ -1,13 +1,9 @@
 namespace GenericGameBridge.Service {
-    public delegate bool BuildingHandler(ushort buildingId, ref Building building);
-
     public interface IBuildingService {
         bool CheckBuildingFlags(ushort buildingId,
                                 Building.Flags flagMask,
                                 Building.Flags? expectedResult = default);
 
         bool IsBuildingValid(ushort buildingId);
-
-        void ProcessBuilding(ushort buildingId, BuildingHandler handler);
     }
 }


### PR DESCRIPTION
Added ushort.ToBuilding() extension method.
Redirected call of ProcessBuilding to new ushort.ToBuilding() method.
Removed ProcessBuilding method since it used a closure.