### PR TITLE
EnumerateSpeedLimits in OnToolGUI ....

### DIFF
--- a/TLM/TLM/State/ConfigData/Main.cs
+++ b/TLM/TLM/State/ConfigData/Main.cs
@@ -1,4 +1,4 @@
-﻿namespace TrafficManager.State.ConfigData {
+namespace TrafficManager.State.ConfigData {
     using System;
     using System.Collections.Generic;
     using System.Linq;
@@ -76,6 +76,10 @@
         /// but internally Kmph are still used).
         /// </summary>
         public bool DisplaySpeedLimitsMph = false;
+
+        public SpeedUnit GetDisplaySpeedUnit() => DisplaySpeedLimitsMph
+            ? SpeedUnit.Mph
+            : SpeedUnit.Kmph;
 
         /// <summary>
         /// Selected theme for road signs when MPH is active.

--- a/TLM/TLM/UI/Helpers/SegmentLaneMarker.cs
+++ b/TLM/TLM/UI/Helpers/SegmentLaneMarker.cs
@@ -18,11 +18,6 @@ namespace TrafficManager.UI.Helpers {
 
         private Bounds[] bounds;
 
-        /// <summary>
-        /// previous vertical hit position stored for caching.
-        /// </summary>
-        private float prev_H;
-
         public bool IsUnderground { get; private set; }
 
         /// <summary>

--- a/TLM/TLM/UI/SubTools/SpeedLimits/SpeedLimitsTool.cs
+++ b/TLM/TLM/UI/SubTools/SpeedLimits/SpeedLimitsTool.cs
@@ -1125,7 +1125,7 @@ namespace TrafficManager.UI.SubTools.SpeedLimits {
                     break;
             }
 
-            result.Add(SpeedValue.Unlimited());
+            result.Add(new SpeedValue(0)); //add last item: no limit
 
             return result.ToArray();
         }

--- a/TLM/TLM/UI/SubTools/SpeedLimits/SpeedUnit.cs
+++ b/TLM/TLM/UI/SubTools/SpeedLimits/SpeedUnit.cs
@@ -1,6 +1,5 @@
 namespace TrafficManager.UI.SubTools.SpeedLimits {
     public enum SpeedUnit {
-        CurrentlyConfigured, // Currently selected in the options menu
         Kmph,
         Mph,
     }

--- a/TLM/TMPE.API/Traffic/Data/SpeedValue.cs
+++ b/TLM/TMPE.API/Traffic/Data/SpeedValue.cs
@@ -68,8 +68,6 @@ namespace TrafficManager.API.Traffic.Data {
         public static SpeedValue FromMph(MphValue mph)
             => new SpeedValue(mph.Mph / ApiConstants.SPEED_TO_MPH);
 
-        public static SpeedValue Unlimited() => new SpeedValue(0);
-
         /// <summary>
         /// Subtracts two speed values
         /// </summary>

--- a/TLM/TMPE.API/Traffic/Data/SpeedValue.cs
+++ b/TLM/TMPE.API/Traffic/Data/SpeedValue.cs
@@ -68,6 +68,8 @@ namespace TrafficManager.API.Traffic.Data {
         public static SpeedValue FromMph(MphValue mph)
             => new SpeedValue(mph.Mph / ApiConstants.SPEED_TO_MPH);
 
+        public static SpeedValue Unlimited() => new SpeedValue(0);
+
         /// <summary>
         /// Subtracts two speed values
         /// </summary>


### PR DESCRIPTION
- Removed SpeedUnit.CurrentlyConfigured because that is not a speed unit.
- Added GlobalConfig.Main.GetDisplaySpeedUnit() method to get SpeedUnit from user config directly.
- Added SpeedValue.Unlimited() convenience method for better expressing intent.
- Removed EnumerateSpeedLimits from OnToolGUI in SpeedLimitsTool.
  The values should be generated once and reused since they don't change during runtime.