### PR TITLE
Opacity for legacy subTool GUI

### DIFF
--- a/TLM/TLM/State/OptionsTabs/OptionsGeneralTab.cs
+++ b/TLM/TLM/State/OptionsTabs/OptionsGeneralTab.cs
@@ -93,7 +93,7 @@ namespace TrafficManager.State {
 
             _guiOpacitySlider = generalGroup.AddSlider(
                                         text: T("General.Slider:Window transparency") + ":",
-                                        min: 10,
+                                        min: 0,
                                         max: 100,
                                         step: 5,
                                         defaultValue: GlobalConfig.Instance.Main.GuiOpacity,
@@ -103,7 +103,7 @@ namespace TrafficManager.State {
             _overlayTransparencySlider = generalGroup.AddSlider(
                                              text: T("General.Slider:Overlay transparency") + ":",
                                              min: 0,
-                                             max: 90,
+                                             max: 100,
                                              step: 5,
                                              defaultValue: GlobalConfig.Instance.Main.OverlayTransparency,
                                              eventCallback: OnOverlayTransparencyChanged) as UISlider;

--- a/TLM/TLM/U/Panel/BaseUWindowPanel.cs
+++ b/TLM/TLM/U/Panel/BaseUWindowPanel.cs
@@ -45,6 +45,13 @@ namespace TrafficManager.U.Panel {
         /// <summary>Called by UResizer for every control after it is to be 'resized'.</summary>
         public virtual void OnAfterResizerUpdate() { }
 
+        /// <summary>Called by UnityEngine when component gets destroyed</summary>
+        public override void OnDestroy() {
+            uiScaleUnbsubscriber_.Dispose();
+            uiTransparencyUnbsubscriber_.Dispose();
+            base.OnDestroy();
+        }
+
         /// <summary>Invoke rescaling handler, because possibly it has the new size now.</summary>
         /// <param name="previousResolution">Previous.</param>
         /// <param name="currentResolution">New.</param>

--- a/TLM/TLM/UI/MainMenu/MainMenuWindow.cs
+++ b/TLM/TLM/UI/MainMenu/MainMenuWindow.cs
@@ -543,6 +543,7 @@ namespace TrafficManager.UI.MainMenu {
         public override void OnDestroy() {
             eventVisibilityChanged -= OnVisibilityChanged;
             confDisposable?.Dispose();
+            base.OnDestroy();
         }
 
         internal void SetPosLock(bool lck) {

--- a/TLM/TLM/UI/SubTools/LaneConnectorTool.cs
+++ b/TLM/TLM/UI/SubTools/LaneConnectorTool.cs
@@ -238,8 +238,8 @@ namespace TrafficManager.UI.SubTools {
                             DrawLaneCurve(
                                 cameraInfo: cameraInfo,
                                 bezier: ref bezier,
-                                color: !viewOnly ? laneEnd.Color : laneEnd.Color.WithAlpha(TrafficManagerTool.OverlayAlpha),
-                                outlineColor: !viewOnly ? Color.black : Color.black.WithAlpha(TrafficManagerTool.OverlayAlpha),
+                                color: laneEnd.Color.WithAlpha(TrafficManagerTool.OverlayAlpha),
+                                outlineColor: Color.black.WithAlpha(TrafficManagerTool.OverlayAlpha),
                                 underground: (height.y + 1f) < intersectionY || laneEnd.NodeId == SelectedNodeId);
                         }
                     }

--- a/TLM/TLM/UI/SubTools/LaneConnectorTool.cs
+++ b/TLM/TLM/UI/SubTools/LaneConnectorTool.cs
@@ -238,8 +238,8 @@ namespace TrafficManager.UI.SubTools {
                             DrawLaneCurve(
                                 cameraInfo: cameraInfo,
                                 bezier: ref bezier,
-                                color: laneEnd.Color,
-                                outlineColor: Color.black,
+                                color: !viewOnly ? laneEnd.Color : laneEnd.Color.WithAlpha(TrafficManagerTool.OverlayAlpha),
+                                outlineColor: !viewOnly ? Color.black : Color.black.WithAlpha(TrafficManagerTool.OverlayAlpha),
                                 underground: (height.y + 1f) < intersectionY || laneEnd.NodeId == SelectedNodeId);
                         }
                     }

--- a/TLM/TLM/UI/SubTools/ParkingRestrictionsTool.cs
+++ b/TLM/TLM/UI/SubTools/ParkingRestrictionsTool.cs
@@ -311,8 +311,9 @@ namespace TrafficManager.UI.SubTools {
                     hoveredDirection = e.Key;
                 }
 
-                GUI.color = guiColor;
+                GUI.color = GUI.color.WithAlpha(TrafficManagerTool.OverlayAlpha);
                 GUI.DrawTexture(boundingBox, RoadUI.ParkingRestrictionTextures[allowed]);
+                GUI.color = guiColor;
 
                 if (hoveredHandle && clicked && !IsCursorInPanel() &&
                     parkingManager.ToggleParkingAllowed(segmentId, hoveredDirection)) {

--- a/TLM/TLM/UI/SubTools/VehicleRestrictionsTool.cs
+++ b/TLM/TLM/UI/SubTools/VehicleRestrictionsTool.cs
@@ -146,6 +146,9 @@ namespace TrafficManager.UI.SubTools {
             if (SelectedSegmentId != 0) {
                 cursorInSecondaryPanel = false;
 
+                Color oldColor = GUI.color;
+                GUI.color = GUI.color.WithAlpha(TrafficManagerTool.GetWindowAlpha());
+
                 windowRect = GUILayout.Window(
                     255,
                     windowRect,
@@ -154,7 +157,7 @@ namespace TrafficManager.UI.SubTools {
                     WindowStyle,
                     EmptyOptionsArray);
                 cursorInSecondaryPanel = windowRect.Contains(Event.current.mousePosition);
-
+                GUI.color = oldColor;
                 // overlayHandleHovered = false;
             }
 
@@ -277,26 +280,25 @@ namespace TrafficManager.UI.SubTools {
         private void GuiVehicleRestrictionsWindow(int num) {
             // use blue color when shift is pressed.
             Color oldColor = GUI.color;
+            GUI.color = GUI.color.WithAlpha(TrafficManagerTool.GetWindowAlpha());
             if (RoadMode) {
                 GUI.color = HighlightColor;
             }
 
-            {
-                // uses pressed sprite when delete is pressed
-                // uses blue color when shift is pressed.
-                KeyCode hotkey = KeyCode.Delete;
-                GUIStyle style = new GUIStyle("button");
-                if (Input.GetKey(hotkey)) {
-                    style.normal.background = style.active.background;
-                }
-                if (GUILayout.Button(
-                   T("Button:Allow all vehicles") + " [delete]",
-                   style,
-                   EmptyOptionsArray) || Input.GetKeyDown(hotkey)) {
-                    AllVehiclesFunc(true);
-                    if (RoadMode) {
-                        ApplyRestrictionsToAllSegments();
-                    }
+            // uses pressed sprite when delete is pressed
+            // uses blue color when shift is pressed.
+            KeyCode hotkey = KeyCode.Delete;
+            GUIStyle style = new GUIStyle("button");
+            if (Input.GetKey(hotkey)) {
+                style.normal.background = style.active.background;
+            }
+            if (GUILayout.Button(
+               T("Button:Allow all vehicles") + " [delete]",
+               style,
+               EmptyOptionsArray) || Input.GetKeyDown(hotkey)) {
+                AllVehiclesFunc(true);
+                if (RoadMode) {
+                    ApplyRestrictionsToAllSegments();
                 }
             }
 
@@ -307,7 +309,9 @@ namespace TrafficManager.UI.SubTools {
                 }
             }
 
-            GUI.color = oldColor;
+            if (RoadMode) {
+                GUI.color = oldColor;
+            }
 
             if (GUILayout.Button(
                T("Button:Apply to entire road"),
@@ -315,6 +319,7 @@ namespace TrafficManager.UI.SubTools {
                 ApplyRestrictionsToAllSegments();
             }
 
+            GUI.color = oldColor;
             DragWindow(ref windowRect);
         }
 
@@ -557,12 +562,15 @@ namespace TrafficManager.UI.SubTools {
 
                 ++y;
 #endif
+                Color guiColor2 = GUI.color;
+                GUI.color = GUI.color.WithAlpha(TrafficManagerTool.OverlayAlpha);
                 foreach (ExtVehicleType vehicleType in possibleVehicleTypes) {
                     bool allowed = VehicleRestrictionsManager.Instance.IsAllowed(allowedTypes, vehicleType);
 
                     if (allowed && viewOnly) {
                         continue; // do not draw allowed vehicles in view-only mode
                     }
+
 
                     bool hoveredHandle = MainTool.DrawGenericSquareOverlayGridTexture(
                         RoadUI.VehicleRestrictionTextures[vehicleType][allowed],
@@ -606,6 +614,8 @@ namespace TrafficManager.UI.SubTools {
 
                     ++y;
                 }
+
+                GUI.color = guiColor2;
 
                 ++x;
             }

--- a/TLM/TLM/UI/TrafficManagerTool.cs
+++ b/TLM/TLM/UI/TrafficManagerTool.cs
@@ -100,6 +100,8 @@ namespace TrafficManager.UI {
 
         public bool IsUndergroundMode => InfoManager.instance.CurrentMode == InfoManager.InfoMode.Underground;
 
+        internal static float OverlayAlpha => TransparencyToAlpha(GlobalConfig.Instance.Main.OverlayTransparency);
+
         static TrafficManagerTool() { }
 
         /// <summary>

--- a/TLM/TLM/UI/TrafficManagerTool.cs
+++ b/TLM/TLM/UI/TrafficManagerTool.cs
@@ -115,6 +115,11 @@ namespace TrafficManager.UI {
                 Destroy(nopeCursor_);
                 nopeCursor_ = null;
             }
+            foreach (KeyValuePair<ToolMode, LegacySubTool> e in legacySubTools_) {
+                e.Value.OnDestroy();
+            }
+            legacySubTools_.Clear();
+            legacySubTools_ = null;
             base.OnDestroy();
         }
 
@@ -163,7 +168,7 @@ namespace TrafficManager.UI {
         internal const float MAX_ZOOM = 0.05f;
 
         internal static float GetWindowAlpha() {
-            return TransparencyToAlpha(GlobalConfig.Instance.Main.GuiTransparency);
+            return Mathf.Clamp(GlobalConfig.Instance.Main.GuiOpacity, 0f, 100f) / 100f;
         }
 
         internal static float GetHandleAlpha(bool hovered) {

--- a/TLM/TLM/Util/Shortcuts.cs
+++ b/TLM/TLM/Util/Shortcuts.cs
@@ -182,6 +182,11 @@ namespace TrafficManager.Util {
                 .SetMessage(title, message, true);
         }
 
+        internal static Color WithAlpha(this Color color, float alpha) {
+            color.a = alpha;
+            return color;
+        }
+
         internal static bool ShiftIsPressed => Input.GetKey(KeyCode.LeftShift) || Input.GetKey(KeyCode.RightShift);
 
         internal static bool ControlIsPressed => Input.GetKey(KeyCode.LeftControl) || Input.GetKey(KeyCode.RightControl);


### PR DESCRIPTION

- UI opacity slider does not work for `legacySubTools`,
- eliminated possible memory leaks