### PR TITLE
Stable 11.5.2 cargo truck PF fix

### DIFF
--- a/TLM/TLM/Custom/AI/CustomCargoTruckAI.cs
+++ b/TLM/TLM/Custom/AI/CustomCargoTruckAI.cs
@@ -99,8 +99,8 @@ namespace TrafficManager.Custom.AI {
                 out _)) {
                 if (!startPosFound
                     || (startAltDistSqrA < startDistSqrA
-                        && (Mathf.Abs(endPos.x) > 8000f
-                            || Mathf.Abs(endPos.z) > 8000f)))
+                        && (Mathf.Abs(startPos.x) > 8000f
+                            || Mathf.Abs(startPos.z) > 8000f)))
                 {
                     startPosA = startAltPosA;
                     startPosB = startAltPosB;

--- a/TLM/TLM/Custom/PathFinding/CustomPathFind.cs
+++ b/TLM/TLM/Custom/PathFinding/CustomPathFind.cs
@@ -889,7 +889,7 @@
                             PathUnits.m_buffer[currentPathUnitId].m_laneTypes =
                                 (byte)finalBufferItem.LanesUsed;
                             PathUnits.m_buffer[currentPathUnitId].m_vehicleTypes =
-                                (ushort)finalBufferItem.VehiclesUsed;
+                                (uint)finalBufferItem.VehiclesUsed;
 #endif
                             sumOfPositionCounts += currentItemPositionCount;
                             Singleton<PathManager>.instance.m_pathUnitCount =
@@ -1629,7 +1629,8 @@
                 }
 
                 ushort nextSegmentId;
-                if ((vehicleTypes_ & VehicleInfo.VehicleType.Ferry) != VehicleInfo.VehicleType.None) {
+                if ((queueItem_.vehicleType & (ExtVehicleType.CargoVehicle | ExtVehicleType.Service)) == ExtVehicleType.None &&
+                    (vehicleTypes_ & VehicleInfo.VehicleType.Ferry) != VehicleInfo.VehicleType.None) {
                     // ferry (/ monorail)
                     if (isLogEnabled) {
                         DebugLog(

--- a/TLM/TLM/TrafficManagerMod.cs
+++ b/TLM/TLM/TrafficManagerMod.cs
@@ -26,8 +26,8 @@ namespace TrafficManager {
         public const uint GAME_VERSION = 188868624U;
         public const uint GAME_VERSION_A = 1u;
         public const uint GAME_VERSION_B = 13u;
-        public const uint GAME_VERSION_C = 0u;
-        public const uint GAME_VERSION_BUILD = 8u;
+        public const uint GAME_VERSION_C = 1u;
+        public const uint GAME_VERSION_BUILD = 1u;
 
         // Use SharedAssemblyInfo.cs to modify TM:PE version
         // External mods (eg. CSUR Toolbox) reference the versioning for compatibility purposes


### PR DESCRIPTION
### Hotfix-2 for **Stable 11.5.2**

- **fixed issue with cargo trucks ignoring lane routing,**

### minor tweaks
--- 
- corrected `BufferItem.VehicleUsed` cast
- bumped current game version
- fixed old bug - outside connection detection (already fixed in `master` via transpiler)