### PR TITLE
Monitor.Enter/Exit changes

### DIFF
--- a/TLM/CSUtil.Commons/Log.cs
+++ b/TLM/CSUtil.Commons/Log.cs
@@ -4,6 +4,7 @@ namespace CSUtil.Commons {
     using System.IO;
     using System.Threading;
     using UnityEngine;
+    using Debug = UnityEngine.Debug;
 
 #if !DEBUG
     #if TRACE
@@ -59,7 +60,8 @@ namespace CSUtil.Commons {
                     File.Delete(LogFilename);
                 }
             }
-            catch (Exception) {
+            catch (Exception e) {
+                Debug.LogException(e);
             }
         }
 
@@ -193,9 +195,7 @@ namespace CSUtil.Commons {
         }
 
         private static void LogToFile(string log, LogLevel level) {
-            try {
-                Monitor.Enter(LogLock);
-
+            lock(LogLock){
                 using (StreamWriter w = File.AppendText(LogFilename)) {
                     long secs = _sw.ElapsedTicks / Stopwatch.Frequency;
                     long fraction = _sw.ElapsedTicks % Stopwatch.Frequency;
@@ -209,9 +209,6 @@ namespace CSUtil.Commons {
                         w.WriteLine();
                     }
                 }
-            }
-            finally {
-                Monitor.Exit(LogLock);
             }
         }
     }

