### PR TITLE
More Vehicles compatibility fix

### DIFF
--- a/TLM/TLM/Lifecycle/SerializableDataExtension.cs
+++ b/TLM/TLM/Lifecycle/SerializableDataExtension.cs
@@ -22,7 +22,7 @@ namespace TrafficManager.Lifecycle {
         public override void OnLoadData() => Load();
         public override void OnSaveData() => Save();
 
-        public static void Load() { 
+        public static void Load() {
             Log.Info("Loading Traffic Manager: PE Data");
             TMPELifecycle.Instance.Deserializing = true;
             bool loadingSucceeded = true;
@@ -36,6 +36,7 @@ namespace TrafficManager.Lifecycle {
                 loadingSucceeded = false;
             }
 
+            TMPELifecycle.Instance.RegisterCustomManagers();
             foreach (ICustomManager manager in TMPELifecycle.Instance.RegisteredManagers) {
                 try {
                     Log.Info($"OnBeforeLoadData: {manager.GetType().Name}");
@@ -274,7 +275,7 @@ namespace TrafficManager.Lifecycle {
             }
         }
 
-        public static void Save() { 
+        public static void Save() {
             bool success = true;
 
             // try {

--- a/TLM/TLM/Lifecycle/SerializableDataExtension.cs
+++ b/TLM/TLM/Lifecycle/SerializableDataExtension.cs
@@ -36,7 +36,6 @@ namespace TrafficManager.Lifecycle {
                 loadingSucceeded = false;
             }
 
-            TMPELifecycle.Instance.RegisterCustomManagers();
             foreach (ICustomManager manager in TMPELifecycle.Instance.RegisteredManagers) {
                 try {
                     Log.Info($"OnBeforeLoadData: {manager.GetType().Name}");

--- a/TLM/TLM/Lifecycle/TMPELifecycle.cs
+++ b/TLM/TLM/Lifecycle/TMPELifecycle.cs
@@ -151,6 +151,7 @@ namespace TrafficManager.Lifecycle {
                 Log._Debug("Scene is " + SceneManager.GetActiveScene().name);
 
                 HarmonyHelper.EnsureHarmonyInstalled();
+                LoadingManager.instance.m_levelPreLoaded += RegisterCustomManagers;
 
                 InGameHotReload = InGameOrEditor();
                 if (InGameHotReload) {
@@ -302,6 +303,7 @@ namespace TrafficManager.Lifecycle {
 
         internal void Unload() {
             CustomPathManager._instance?.OnLevelUnloading();
+            LoadingManager.instance.m_levelPreLoaded -= RegisterCustomManagers;
 
             try {
                 foreach (ICustomManager manager in RegisteredManagers.AsEnumerable().Reverse()) {

--- a/TLM/TLM/Lifecycle/TMPELifecycle.cs
+++ b/TLM/TLM/Lifecycle/TMPELifecycle.cs
@@ -74,7 +74,7 @@ namespace TrafficManager.Lifecycle {
             mcc.PerformModCheck();
         }
 
-        private void RegisterCustomManagers() {
+        internal void RegisterCustomManagers() {
             // TODO represent data dependencies differently
             RegisteredManagers.Add(ExtNodeManager.Instance);
             RegisteredManagers.Add(ExtSegmentManager.Instance);
@@ -274,7 +274,6 @@ namespace TrafficManager.Lifecycle {
 
             IsGameLoaded = true;
 
-            RegisterCustomManagers();
             CustomPathManager.OnLevelLoaded();
 
             ModUI.OnLevelLoaded();

--- a/TLM/TLM/Lifecycle/TMPELifecycle.cs
+++ b/TLM/TLM/Lifecycle/TMPELifecycle.cs
@@ -18,16 +18,16 @@ namespace TrafficManager.Lifecycle {
     using UnityEngine.SceneManagement;
     using UnityEngine;
     using JetBrains.Annotations;
-    
+
     /// <summary>
-    /// Do not use Singleton<TMPELifecycle>.instance to prevent memory leak. 
+    /// Do not use Singleton<TMPELifecycle>.instance to prevent memory leak.
     /// Instead use the TMPELifecycle.Instance property.
     /// </summary>
     public class TMPELifecycle : MonoBehaviour {
-        public static TMPELifecycle Instance { 
+        public static TMPELifecycle Instance {
             /// <summary> returns instance of TMPELifecycle if it exists. returns null otherwise. </summary>
-            get; 
-            private set; 
+            get;
+            private set;
         }
 
         /// <summary>TMPE is in the middle of deserializing data.</summary>
@@ -54,6 +54,7 @@ namespace TrafficManager.Lifecycle {
         /// </summary>
         public static bool InGameOrEditor() =>
             SceneManager.GetActiveScene().name != "IntroScreen" &&
+            SceneManager.GetActiveScene().name != "MainMenu" &&
             SceneManager.GetActiveScene().name != "Startup";
 
         public static AppMode? AppMode => SimulationManager.instance.m_ManagersWrapper.loading?.currentMode;
@@ -113,7 +114,6 @@ namespace TrafficManager.Lifecycle {
             Benchmark.BenchmarkManager.Setup();
 #endif
                 TranslationDatabase.LoadAllTranslations();
-                RegisterCustomManagers();
 
                 Log.InfoFormat(
                     "TM:PE enabled. Version {0}, Build {1} {2} for game version {3}.{4}.{5}-f{6}",
@@ -188,7 +188,7 @@ namespace TrafficManager.Lifecycle {
 #if DEBUG
         ~TMPELifecycle() {
             // ensure there is no memory leak:
-            Log._Debug("TMPELifecycle.~TMPELifecycle()"); 
+            Log._Debug("TMPELifecycle.~TMPELifecycle()");
         }
 #endif
         internal static void StartMod() {
@@ -274,6 +274,7 @@ namespace TrafficManager.Lifecycle {
 
             IsGameLoaded = true;
 
+            RegisterCustomManagers();
             CustomPathManager.OnLevelLoaded();
 
             ModUI.OnLevelLoaded();


### PR DESCRIPTION
- `More Vehicles` compatibility fix (we can't init managers in the main menu, because we will initialize array with incorrect vehicle count (not patched yet))
- hot reload fix (when you return to main menu scene is `MainMenu`)
- changed order of initialization mod managers (need to be called before `SerializableDataExtension.Load()` -> is too late if `ThreadingExtension.OnLevelLoaded()` used )

[Compiled build](https://ci.appveyor.com/api/projects/krzychu124/tmpe/artifacts/TMPE.zip?branch=1092-more-vehicles-compatibility-fix) 

Resolves #1092 