### PR TITLE
Citizen not found fix

### DIFF
--- a/TLM/TLM/Patch/_CitizenAI/_HumanAI/SimulationStepPatch.cs
+++ b/TLM/TLM/Patch/_CitizenAI/_HumanAI/SimulationStepPatch.cs
@@ -389,6 +389,7 @@ namespace TrafficManager.Patch._CitizenAI._HumanAI {
                                                     | CitizenInstance.Flags.CustomColor
                                                     | CitizenInstance.Flags.Blown
                                                     | CitizenInstance.Flags.Floating
+                                                    | CitizenInstance.Flags.TargetIsNode
                                                     | CitizenInstance.Flags.TargetFlags;
 
                             if (StartPathFindCitizenAI(instance, instanceID, ref data)) {


### PR DESCRIPTION
 
Incomplete flag reset was clearing important flag `CitizenInstance.Flags.TargetIsNode` used to distinguish type of ID stored.

Flag indicates that value of `CitizenInstance.m_targetBuilding` is Node ID, not Building ID - Node ID is used for all kind of public transport stops including node of walking tour. Warning about wrong Citizen was triggered because citizen reached last walking tour path node, close to his parked vehicle - cim requests for additional path to reach vehicle. 

Test build available [here](https://ci.appveyor.com/api/projects/krzychu124/tmpe/artifacts/TMPE.zip?branch=bugfix/1067-citizen-not-found-warning) _(requires CitiesHarmony mod unlike workshop versions)_

Resolves #1067 