### PR TITLE
Ignore invalid (disconnected) segments while calculating lane routings

### DIFF
--- a/TLM/TLM/Manager/Impl/RoutingManager.cs
+++ b/TLM/TLM/Manager/Impl/RoutingManager.cs
@@ -12,6 +12,7 @@ namespace TrafficManager.Manager.Impl {
     using TrafficManager.State.ConfigData;
     using TrafficManager.State;
     using TrafficManager.Util;
+    using UnityEngine;
 
     public class RoutingManager
         : AbstractGeometryObservingManager,
@@ -460,8 +461,13 @@ namespace TrafficManager.Manager.Impl {
                         continue;
                     }
 
-                    bool start = (bool)Constants.ServiceFactory.NetService.IsStartNode(segId, nextNodeId);
-                    ExtSegmentEnd segEnd = segEndMan.ExtSegmentEnds[segEndMan.GetIndex(segId, start)];
+                    bool? start = Constants.ServiceFactory.NetService.IsStartNode(segId, nextNodeId);
+                    if (!start.HasValue) {
+                        Log.Error($"Segment with id: {segId} is not connected to the node {nextNodeId}");
+                        Debug.LogError($"TM:PE RecalculateLaneRoutings - Segment with id {segId} is not connected to the node {nextNodeId}");
+                        continue;
+                    }
+                    ExtSegmentEnd segEnd = segEndMan.ExtSegmentEnds[segEndMan.GetIndex(segId, start.Value)];
 
                     if (segEnd.incoming) {
                         ++numIncoming;

--- a/TLM/TLM/Util/VersionUtil.cs
+++ b/TLM/TLM/Util/VersionUtil.cs
@@ -29,7 +29,7 @@ namespace TrafficManager.Util {
         // we could alternatively use BuildConfig.APPLICATION_VERSION because const values are evaluated at compile time.
         // but I have decided not to do this because I don't want this to happen automatically with a rebuild if
         // CS updates. these values should be changed manaually so as to force us to acknowledge that they have changed.
-        public const uint EXPECTED_GAME_VERSION_U = 188868624U;
+        public const uint EXPECTED_GAME_VERSION_U = 189262096U;
 
         // see comments for EXPECTED_GAME_VERSION_U.
         public static Version ExpectedGameVersion => new Version(1, 13, 3, 9);


### PR DESCRIPTION

- Ignore invalid (disconnected) segments while calculating lane routings
- update outdated version number

Fixes #1124 