### PR TITLE
flag extension

### DIFF
--- a/TLM/TLM/Manager/Impl/JunctionRestrictionsManager.cs
+++ b/TLM/TLM/Manager/Impl/JunctionRestrictionsManager.cs
@@ -15,6 +15,7 @@ namespace TrafficManager.Manager.Impl {
     using static TrafficManager.Util.Shortcuts;
     using static CSUtil.Commons.TernaryBoolUtil;
     using TrafficManager.Util;
+    using TrafficManager.Util.Extensions;
 
     public class JunctionRestrictionsManager
         : AbstractGeometryObservingManager,

--- a/TLM/TLM/Manager/Impl/ParkingRestrictionsManager.cs
+++ b/TLM/TLM/Manager/Impl/ParkingRestrictionsManager.cs
@@ -7,6 +7,7 @@ namespace TrafficManager.Manager.Impl {
     using TrafficManager.State.ConfigData;
     using TrafficManager.Util;
     using ColossalFramework;
+    using TrafficManager.Util.Extensions;
 
     public class ParkingRestrictionsManager
         : AbstractGeometryObservingManager,

--- a/TLM/TLM/Patch/_PathManager/CreatePathPatch.cs
+++ b/TLM/TLM/Patch/_PathManager/CreatePathPatch.cs
@@ -11,6 +11,7 @@ namespace TrafficManager.Patch._PathManager {
     using TrafficManager.Custom.PathFinding;
     using TrafficManager.State.ConfigData;
     using TrafficManager.Util;
+    using TrafficManager.Util.Extensions;
 
     [HarmonyPatch]
     [UsedImplicitly]

--- a/TLM/TLM/Patch/_RoadBaseAI/UpdateNodePatch.cs
+++ b/TLM/TLM/Patch/_RoadBaseAI/UpdateNodePatch.cs
@@ -4,6 +4,7 @@ namespace TrafficManager.Patch._RoadBaseAI {
     using JetBrains.Annotations;
     using TrafficManager.Manager.Impl;
     using TrafficManager.State;
+    using TrafficManager.Util.Extensions;
 
     [HarmonyPatch(typeof(RoadBaseAI), "UpdateNode")]
     [UsedImplicitly]

--- a/TLM/TLM/Patch/_VehicleAI/_AmbulanceAI/StartPathFindPatch.cs
+++ b/TLM/TLM/Patch/_VehicleAI/_AmbulanceAI/StartPathFindPatch.cs
@@ -6,6 +6,7 @@ namespace TrafficManager.Patch._VehicleAI._AmbulanceAI {
     using TrafficManager.API.Traffic.Enums;
     using TrafficManager.Manager.Impl;
     using ColossalFramework;
+    using TrafficManager.Util.Extensions;
 
     [HarmonyPatch]
     public class StartPathFindPatch {

--- a/TLM/TLM/Patch/_VehicleAI/_FireTruckAI/StartPathFindPatch.cs
+++ b/TLM/TLM/Patch/_VehicleAI/_FireTruckAI/StartPathFindPatch.cs
@@ -6,6 +6,7 @@ namespace TrafficManager.Patch._VehicleAI._FireTruckAI {
     using TrafficManager.API.Traffic.Enums;
     using TrafficManager.Manager.Impl;
     using ColossalFramework;
+    using TrafficManager.Util.Extensions;
 
     [HarmonyPatch]
     public class StartPathFindPatch {

--- a/TLM/TLM/Patch/_VehicleAI/_PoliceCarAI/StartPathFindPatch.cs
+++ b/TLM/TLM/Patch/_VehicleAI/_PoliceCarAI/StartPathFindPatch.cs
@@ -6,6 +6,7 @@ namespace TrafficManager.Patch._VehicleAI._PoliceCarAI {
     using TrafficManager.API.Traffic.Enums;
     using TrafficManager.Manager.Impl;
     using ColossalFramework;
+    using TrafficManager.Util.Extensions;
 
     [HarmonyPatch]
     public class StartPathFindPatch {

--- a/TLM/TLM/TLM.csproj
+++ b/TLM/TLM/TLM.csproj
@@ -354,6 +354,7 @@
     <Compile Include="UI\TransportDemandViewMode.cs" />
     <Compile Include="UI\UITransportDemand.cs" />
     <Compile Include="Util\AutoTimedTrafficLights.cs" />
+    <Compile Include="Util\Extensions\FlagsExtensions.cs" />
     <Compile Include="Util\InGameUtil.cs" />
     <Compile Include="Util\IntVector2.cs" />
     <Compile Include="Util\Spiral.cs" />

--- a/TLM/TLM/UI/SubTools/LaneConnectorTool.cs
+++ b/TLM/TLM/UI/SubTools/LaneConnectorTool.cs
@@ -15,6 +15,7 @@ namespace TrafficManager.UI.SubTools {
     using TrafficManager.UI.MainMenu.OSD;
     using static TrafficManager.Util.Shortcuts;
     using TrafficManager.UI.SubTools.PrioritySigns;
+    using TrafficManager.Util.Extensions;
 
     public class LaneConnectorTool
         : LegacySubTool,

--- a/TLM/TLM/UI/SubTools/ParkingRestrictionsTool.cs
+++ b/TLM/TLM/UI/SubTools/ParkingRestrictionsTool.cs
@@ -14,6 +14,7 @@ namespace TrafficManager.UI.SubTools {
     using TrafficManager.UI.SubTools.PrioritySigns;
     using ColossalFramework.UI;
     using TrafficManager.UI.MainMenu.OSD;
+    using TrafficManager.Util.Extensions;
 
     public class ParkingRestrictionsTool
         : LegacySubTool,

--- a/TLM/TLM/UI/SubTools/SpeedLimits/SpeedLimitsTool.cs
+++ b/TLM/TLM/UI/SubTools/SpeedLimits/SpeedLimitsTool.cs
@@ -16,6 +16,7 @@ namespace TrafficManager.UI.SubTools.SpeedLimits {
     using TrafficManager.Util.Caching;
     using UnityEngine;
     using static TrafficManager.Util.Shortcuts;
+    using TrafficManager.Util.Extensions;
 
     public class SpeedLimitsTool : LegacySubTool {
         public const int

--- a/TLM/TLM/Util/Extensions/FlagsExtensions.cs
+++ b/TLM/TLM/Util/Extensions/FlagsExtensions.cs
@@ -1,0 +1,33 @@
+namespace TrafficManager.Util.Extensions {
+    internal static class FlagsExtensions {
+        internal static bool IsFlagSet(this NetInfo.LaneType value, NetInfo.LaneType flag) => (value & flag) != 0;
+
+        internal static bool IsFlagSet(this VehicleInfo.VehicleType value, VehicleInfo.VehicleType flag) => (value & flag) != 0;
+
+        internal static bool IsFlagSet(this Vehicle.Flags value, Vehicle.Flags flag) => (value & flag) != 0;
+
+        internal static bool IsFlagSet(this NetNode.Flags value, NetNode.Flags flag) => (value & flag) != 0;
+
+        internal static bool IsFlagSet(this NetSegment.Flags value, NetSegment.Flags flag) => (value & flag) != 0;
+
+        internal static bool IsFlagSet(this NetLane.Flags value, NetLane.Flags flag) => (value & flag) != 0;
+
+        internal static bool CheckFlags(this NetInfo.LaneType value, NetInfo.LaneType required, NetInfo.LaneType forbidden = 0) =>
+            (value & (required | forbidden)) == required;
+
+        internal static bool CheckFlags(this VehicleInfo.VehicleType value, VehicleInfo.VehicleType required, VehicleInfo.VehicleType forbidden = 0) =>
+            (value & (required | forbidden)) == required;
+
+        internal static bool CheckFlags(this Vehicle.Flags value, Vehicle.Flags required, Vehicle.Flags forbidden = 0) =>
+            (value & (required | forbidden)) == required;
+
+        internal static bool CheckFlags(this NetNode.Flags value, NetNode.Flags required, NetNode.Flags forbidden = 0) =>
+            (value & (required | forbidden)) == required;
+
+        internal static bool CheckFlags(this NetSegment.Flags value, NetSegment.Flags required, NetSegment.Flags forbidden = 0) =>
+            (value & (required | forbidden)) == required;
+
+        internal static bool CheckFlags(this NetLane.Flags value, NetLane.Flags required, NetLane.Flags forbidden = 0) =>
+            (value & (required | forbidden)) == required;
+    }
+}


### PR DESCRIPTION
previously IsFlagSet was using CO's extension which allocates heap memory in each frame.
I introduced our own IsFlagSet for every Enum [that we use] to avoid using heap memory.