### PR TITLE
cleaning up life cycle code

### DIFF
--- a/TLM/TLM/LoadingExtension.cs
+++ b/TLM/TLM/LoadingExtension.cs
@@ -19,6 +19,10 @@ namespace TrafficManager {
 
     [UsedImplicitly]
     public class LoadingExtension : LoadingExtensionBase {
+        static LoadingExtension() {
+            TranslationDatabase.LoadAllTranslations();
+        }
+
         static FastList<ISimulationManager> simManager =>
             typeof(SimulationManager).GetField("m_managers", BindingFlags.Static | BindingFlags.NonPublic)
                 ?.GetValue(null) as FastList<ISimulationManager>;
@@ -148,7 +152,6 @@ namespace TrafficManager {
             if(Scene == "ThemeEditor")
                 return;
 
-            TranslationDatabase.LoadAllTranslations();
             InGameUtil.Instantiate();
 
             RegisteredManagers = new List<ICustomManager>();

--- a/TLM/TLM/Patcher.cs
+++ b/TLM/TLM/Patcher.cs
@@ -9,20 +9,10 @@ namespace TrafficManager {
     using TrafficManager.RedirectionFramework;
     using TrafficManager.Util;
 
-    public class Patcher {
-        public static Patcher Instance { get; private set; }
-
-        public static Patcher Create() => Instance = new Patcher();
-
+    public static class Patcher {
         private const string HARMONY_ID = "de.viathinksoft.tmpe";
 
-        private bool initialized_ = false;
-
-        public void Install() {
-            if (initialized_) {
-                return;
-            }
-
+        public static void Install() {
             Log.Info("Init detours");
             bool fail = false;
 
@@ -71,20 +61,13 @@ namespace TrafficManager {
             } else {
                 Log.Info("Detours successful");
             }
-
-            initialized_ = true;
         }
 
-        public void Uninstall() {
-            if (!initialized_) {
-                return;
-            }
-
+        public static void Uninstall() {
             var harmony = new Harmony(HARMONY_ID);
             Shortcuts.Assert(harmony != null, "HarmonyInst!=null");
             harmony.UnpatchAll(HARMONY_ID);
 
-            initialized_ = false;
             Log.Info("Reverting detours finished.");
         }
     }

--- a/TLM/TLM/Patcher.cs
+++ b/TLM/TLM/Patcher.cs
@@ -21,10 +21,8 @@ namespace TrafficManager {
                 Harmony.DEBUG = true;
 #endif
                 // Harmony attribute-driven patching
-                Log.Info($"Performing Harmony attribute-driven patching");
-                var harmony = new Harmony(HARMONY_ID);
-                Shortcuts.Assert(harmony != null, "HarmonyInst!=null");
-                harmony.PatchAll();
+                Log.Info($"Performing Harmony attribute-driven patches");
+                new Harmony(HARMONY_ID).PatchAll();
                 Log.Info($"Harmony attribute-driven patching successfull!");
             }
             catch (Exception e) {
@@ -46,29 +44,24 @@ namespace TrafficManager {
             }
 
             if (fail) {
-                Log.Info("Detours failed");
-                Singleton<SimulationManager>.instance.m_ThreadingWrapper.QueueMainThread(
-                    () => {
-                        UIView.library
-                              .ShowModal<ExceptionPanel>("ExceptionPanel")
-                              .SetMessage(
-                                "TM:PE failed to load",
-                                "Traffic Manager: President Edition failed to load. You can " +
-                                "continue playing but it's NOT recommended. Traffic Manager will " +
-                                "not work as expected.",
-                                true);
-                    });
+                Log.Info("patcher failed");
+                UIView.library
+                        .ShowModal<ExceptionPanel>("ExceptionPanel")
+                        .SetMessage(
+                        "TM:PE failed to load",
+                        "Traffic Manager: President Edition failed to load. You can " +
+                        "continue playing but it's NOT recommended. Traffic Manager will " +
+                        "not work as expected.",
+                        true);
             } else {
-                Log.Info("Detours successful");
+                Log.Info("TMPE patches installed successfully");
             }
         }
 
         public static void Uninstall() {
-            var harmony = new Harmony(HARMONY_ID);
-            Shortcuts.Assert(harmony != null, "HarmonyInst!=null");
-            harmony.UnpatchAll(HARMONY_ID);
-
-            Log.Info("Reverting detours finished.");
+            new Harmony(HARMONY_ID).UnpatchAll(HARMONY_ID);
+            AssemblyRedirector.Revert();
+            Log.Info("TMPE patches uninstalled.");
         }
     }
 }

--- a/TLM/TLM/State/Options.cs
+++ b/TLM/TLM/State/Options.cs
@@ -132,7 +132,7 @@ namespace TrafficManager.State {
             }
         }
 
-        public static void MakeSettings(UIHelperBase helper) {
+        public static void MakeSettings(UIHelper helper) {
             ExtUITabstrip tabStrip = ExtUITabstrip.Create(helper);
             OptionsGeneralTab.MakeSettings_General(tabStrip);
             OptionsGameplayTab.MakeSettings_Gameplay(tabStrip);

--- a/TLM/TLM/State/SerializableDataExtension.cs
+++ b/TLM/TLM/State/SerializableDataExtension.cs
@@ -15,28 +15,14 @@ namespace TrafficManager.State {
     {
         private const string DATA_ID = "TrafficManager_v1.0";
 
-        private static ISerializableData _serializableData;
+        private static ISerializableData SerializableData => SimulationManager.instance.m_SerializableDataWrapper;
         private static Configuration _configuration;
         public static bool StateLoading;
 
-        public override void OnCreated(ISerializableData serializableData) {
-            Log._Debug("SerializableDataExtension.OnCreated() called");
-            if(LoadingExtension.IsGameLoaded) {
-                Log._Debug("Hot reload of another mod detected. Skipping SerializableDataExtension.OnCreated() ...");
-                return;
-            }
-            _serializableData = serializableData;
+        public override void OnLoadData() => Load();
+        public override void OnSaveData() => Save();
 
-            if (TrafficManagerMod.Instance.InGameHotReload) {
-                Log._Debug("HOT RELOAD ...");
-                OnLoadData();
-                LoadingExtension.Instance.OnLevelLoaded(LoadMode.LoadGame);
-            }
-        }
-
-        public override void OnReleased() { }
-
-        public override void OnLoadData() {
+        public static void Load() { 
             Log.Info("Loading Traffic Manager: PE Data");
             StateLoading = true;
             bool loadingSucceeded = true;
@@ -64,7 +50,7 @@ namespace TrafficManager.State {
             Log.Info("Initialization done. Loading mod data now.");
 
             try {
-                byte[] data = _serializableData.LoadData(DATA_ID);
+                byte[] data = SerializableData.LoadData(DATA_ID);
                 DeserializeData(data);
             }
             catch (Exception e) {
@@ -74,7 +60,7 @@ namespace TrafficManager.State {
 
             // load options
             try {
-                byte[] options = _serializableData.LoadData("TMPE_Options");
+                byte[] options = SerializableData.LoadData("TMPE_Options");
                 if (options != null) {
                     if (!OptionsManager.Instance.LoadData(options)) {
                         loadingSucceeded = false;
@@ -288,7 +274,7 @@ namespace TrafficManager.State {
             }
         }
 
-        public override void OnSaveData() {
+        public static void Save() { 
             bool success = true;
 
             // try {
@@ -369,7 +355,7 @@ namespace TrafficManager.State {
 
                 try {
                     // save options
-                    _serializableData.SaveData("TMPE_Options", OptionsManager.Instance.SaveData(ref success));
+                    SerializableData.SaveData("TMPE_Options", OptionsManager.Instance.SaveData(ref success));
                 } catch (Exception ex) {
                     Log.Error("Unexpected error while saving options: " + ex.Message);
                     success = false;
@@ -382,7 +368,7 @@ namespace TrafficManager.State {
                     binaryFormatter.Serialize(memoryStream, configuration);
                     memoryStream.Position = 0;
                     Log.Info($"Save data byte length {memoryStream.Length}");
-                    _serializableData.SaveData(DATA_ID, memoryStream.ToArray());
+                    SerializableData.SaveData(DATA_ID, memoryStream.ToArray());
                 } catch (Exception ex) {
                     Log.Error("Unexpected error while saving data: " + ex);
                     success = false;

--- a/TLM/TLM/TrafficManagerMod.cs
+++ b/TLM/TLM/TrafficManagerMod.cs
@@ -125,7 +125,7 @@ namespace TrafficManager {
         }
 
         [UsedImplicitly]
-        public void OnSettingsUI(UIHelperBase helper) {
+        public void OnSettingsUI(UIHelper helper) {
             // Note: This bugs out if done in OnEnabled(), hence doing it here instead.
             if (!Translation.IsListeningToGameLocaleChanged) {
                 Translation.IsListeningToGameLocaleChanged = true;

--- a/TLM/TLM/UI/Helpers/ExtUITabStrip.cs
+++ b/TLM/TLM/UI/Helpers/ExtUITabStrip.cs
@@ -104,9 +104,8 @@ namespace TrafficManager.UI.Helpers {
             return panelHelper;
         }
 
-        public static ExtUITabstrip Create(UIHelperBase helperBase) {
-            UIHelper actualHelper = helperBase as UIHelper;
-            UIComponent optionsContainer = actualHelper.self as UIComponent;
+        public static ExtUITabstrip Create(UIHelper helper) {
+            UIComponent optionsContainer = helper.self as UIComponent;
             float orgOptsContainerWidth = optionsContainer.height;
             float orgOptsContainerHeight = optionsContainer.width;
 

--- a/TLM/TLM/UI/MainMenu/MainMenuWindow.cs
+++ b/TLM/TLM/UI/MainMenu/MainMenuWindow.cs
@@ -372,8 +372,7 @@ namespace TrafficManager.UI.MainMenu {
                 }
             }
 
-            // Hot Reload version label (debug only)
-            if (TrafficManagerMod.Instance.InGameHotReload) {
+            if (TrafficManagerMod.InGameHotReload) {
                 // Hot Reload version label (debug only)
                 string text = $"HOT RELOAD {Assembly.GetExecutingAssembly().GetName().Version}";
                 using (var hotReloadB = builder.Label<U.ULabel>(text)) {


### PR DESCRIPTION
related: #767
#### Intro: 
CS recreates all ILoadingExtensions/ISerializableDataExtensions for ALL mods any time ANY mod is hot-swapped. therefore it is a bad idea to rely on a particular instance of such classes. Also, OnCreated/OnRelease are not meaningful. 

#### changes:
- polished life cycle code a bit.
- Removed OnCreated() and release(). 
- also made everything in lifecycle classes static. 
- this makes the code much less complicated.

#### Test passed:
start new game -> load saved game -> hot reload -> load saved game ->  exit to main manu -> load saved game
