### PR TITLE
Replace slow, garbage generating `TinyDictionary` with regular one

### DIFF
--- a/TLM/TLM/Manager/Impl/VehicleRestrictionsManager.cs
+++ b/TLM/TLM/Manager/Impl/VehicleRestrictionsManager.cs
@@ -97,7 +97,7 @@ namespace TrafficManager.Manager.Impl {
             ushort nodeId,
             VehicleRestrictionsMode busLaneMode)
         {
-            IDictionary<byte, ExtVehicleType> ret = new TinyDictionary<byte, ExtVehicleType>();
+            IDictionary<byte, ExtVehicleType> ret = new Dictionary<byte, ExtVehicleType>();
             NetManager netManager = Singleton<NetManager>.instance;
 
             if (segmentId == 0

--- a/TLM/TLM/Traffic/Impl/SegmentEnd.cs
+++ b/TLM/TLM/Traffic/Impl/SegmentEnd.cs
@@ -47,8 +47,8 @@ namespace TrafficManager.Traffic.Impl {
         /// Number of vehicles / vehicle length going to a certain segment.
         /// First key: source lane index, second key: target segment id, value: total normalized vehicle length
         /// </summary>
-        private IDictionary<ushort, uint>[] numVehiclesMovingToSegmentId; // minimum speed required
-        private IDictionary<ushort, uint>[] numVehiclesGoingToSegmentId; // no minimum speed required
+        private Dictionary<ushort, uint>[] numVehiclesMovingToSegmentId; // minimum speed required
+        private Dictionary<ushort, uint>[] numVehiclesGoingToSegmentId; // no minimum speed required
 
         public override string ToString() {
             return $"[SegmentEnd {base.ToString()}\n" +
@@ -82,7 +82,7 @@ namespace TrafficManager.Traffic.Impl {
             // TODO pre-calculate this
             uint avgSegLen = (uint)SegmentId.ToSegment().m_averageLength;
 
-            IDictionary<ushort, uint>[] ret =
+            Dictionary<ushort, uint>[] ret =
                 includeStopped ? numVehiclesGoingToSegmentId : numVehiclesMovingToSegmentId;
 
             // reset
@@ -313,8 +313,8 @@ namespace TrafficManager.Traffic.Impl {
         }
 
         private void RebuildVehicleNumDicts(ref NetNode node) {
-            numVehiclesMovingToSegmentId = new TinyDictionary<ushort, uint>[numLanes];
-            numVehiclesGoingToSegmentId = new TinyDictionary<ushort, uint>[numLanes];
+            numVehiclesMovingToSegmentId = new Dictionary<ushort, uint>[numLanes];
+            numVehiclesGoingToSegmentId = new Dictionary<ushort, uint>[numLanes];
 
             Constants.ServiceFactory.NetService.IterateSegmentLanes(
                 SegmentId,
@@ -325,8 +325,8 @@ namespace TrafficManager.Traffic.Impl {
                  ref NetSegment segment,
                  byte laneIndex) =>
                 {
-                    IDictionary<ushort, uint> numVehicleMoving = new TinyDictionary<ushort, uint>();
-                    IDictionary<ushort, uint> numVehicleGoing = new TinyDictionary<ushort, uint>();
+                    var numVehicleMoving = new Dictionary<ushort, uint>();
+                    var numVehicleGoing = new Dictionary<ushort, uint>();
 
                     numVehiclesMovingToSegmentId[laneIndex] = numVehicleMoving;
                     numVehiclesGoingToSegmentId[laneIndex] = numVehicleGoing;
@@ -350,12 +350,9 @@ namespace TrafficManager.Traffic.Impl {
                     continue;
                 }
 
-                foreach (TinyDictionary<ushort, uint> numVehiclesMovingToSegId in numVehiclesMovingToSegmentId) {
-                    numVehiclesMovingToSegId[segId] = 0;
-                }
-
-                foreach (TinyDictionary<ushort, uint> numVehiclesGoingToSegId in numVehiclesGoingToSegmentId) {
-                    numVehiclesGoingToSegId[segId] = 0;
+                for (int j = 0; j < numLanes; j++) {
+                    numVehiclesMovingToSegmentId[j][segId] = 0;
+                    numVehiclesGoingToSegmentId[j][segId] = 0;
                 }
             }
         } // end RebuildVehicleNumDicts

--- a/TLM/TLM/TrafficLight/Impl/CustomSegmentLights.cs
+++ b/TLM/TLM/TrafficLight/Impl/CustomSegmentLights.cs
@@ -71,7 +71,7 @@ namespace TrafficManager.TrafficLight.Impl {
 
         public IDictionary<ExtVehicleType, ICustomSegmentLight> CustomLights {
             get;
-        } = new TinyDictionary<ExtVehicleType, ICustomSegmentLight>();
+        } = new Dictionary<ExtVehicleType, ICustomSegmentLight>();
 
         // TODO replace collection
         public LinkedList<ExtVehicleType> VehicleTypes {

--- a/TLM/TLM/TrafficLight/Impl/TimedTrafficLights.cs
+++ b/TLM/TLM/TrafficLight/Impl/TimedTrafficLights.cs
@@ -251,7 +251,7 @@ namespace TrafficManager.TrafficLight.Impl {
                 () => $">>>>> TimedTrafficLights.UpdateDirections: called for node {NodeId}");
 
             IExtSegmentEndManager segEndMan = Constants.ManagerFactory.ExtSegmentEndManager;
-            Directions = new TinyDictionary<ushort, IDictionary<ushort, ArrowDirection>>();
+            Directions = new Dictionary<ushort, IDictionary<ushort, ArrowDirection>>();
 
             for (int i = 0; i < 8; ++i) {
                 ushort sourceSegmentId = node.GetSegment(i);
@@ -264,7 +264,7 @@ namespace TrafficManager.TrafficLight.Impl {
                     logTrafficLights,
                     () => $"TimedTrafficLights.UpdateDirections: Processing source segment {sourceSegmentId}");
 
-                IDictionary<ushort, ArrowDirection> dirs = new TinyDictionary<ushort, ArrowDirection>();
+                IDictionary<ushort, ArrowDirection> dirs = new Dictionary<ushort, ArrowDirection>();
                 Directions.Add(sourceSegmentId, dirs);
                 int endIndex = segEndMan.GetIndex(
                     sourceSegmentId,

--- a/TLM/TLM/TrafficLight/Impl/TimedTrafficLightsStep.cs
+++ b/TLM/TLM/TrafficLight/Impl/TimedTrafficLightsStep.cs
@@ -103,7 +103,7 @@ namespace TrafficManager.TrafficLight.Impl {
         private ITimedTrafficLights timedNode;
 
         public IDictionary<ushort, ICustomSegmentLights> CustomSegmentLights { get; }
-            = new TinyDictionary<ushort, ICustomSegmentLights>();
+            = new Dictionary<ushort, ICustomSegmentLights>();
 
         public LinkedList<ICustomSegmentLights> InvalidSegmentLights { get; }
             = new LinkedList<ICustomSegmentLights>();

--- a/TLM/TLM/UI/Textures/RoadUI.cs
+++ b/TLM/TLM/UI/Textures/RoadUI.cs
@@ -17,7 +17,7 @@ namespace TrafficManager.UI.Textures {
             IntVector2 size = new IntVector2(200);
 
             // priority signs
-            PrioritySignTextures = new TinyDictionary<PriorityType, Texture2D> {
+            PrioritySignTextures = new Dictionary<PriorityType, Texture2D> {
                 [PriorityType.None] = LoadDllResource("RoadUI.sign_none.png", size),
                 [PriorityType.Main] = LoadDllResource("RoadUI.sign_priority.png", size),
                 [PriorityType.Stop] = LoadDllResource(Translation.GetTranslatedFileName("RoadUI.sign_stop.png"), size),
@@ -28,15 +28,15 @@ namespace TrafficManager.UI.Textures {
             SignClear = LoadDllResource("clear.png", new IntVector2(256));
 
             VehicleRestrictionTextures =
-                new TinyDictionary<ExtVehicleType, IDictionary<bool, Texture2D>> {
-                    [ExtVehicleType.Bus] = new TinyDictionary<bool, Texture2D>(),
-                    [ExtVehicleType.CargoTrain] = new TinyDictionary<bool, Texture2D>(),
-                    [ExtVehicleType.CargoTruck] = new TinyDictionary<bool, Texture2D>(),
-                    [ExtVehicleType.Emergency] = new TinyDictionary<bool, Texture2D>(),
-                    [ExtVehicleType.PassengerCar] = new TinyDictionary<bool, Texture2D>(),
-                    [ExtVehicleType.PassengerTrain] = new TinyDictionary<bool, Texture2D>(),
-                    [ExtVehicleType.Service] = new TinyDictionary<bool, Texture2D>(),
-                    [ExtVehicleType.Taxi] = new TinyDictionary<bool, Texture2D>(),
+                new Dictionary<ExtVehicleType, IDictionary<bool, Texture2D>> {
+                    [ExtVehicleType.Bus] = new Dictionary<bool, Texture2D>(),
+                    [ExtVehicleType.CargoTrain] = new Dictionary<bool, Texture2D>(),
+                    [ExtVehicleType.CargoTruck] = new Dictionary<bool, Texture2D>(),
+                    [ExtVehicleType.Emergency] = new Dictionary<bool, Texture2D>(),
+                    [ExtVehicleType.PassengerCar] = new Dictionary<bool, Texture2D>(),
+                    [ExtVehicleType.PassengerTrain] = new Dictionary<bool, Texture2D>(),
+                    [ExtVehicleType.Service] = new Dictionary<bool, Texture2D>(),
+                    [ExtVehicleType.Taxi] = new Dictionary<bool, Texture2D>(),
                 };
 
             foreach (KeyValuePair<ExtVehicleType, IDictionary<bool, Texture2D>> e in
@@ -49,13 +49,13 @@ namespace TrafficManager.UI.Textures {
                 }
             }
 
-            ParkingRestrictionTextures = new TinyDictionary<bool, Texture2D>();
+            ParkingRestrictionTextures = new Dictionary<bool, Texture2D>();
             ParkingRestrictionTextures[true] = LoadDllResource("RoadUI.parking_allowed.png", size);
             ParkingRestrictionTextures[false] = LoadDllResource("RoadUI.parking_disallowed.png", size);
 
             IntVector2 signSize = new IntVector2(449, 411);
 
-            VehicleInfoSignTextures = new TinyDictionary<ExtVehicleType, Texture2D> {
+            VehicleInfoSignTextures = new Dictionary<ExtVehicleType, Texture2D> {
                 [ExtVehicleType.Bicycle] = LoadDllResource("RoadUI.bicycle_infosign.png", signSize),
                 [ExtVehicleType.Bus] = LoadDllResource("RoadUI.bus_infosign.png", signSize),
                 [ExtVehicleType.CargoTrain] = LoadDllResource("RoadUI.cargotrain_infosign.png", signSize),

--- a/TLM/TLM/UI/Textures/SpeedLimitTextures.cs
+++ b/TLM/TLM/UI/Textures/SpeedLimitTextures.cs
@@ -25,9 +25,9 @@ namespace TrafficManager.UI.Textures {
 
         static SpeedLimitTextures() {
             // TODO: Split loading here into dynamic sections, static enforces everything to stay in this ctor
-            TexturesKmph = new TinyDictionary<int, Texture2D>();
-            TexturesMphUS = new TinyDictionary<int, Texture2D>();
-            TexturesMphUK = new TinyDictionary<int, Texture2D>();
+            TexturesKmph = new Dictionary<int, Texture2D>();
+            TexturesMphUS = new Dictionary<int, Texture2D>();
+            TexturesMphUK = new Dictionary<int, Texture2D>();
 
             IntVector2 size = new IntVector2(200);
             IntVector2 sizeUS = new IntVector2(200, 250);

--- a/TLM/TLM/UI/TrafficManagerTool.cs
+++ b/TLM/TLM/UI/TrafficManagerTool.cs
@@ -206,10 +206,10 @@ namespace TrafficManager.UI {
 
             LegacySubTool timedLightsTool = new TimedTrafficLightsTool(this);
 
-            subTools_ = new TinyDictionary<ToolMode, TrafficManagerSubTool> {
+            subTools_ = new Dictionary<ToolMode, TrafficManagerSubTool> {
                 [ToolMode.LaneArrows] = new LaneArrowTool(this),
             };
-            legacySubTools_ = new TinyDictionary<ToolMode, LegacySubTool> {
+            legacySubTools_ = new Dictionary<ToolMode, LegacySubTool> {
                 [ToolMode.ToggleTrafficLight] = new ToggleTrafficLightsTool(this),
                 [ToolMode.AddPrioritySigns] = new PrioritySignsTool(this),
                 [ToolMode.ManualSwitch] = new ManualTrafficLightsTool(this),


### PR DESCRIPTION
After quick benchmarking session I found that `TinyDictionary<>` used in few places(including performance critical):
- is slow to add/remove items, 
- memory heavy
- and creates garbage under normal operations like reading `value` by `key`

![image](https://user-images.githubusercontent.com/19638970/133864627-6132d00b-4d5b-44e3-a364-f33584ba6ae9.png)