--- a/TLM/TLM/Custom/PathFinding/CustomPathManager.cs
+++ b/TLM/TLM/Custom/PathFinding/CustomPathManager.cs
@@ -68,8 +68,7 @@ namespace TrafficManager.Custom.PathFinding {
             Log._Debug("Creating " + numCustomPathFinds + " custom PathFind objects.");
             _replacementPathFinds = new CustomPathFind[numCustomPathFinds];
 
-            try {
-                Monitor.Enter(m_bufferLock);
+            lock(m_bufferLock) {
 
                 for (int i = 0; i < numCustomPathFinds; i++) {
                     _replacementPathFinds[i] = gameObject.AddComponent<CustomPathFind>();
@@ -96,8 +95,6 @@ namespace TrafficManager.Custom.PathFinding {
                     // stockPathFinds[i].WaitForAllPaths();
                     Destroy(stockPathFinds[i]);
                 }
-            } finally {
-                Monitor.Exit(m_bufferLock);
             }
 
             InitDone = true;
@@ -112,8 +109,7 @@ namespace TrafficManager.Custom.PathFinding {
             if (m_pathUnits.m_buffer[unit].m_simulationFlags == 0) {
                 return;
             }
-            try {
-                Monitor.Enter(m_bufferLock);
+            lock(m_bufferLock) {
 
                 int numIters = 0;
                 while (unit != 0u) {
@@ -143,8 +139,6 @@ namespace TrafficManager.Custom.PathFinding {
                 }
 
                 m_pathUnitCount = (int)(m_pathUnits.ItemCount() - 1u);
-            } finally {
-                Monitor.Exit(m_bufferLock);
             }
         }
 
@@ -152,8 +146,7 @@ namespace TrafficManager.Custom.PathFinding {
                                      ref Randomizer randomizer,
                                      PathCreationArgs args) {
             uint pathUnitId;
-            try {
-                Monitor.Enter(m_bufferLock);
+            lock(m_bufferLock) {
 
                 int numIters = 0;
                 while (true) {
@@ -192,9 +185,6 @@ namespace TrafficManager.Custom.PathFinding {
                 // NON-STOCK CODE END
 
                 m_pathUnitCount = (int)(m_pathUnits.ItemCount() - 1u);
-            }
-            finally {
-                Monitor.Exit(m_bufferLock);
             }
 
             unit = pathUnitId;
@@ -269,8 +259,7 @@ namespace TrafficManager.Custom.PathFinding {
 #endif
 
             // NON-STOCK CODE START
-            try {
-                Monitor.Enter(m_bufferLock);
+            lock(m_bufferLock) {
 
                 QueueItems[pathUnitId].queued = false;
                 // NON-STOCK CODE END
@@ -278,9 +267,6 @@ namespace TrafficManager.Custom.PathFinding {
 
                 // NON-STOCK CODE START
                 m_pathUnitCount = (int)(m_pathUnits.ItemCount() - 1u);
-            }
-            finally {
-                Monitor.Exit(m_bufferLock);
             }
 
             // NON-STOCK CODE END

--- a/TLM/TLM/Manager/Impl/GeometryManager.cs
+++ b/TLM/TLM/Manager/Impl/GeometryManager.cs
@@ -70,8 +70,7 @@
                 return;
             }
 
-            try {
-                Monitor.Enter(updateLock);
+            lock(updateLock) {
 
                 bool updatesMissing = onlyFirstPass;
 
@@ -178,8 +177,6 @@
                 }
 
                 stateUpdated = false;
-            } finally {
-                Monitor.Exit(updateLock);
             }
         }
 
@@ -202,8 +199,7 @@
                     $"GeometryManager.MarkAsUpdated(segment {seg.segmentId}): Marking segment as updated");
             }
 #endif
-            try {
-                Monitor.Enter(updateLock);
+            lock(updateLock) {
 
                 updatedSegmentBuckets[seg.segmentId >> 6] |= 1uL << (seg.segmentId & 63);
                 stateUpdated = true;
@@ -218,8 +214,6 @@
                 if (!seg.valid) {
                     SimulationStep(true);
                 }
-            } finally {
-                Monitor.Exit(updateLock);
             }
         }
 
@@ -230,8 +224,7 @@
                     $"GeometryManager.MarkAsUpdated(node {nodeId}): Marking node as updated");
             }
 #endif
-            try {
-                Monitor.Enter(updateLock);
+            lock(updateLock) {
 
                 if (nodeId == 0) {
                     return;
@@ -257,9 +250,6 @@
                     SimulationStep(true);
                 }
             }
-            finally {
-                Monitor.Exit(updateLock);
-            }
         }
 
         public void OnSegmentEndReplacement(SegmentEndReplacement replacement) {
@@ -270,14 +260,9 @@
                     $"{replacement.oldSegmentEndId.SegmentId} -> {replacement.newSegmentEndId.SegmentId}");
             }
 #endif
-            try {
-                Monitor.Enter(updateLock);
-
+            lock(updateLock) {
                 segmentReplacements.Enqueue(replacement);
                 stateUpdated = true;
-            }
-            finally {
-                Monitor.Exit(updateLock);
             }
         }
 

--- a/TLM/TLM/Manager/Impl/RoutingManager.cs
+++ b/TLM/TLM/Manager/Impl/RoutingManager.cs
@@ -107,8 +107,7 @@ namespace TrafficManager.Manager.Impl {
                 return;
             }
 
-            try {
-                Monitor.Enter(updateLock);
+            lock(updateLock) {
                 segmentsUpdated = false;
 
                 int len = updatedSegmentBuckets.Length;
@@ -128,14 +127,10 @@ namespace TrafficManager.Manager.Impl {
                     }
                 }
             }
-            finally {
-                Monitor.Exit(updateLock);
-            }
         }
 
         public void RequestFullRecalculation() {
-            try {
-                Monitor.Enter(updateLock);
+            lock(updateLock) {
 
                 for (uint segmentId = 0; segmentId < NetManager.MAX_SEGMENT_COUNT; ++segmentId) {
                     updatedSegmentBuckets[segmentId >> 6] |= 1uL << (int)(segmentId & 63);
@@ -148,9 +143,6 @@ namespace TrafficManager.Manager.Impl {
                     Services.SimulationService.ForcedSimulationPaused) {
                     SimulationStep();
                 }
-            }
-            finally {
-                Monitor.Exit(updateLock);
             }
         }
 
@@ -166,15 +158,11 @@ namespace TrafficManager.Manager.Impl {
                 Log._Debug($"RoutingManager.RequestRecalculation({segmentId}, {propagate}) called.");
             }
 
-            try {
-                Monitor.Enter(updateLock);
+            lock(updateLock) {
 
                 updatedSegmentBuckets[segmentId >> 6] |= 1uL << (segmentId & 63);
                 ResetIncomingHighwayLaneArrows(segmentId);
                 segmentsUpdated = true;
-            }
-            finally {
-                Monitor.Exit(updateLock);
             }
 
             if (propagate) {

--- a/TLM/TLM/Manager/Impl/UtilityManager.cs
+++ b/TLM/TLM/Manager/Impl/UtilityManager.cs
@@ -16,45 +16,37 @@ namespace TrafficManager.Manager.Impl {
         public static UtilityManager Instance { get; }
 
         public void ClearTraffic() {
-            try {
-                Monitor.Enter(Singleton<VehicleManager>.instance);
-
-                VehicleManager vehicleManager = Singleton<VehicleManager>.instance;
-                for (uint i = 0; i < vehicleManager.m_vehicles.m_size; ++i) {
-                    if ((vehicleManager.m_vehicles.m_buffer[i].m_flags & Vehicle.Flags.Created) != 0) {
-                        vehicleManager.ReleaseVehicle((ushort)i);
+            lock (Singleton<VehicleManager>.instance) {
+                try {
+                    VehicleManager vehicleManager = Singleton<VehicleManager>.instance;
+                    for (uint i = 0; i < vehicleManager.m_vehicles.m_size; ++i) {
+                        if ((vehicleManager.m_vehicles.m_buffer[i].m_flags &
+                             Vehicle.Flags.Created) != 0) {
+                            vehicleManager.ReleaseVehicle((ushort)i);
+                        }
                     }
-                }
 
-                TrafficMeasurementManager.Instance.ResetTrafficStats();
-            }
-            catch (Exception ex) {
-                Log.Error($"Error occured while trying to clear traffic: {ex}");
-            }
-            finally {
-                Monitor.Exit(Singleton<VehicleManager>.instance);
+                    TrafficMeasurementManager.Instance.ResetTrafficStats();
+                } catch (Exception ex) {
+                    Log.Error($"Error occured while trying to clear traffic: {ex}");
+                }
             }
         }
 
         public void RemoveParkedVehicles() {
-            try {
-                Monitor.Enter(Singleton<VehicleManager>.instance);
+            lock (Singleton<VehicleManager>.instance) {
+                try {
+                    VehicleManager vehicleManager = Singleton<VehicleManager>.instance;
 
-                VehicleManager vehicleManager = Singleton<VehicleManager>.instance;
-
-                for (uint i = 0; i < vehicleManager.m_parkedVehicles.m_size; ++i) {
-                    if ((vehicleManager.m_parkedVehicles.m_buffer[i].m_flags &
-                         (ushort)VehicleParked.Flags.Created) != 0)
-                    {
-                        vehicleManager.ReleaseParkedVehicle((ushort)i);
+                    for (uint i = 0; i < vehicleManager.m_parkedVehicles.m_size; ++i) {
+                        if ((vehicleManager.m_parkedVehicles.m_buffer[i].m_flags &
+                             (ushort)VehicleParked.Flags.Created) != 0) {
+                            vehicleManager.ReleaseParkedVehicle((ushort)i);
+                        }
                     }
+                } catch (Exception ex) {
+                    Log.Error($"Error occured while trying to remove parked vehicles: {ex}");
                 }
-            }
-            catch (Exception ex) {
-                Log.Error($"Error occured while trying to remove parked vehicles: {ex}");
-            }
-            finally {
-                Monitor.Exit(Singleton<VehicleManager>.instance);
             }
         }
 

--- a/TLM/TLM/State/Flags.cs
+++ b/TLM/TLM/State/Flags.cs
@@ -530,8 +530,7 @@ namespace TrafficManager.State {
                 return;
             }
 
-            try {
-                Monitor.Enter(laneSpeedLimitLock);
+            lock(laneSpeedLimitLock) {
 #if DEBUGFLAGS
                 Log._Debug(
                     $"Flags.setLaneSpeedLimit: setting speed limit of lane index {laneIndex} @ seg. " +
@@ -565,9 +564,6 @@ namespace TrafficManager.State {
                     // (2) insert the custom speed limit
                     laneSpeedLimitArray[segmentId][laneIndex] = speedLimit;
                 }
-            }
-            finally {
-                Monitor.Exit(laneSpeedLimitLock);
             }
         }
 
@@ -859,8 +855,7 @@ namespace TrafficManager.State {
         }
 
         public static float? GetLaneSpeedLimit(uint laneId) {
-            try {
-                Monitor.Enter(laneSpeedLimitLock);
+            lock(laneSpeedLimitLock) {
 
                 if (laneId <= 0 || !laneSpeedLimit.TryGetValue(laneId, out float speedLimit)) {
                     return null;
@@ -868,20 +863,12 @@ namespace TrafficManager.State {
 
                 return speedLimit;
             }
-            finally {
-                Monitor.Exit(laneSpeedLimitLock);
-            }
         }
 
         internal static IDictionary<uint, float> GetAllLaneSpeedLimits() {
-            IDictionary<uint, float> ret = new Dictionary<uint, float>();
-            try {
-                Monitor.Enter(laneSpeedLimitLock);
-
+            IDictionary<uint, float> ret;
+            lock(laneSpeedLimitLock) {
                 ret = new Dictionary<uint, float>(laneSpeedLimit);
-            }
-            finally {
-                Monitor.Exit(laneSpeedLimitLock);
             }
 
             return ret;
@@ -1074,17 +1061,13 @@ namespace TrafficManager.State {
         }
 
         public static void ResetSpeedLimits() {
-            try {
-                Monitor.Enter(laneSpeedLimitLock);
+            lock(laneSpeedLimitLock) {
                 laneSpeedLimit.Clear();
 
                 uint segmentsCount = Singleton<NetManager>.instance.m_segments.m_size;
                 for (int i = 0; i < segmentsCount; ++i) {
                     laneSpeedLimitArray[i] = null;
                 }
-            }
-            finally {
-                Monitor.Exit(laneSpeedLimitLock);
             }
         }
 
@@ -1097,12 +1080,8 @@ namespace TrafficManager.State {
                 laneSpeedLimitArray[i] = null;
             }
 
-            try {
-                Monitor.Enter(laneSpeedLimitLock);
+            lock(laneSpeedLimitLock) {
                 laneSpeedLimit.Clear();
-            }
-            finally {
-                Monitor.Exit(laneSpeedLimitLock);
             }
 
             for (uint i = 0; i < laneAllowedVehicleTypesArray.Length; ++i) {

--- a/TLM/TLM/TrafficLight/Impl/TimedTrafficLights.cs
+++ b/TLM/TLM/TrafficLight/Impl/TimedTrafficLights.cs
@@ -156,8 +156,7 @@ namespace TrafficManager.TrafficLight.Impl {
 
             Stop();
 
-            try {
-                Monitor.Enter(rotateLock_);
+            lock(rotateLock_) {
 
                 Log._Debug($"TimedTrafficLights.Rotate({dir}) @ node {NodeId}: Rotating timed traffic light.");
 
@@ -247,8 +246,6 @@ namespace TrafficManager.TrafficLight.Impl {
 
                 CurrentStep = 0;
                 SetLights(true);
-            } finally {
-                Monitor.Exit(rotateLock_);
             }
         }
 

--- a/TLM/TLM/Util/GenericUnsubscriber.cs
+++ b/TLM/TLM/Util/GenericUnsubscriber.cs
@@ -22,12 +22,8 @@
                 return;
             }
 
-            try {
-                Monitor.Enter(lck_);
+            lock(lck_) {
                 observers_.Remove(observer_);
-            }
-            finally {
-                Monitor.Exit(lck_);
             }
         }
     }


### PR DESCRIPTION
It was suspicious, seem to help with crashing/sim lock when the mod is running on the Linux OS(#817)

Replaced `Monitor.Enter(<lock_obj>)/Exit` with `lock(<lock_obj>){ }`