### PR TITLE
CustomPathFind reflection calls

### DIFF
--- a/TLM/TLM/Custom/PathFinding/CustomPathFind.cs
+++ b/TLM/TLM/Custom/PathFinding/CustomPathFind.cs
@@ -877,6 +877,10 @@ namespace TrafficManager.Custom.PathFinding {
                     + $"ITEM({item})\n" + message);
         }
 
+        // be aware:
+        //   (1) path-finding works from target to start. the "next" segment is always the previous and the "previous" segment is always the next segment on the path!
+        //   (2) when I use the term "lane index from outer" this means outer right lane for right-hand traffic systems and outer-left lane for left-hand traffic systems.
+        //
         // main item processor
         // 1
         private void ProcessItemMain(

--- a/TLM/TLM/Custom/PathFinding/CustomPathManager.cs
+++ b/TLM/TLM/Custom/PathFinding/CustomPathManager.cs
@@ -17,6 +17,7 @@ namespace TrafficManager.Custom.PathFinding {
     using ColossalFramework.UI;
 
     public class CustomPathManager : PathManager {
+        public const int DEFAULT_SIM_SLEEP_TIME = 100;
         /// <summary>
         /// Holds a linked list of path units waiting to be calculated
         /// </summary>
@@ -30,7 +31,7 @@ namespace TrafficManager.Custom.PathFinding {
 
         private bool terminated_;
 
-        private int simSleepMultiplier_ = 100;//vanilla value
+        private int simSleepMultiplier_ = DEFAULT_SIM_SLEEP_TIME;//vanilla value
 
         private static FastList<ISimulationManager> GetSimulationManagers() =>
             typeof(SimulationManager)
@@ -99,8 +100,10 @@ namespace TrafficManager.Custom.PathFinding {
 
             PathFind[] stockPathFinds = GetComponents<PathFind>();
             int numOfStockPathFinds = stockPathFinds.Length;
-            // utilize more threads if possible (systems with 8+ threads (9-n))
-            int numCustomPathFinds = Mathf.Clamp(SystemInfo.processorCount / 2, 1, 6);
+            // utilize more threads if possible (systems with 8+) otherwise use vanilla calculation
+            int numCustomPathFinds = SystemInfo.processorCount < 8
+                                         ? SystemInfo.processorCount / 2
+                                         : SystemInfo.processorCount - 4;
             simSleepMultiplier_ = CalculateBestSimSleepMultiplier(numCustomPathFinds);
 
             Log._Debug("Creating " + numCustomPathFinds + " custom PathFind objects.");
@@ -446,7 +449,7 @@ namespace TrafficManager.Custom.PathFinding {
 
         public int CalculateBestSimSleepMultiplier(int numberOfThreads) {
             if (numberOfThreads < 4)
-                return 100; //vanilla value
+                return DEFAULT_SIM_SLEEP_TIME; //vanilla value
 
             /*
              * 4 - 200

--- a/TLM/TLM/Custom/PathFinding/CustomPathManager.cs
+++ b/TLM/TLM/Custom/PathFinding/CustomPathManager.cs
@@ -8,6 +8,7 @@ namespace TrafficManager.Custom.PathFinding {
     using JetBrains.Annotations;
     using System.Reflection;
     using System;
+    using System.Threading;
     using API.Traffic.Enums;
     using TrafficManager.API.Traffic.Data;
     using TrafficManager.Manager.Impl;
@@ -27,18 +28,22 @@ namespace TrafficManager.Custom.PathFinding {
 
         private PathManager stockPathManager_;
 
+        private bool terminated_;
+
+        private int simSleepMultiplier_ = 100;//vanilla value
+
         private static FastList<ISimulationManager> GetSimulationManagers() =>
             typeof(SimulationManager)
-            .GetField("m_managers", BindingFlags.Static | BindingFlags.NonPublic)
-            ?.GetValue(null)
-            as FastList<ISimulationManager>
+                    .GetField("m_managers", BindingFlags.Static | BindingFlags.NonPublic)
+                    ?.GetValue(null)
+                as FastList<ISimulationManager>
             ?? throw new Exception("could not get SimulationManager.m_managers");
 
         private static FieldInfo PathManagerInstance =>
             typeof(Singleton<PathManager>)
-            .GetField(
-            "sInstance",
-            BindingFlags.Static | BindingFlags.NonPublic) ??
+                .GetField(
+                    "sInstance",
+                    BindingFlags.Static | BindingFlags.NonPublic) ??
             throw new Exception("pathManagerInstance is null");
 
 #if QUEUEDSTATS
@@ -56,7 +61,7 @@ namespace TrafficManager.Custom.PathFinding {
                 Log.Error(error);
                 Log.Error($"Path manager replacement error: {ex}");
                 UIView.library.ShowModal<ExceptionPanel>("ExceptionPanel")
-                    .SetMessage("TM:PE failed to load", error, true);
+                      .SetMessage("TM:PE failed to load", error, true);
             }
         }
 
@@ -67,7 +72,7 @@ namespace TrafficManager.Custom.PathFinding {
             // also suppress call to base class.
             _instance = this;
             stockPathManager_ = PathManager.instance
-                ?? throw new Exception("stockPathManager is null");
+                                ?? throw new Exception("stockPathManager is null");
             Log._Debug($"Got stock PathManager instance {stockPathManager_?.GetName()}");
             PathManagerInstance.SetValue(null, this);
             Log._Debug("Should be custom: " + PathManager.instance.GetType());
@@ -94,14 +99,16 @@ namespace TrafficManager.Custom.PathFinding {
 
             PathFind[] stockPathFinds = GetComponents<PathFind>();
             int numOfStockPathFinds = stockPathFinds.Length;
-            int numCustomPathFinds = numOfStockPathFinds;
+            // utilize more threads if possible (systems with 8+ threads (9-n))
+            int numCustomPathFinds = Mathf.Clamp(SystemInfo.processorCount / 2, 1, 6);
+            simSleepMultiplier_ = CalculateBestSimSleepMultiplier(numCustomPathFinds);
 
             Log._Debug("Creating " + numCustomPathFinds + " custom PathFind objects.");
             _replacementPathFinds = new CustomPathFind[numCustomPathFinds];
             FieldInfo f_pathfinds = typeof(PathManager).GetField(
-                "m_pathfinds",
-                BindingFlags.NonPublic | BindingFlags.Instance)
-                ?? throw new Exception("f_pathFinds is null");
+                                        "m_pathfinds",
+                                        BindingFlags.NonPublic | BindingFlags.Instance)
+                                    ?? throw new Exception("f_pathFinds is null");
 
             lock (m_bufferLock) {
 
@@ -132,9 +139,9 @@ namespace TrafficManager.Custom.PathFinding {
             PathFind[] stockPathFinds = new PathFind[n];
 
             FieldInfo f_pathfinds = typeof(PathManager).GetField(
-                  "m_pathfinds",
-                  BindingFlags.NonPublic | BindingFlags.Instance)
-                  ?? throw new Exception("f_pathFinds is null");
+                                        "m_pathfinds",
+                                        BindingFlags.NonPublic | BindingFlags.Instance)
+                                    ?? throw new Exception("f_pathFinds is null");
 
             // both stcok and custom PathMangers use the same lock object
             lock (m_bufferLock) {
@@ -146,6 +153,8 @@ namespace TrafficManager.Custom.PathFinding {
                     Destroy(_replacementPathFinds[i]);
                 }
 
+                // revert to vanilla number of threads
+                n = Mathf.Clamp(SystemInfo.processorCount / 2, 1, 4);
                 for (int i = 0; i < n; i++) {
                     stockPathFinds[i] = gameObject.AddComponent<PathFind>();
                 }
@@ -170,6 +179,7 @@ namespace TrafficManager.Custom.PathFinding {
             if (m_pathUnits.m_buffer[unit].m_simulationFlags == 0) {
                 return;
             }
+
             lock (m_bufferLock) {
 
                 int numIters = 0;
@@ -189,7 +199,7 @@ namespace TrafficManager.Custom.PathFinding {
                     m_pathUnits.m_buffer[unit].m_nextPathUnit = 0u;
                     m_pathUnits.m_buffer[unit].m_referenceCount = 0;
                     m_pathUnits.ReleaseItem(unit);
-                    //queueItems[unit].Reset(); // NON-STOCK CODE
+
                     unit = nextPathUnit;
                     if (++numIters >= 262144) {
                         CODebugBase<LogChannel>.Error(
@@ -328,10 +338,6 @@ namespace TrafficManager.Custom.PathFinding {
             return false;
         }
 
-        /*internal void ResetQueueItem(uint unit) {
-                queueItems[unit].Reset();
-        }*/
-
         /// <summary>
         /// Builds Creates Path for TransportLineAI
         /// </summary>
@@ -438,6 +444,40 @@ namespace TrafficManager.Custom.PathFinding {
             DestroyImmediate(this);
         }
 
+        public int CalculateBestSimSleepMultiplier(int numberOfThreads) {
+            if (numberOfThreads < 4)
+                return 100; //vanilla value
+
+            /*
+             * 4 - 200
+             * 5 - 250
+             * 6 - 300
+             */
+            return numberOfThreads * 50;
+        }
+
+        /// <summary>
+        /// Override required to tweak
+        /// </summary>
+        /// <param name="subStep"></param>
+        protected override void SimulationStepImpl(int subStep) {
+            int num = 0;
+            for (int i = 0; i < _replacementPathFinds.Length; i++) {
+                num = Mathf.Max(num, _replacementPathFinds[i].m_queuedPathFindCount);
+            }
+
+            // put simulation thread to sleep when queued path exceed limit
+            if (num >= simSleepMultiplier_ && !terminated_) {
+                Thread.Sleep((num - simSleepMultiplier_) / simSleepMultiplier_ + 1);
+            }
+        }
+
+        public new void WaitForAllPaths() {
+            for (int i = 0; i < _replacementPathFinds.Length; i++) {
+                _replacementPathFinds[i].WaitForAllPaths();
+            }
+        }
+
         protected virtual void OnDestroy() {
             Log._Debug("CustomPathManager: OnDestroy");
             WaitForAllPaths();
@@ -451,7 +491,7 @@ namespace TrafficManager.Custom.PathFinding {
             simManagers.Remove(this);
 
             simManagers.Add(stockPathManager_);
-
+            terminated_ = true;
             _instance = null;
         }
     }

--- a/TLM/TLM/Patch/_PathManager/CreatePathPatch.cs
+++ b/TLM/TLM/Patch/_PathManager/CreatePathPatch.cs
@@ -6,6 +6,7 @@ namespace TrafficManager.Patch._PathManager {
     using HarmonyLib;
     using JetBrains.Annotations;
     using System;
+    using System.ComponentModel.Design;
     using System.Reflection;
     using TrafficManager.API.Traffic.Data;
     using TrafficManager.Custom.PathFinding;
@@ -38,23 +39,28 @@ namespace TrafficManager.Patch._PathManager {
             NetInfo.LaneType laneTypes, VehicleInfo.VehicleType vehicleTypes, float maxLength, bool isHeavyVehicle,
             bool ignoreBlocked, bool stablePath, bool skipQueue, bool randomParking, bool ignoreFlooded, bool combustionEngine, bool ignoreCost)
         {
-            if (VehicleID == 0) {
-                Log.Error("unexpected VehcileID == 0. " +
-                    "StartPathFind() is not ptched or it failed to set VehicleID. " +
-                    "Falling back to Vanilla path find");
-                return true; // fall back to Vanilla path find.
+            PathCreationArgs args = default;
+            VehicleInfo info = null;
+            if (VehicleID != 0) {
+                // CreatePath called for customized AI
+                Vehicle[] vehicleBuffer = VehicleManager.instance.m_vehicles.m_buffer;
+                ref Vehicle vehicleData = ref vehicleBuffer[VehicleID];
+                info = vehicleData.Info;
+                VehicleAI ai = info.m_vehicleAI;
+
+                args.vehicleId = VehicleID;
+                args.extPathType = ExtPathType;
+                args.extVehicleType = ExtVehicleType;
+                args.spawned = vehicleData.m_flags.IsFlagSet(Vehicle.Flags.Spawned);
+                args.skipQueue = skipQueue;
+
+                if (ai is ShipAI)
+                    args.skipQueue = false; // TODO [issue #952] why ShipAI should be different than others?
+
+            } else {
+                // CreatePath called for vanilla AI
+                args.skipQueue = skipQueue;
             }
-
-            var vehicleBuffer = VehicleManager.instance.m_vehicles.m_buffer;
-            ref Vehicle vehicleData = ref vehicleBuffer[VehicleID];
-            var info = vehicleData.Info;
-            var ai = info.m_vehicleAI;
-
-            PathCreationArgs args;
-            args.vehicleId = VehicleID;
-            args.extPathType = ExtPathType;
-            args.extVehicleType = ExtVehicleType;
-            args.spawned = vehicleData.m_flags.IsFlagSet(Vehicle.Flags.Spawned);
 
             // vanilla values
             args.buildIndex = buildIndex;
@@ -76,12 +82,8 @@ namespace TrafficManager.Patch._PathManager {
             args.endPosA = endPosA;
             args.endPosB = endPosB;
 
-            // overridden vanilla values:
-            args.skipQueue = args.spawned;
-            if (ai is ShipAI) args.skipQueue = false; // TODO [issue #952] why ShipAI should be different than others?
-
             __result = CustomPathManager._instance.CustomCreatePath(out unit, ref randomizer, args);
-            if (__result) {
+            if (__result && VehicleID != 0) {
 #if DEBUG
                 bool vehDebug = DebugSettings.VehicleId == 0 || DebugSettings.VehicleId == VehicleID;
                 bool logParkingAi = DebugSwitch.BasicParkingAILog.Get() && vehDebug;
@@ -94,7 +96,7 @@ namespace TrafficManager.Patch._PathManager {
                     () => $"CreatePathPatch.Prefix({args.vehicleId}): " +
                     $"Path-finding starts for vehicle {args.vehicleId}, path={path}, " +
                     $"extVehicleType={ExtVehicleType}, startPosA.segment={startPosA.m_segment}, " +
-                    $"startPosA.lane={startPosA.m_lane}, info.m_vehicleType={info.m_vehicleType}, " +
+                    $"startPosA.lane={startPosA.m_lane}, info.m_vehicleType={info?.m_vehicleType}, " +
                     $"endPosA.segment={endPosA.m_segment}, endPosA.lane={endPosA.m_lane}");
             }
 

--- a/TLM/TLM/Patch/_PathManager/CreatePathPatch.cs
+++ b/TLM/TLM/Patch/_PathManager/CreatePathPatch.cs
@@ -45,8 +45,6 @@ namespace TrafficManager.Patch._PathManager {
                 // CreatePath called for customized AI
                 Vehicle[] vehicleBuffer = VehicleManager.instance.m_vehicles.m_buffer;
                 ref Vehicle vehicleData = ref vehicleBuffer[VehicleID];
-                info = vehicleData.Info;
-                VehicleAI ai = info.m_vehicleAI;
 
                 args.vehicleId = VehicleID;
                 args.extPathType = ExtPathType;
@@ -54,8 +52,8 @@ namespace TrafficManager.Patch._PathManager {
                 args.spawned = vehicleData.m_flags.IsFlagSet(Vehicle.Flags.Spawned);
                 args.skipQueue = skipQueue;
 
-                if (ai is ShipAI)
-                    args.skipQueue = false; // TODO [issue #952] why ShipAI should be different than others?
+                if (vehicleData.Info.m_vehicleAI is ShipAI)
+                    args.skipQueue = false;
 
             } else {
                 // CreatePath called for vanilla AI

--- a/TLM/TLM/Patch/_PathManager/WaitForAllPathsPatch.cs
+++ b/TLM/TLM/Patch/_PathManager/WaitForAllPathsPatch.cs
@@ -8,7 +8,7 @@ namespace TrafficManager.Patch._PathManager {
 
         [UsedImplicitly]
         public static bool Prefix() {
-            if (CustomPathManager._instance) {
+            if (CustomPathManager._instance != null) {
                 CustomPathManager._instance.WaitForAllPaths();
                 return false;
             }

--- a/TLM/TLM/Patch/_PathManager/WaitForAllPathsPatch.cs
+++ b/TLM/TLM/Patch/_PathManager/WaitForAllPathsPatch.cs
@@ -1,0 +1,19 @@
+namespace TrafficManager.Patch._PathManager {
+    using Custom.PathFinding;
+    using HarmonyLib;
+    using JetBrains.Annotations;
+
+    [HarmonyPatch(typeof(PathManager), nameof(PathManager.WaitForAllPaths))]
+    public class WaitForAllPathsPatch {
+
+        [UsedImplicitly]
+        public static bool Prefix() {
+            if (CustomPathManager._instance) {
+                CustomPathManager._instance.WaitForAllPaths();
+                return false;
+            }
+
+            return true;
+        }
+    }
+}

--- a/TLM/TLM/TLM.csproj
+++ b/TLM/TLM/TLM.csproj
@@ -12,7 +12,7 @@
     <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
-    <LangVersion>latest</LangVersion>
+    <LangVersion>preview</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -159,6 +159,7 @@
     <Compile Include="Patch\_CitizenAI\_TouristAI\GetVehicleInfoPatch.cs" />
     <Compile Include="Patch\_PathFind\CalculatePathPatch.cs" />
     <Compile Include="Patch\_PathManager\ReleasePathPatch.cs" />
+    <Compile Include="Patch\_PathManager\WaitForAllPathsPatch.cs" />
     <Compile Include="Patch\_RoadBaseAI\ClickNodeButtonPatch.cs" />
     <Compile Include="Patch\_TransportLineAI\StartPathFindPatch.cs" />
     <Compile Include="Patch\_VehicleAI\CalculateSegmentPositionPatch.cs" />


### PR DESCRIPTION
- removed most of reflection code from `CustomPathFind` class,
- redirected all `CreatePath` requests to TM:PE custom PF, no fallback to vanilla (aircrafts and ships)
- changed necessary code to support `no-fallback` option
- increased limit of path find threads to (CPU threads - 4) (for 8+ threads CPU's)
- variable reduction of Simulation sleep time when a lot of paths finds are queued (depends on number of threads available)