### PR TITLE
Trains not counted as waiting - Timed Traffic Lights

### DIFF
--- a/TLM/TLM/Patch/_VehicleAI/_TrainAI/Connection/TrainAIConnection.cs
+++ b/TLM/TLM/Patch/_VehicleAI/_TrainAI/Connection/TrainAIConnection.cs
@@ -34,6 +34,11 @@ namespace TrafficManager.Patch._VehicleAI._TrainAI.Connection {
     public delegate void ReverseDelegate(ushort leaderID,
                                          ref Vehicle leaderData);
 
+    public delegate void ForceTrafficLightsDelegate(TrainAI trainAI,
+                                        ushort vehicleID,
+                                        ref Vehicle vehicleData,
+                                        bool reserveSpace);
+
     internal class TrainAIConnection {
         internal TrainAIConnection(UpdatePathTargetPositionsDelegate updatePathTargetPositionsDelegate,
                                    GetNoiseLevelDelegate getNoiseLevelDelegate,
@@ -41,7 +46,8 @@ namespace TrafficManager.Patch._VehicleAI._TrainAI.Connection {
                                    CalculateMaxSpeedDelegate calculateMaxSpeedDelegate,
                                    ReverseDelegate reverseDelegate,
                                    CalculateTargetSpeedTrainDelegate calculateTargetSpeedDelegate,
-                                   CheckOverlapDelegate checkOverlapDelegate) {
+                                   CheckOverlapDelegate checkOverlapDelegate,
+                                   ForceTrafficLightsDelegate forceTrafficLightsDelegate) {
             UpdatePathTargetPositions = updatePathTargetPositionsDelegate ?? throw new ArgumentNullException(nameof(updatePathTargetPositionsDelegate));
             GetNoiseLevel = getNoiseLevelDelegate ?? throw new ArgumentNullException(nameof(getNoiseLevelDelegate));
             GetMaxSpeed = getMaxSpeedDelegate ?? throw new ArgumentNullException(nameof(getMaxSpeedDelegate));
@@ -49,6 +55,7 @@ namespace TrafficManager.Patch._VehicleAI._TrainAI.Connection {
             Reverse = reverseDelegate ?? throw new ArgumentNullException(nameof(reverseDelegate));
             CalculateTargetSpeed = calculateTargetSpeedDelegate ?? throw new ArgumentNullException( nameof(calculateTargetSpeedDelegate));
             CheckOverlap = checkOverlapDelegate ?? throw new ArgumentNullException(nameof(checkOverlapDelegate));
+            ForceTrafficLights = forceTrafficLightsDelegate ?? throw new ArgumentNullException(nameof(forceTrafficLightsDelegate));
         }
 
         public UpdatePathTargetPositionsDelegate UpdatePathTargetPositions { get; }
@@ -58,5 +65,6 @@ namespace TrafficManager.Patch._VehicleAI._TrainAI.Connection {
         public ReverseDelegate Reverse { get; }
         public CalculateTargetSpeedTrainDelegate CalculateTargetSpeed { get; }
         public CheckOverlapDelegate CheckOverlap { get; }
+        public ForceTrafficLightsDelegate ForceTrafficLights { get; }
     }
 }

--- a/TLM/TLM/Patch/_VehicleAI/_TrainAI/Connection/TrainAIHook.cs
+++ b/TLM/TLM/Patch/_VehicleAI/_TrainAI/Connection/TrainAIHook.cs
@@ -41,6 +41,11 @@ namespace TrafficManager.Patch._VehicleAI._TrainAI.Connection {
                         typeof(TrainAI),
                         "CheckOverlap",
                         false);
+                ForceTrafficLightsDelegate forceTrafficLightsDelegate =
+                    TranspilerUtil.CreateDelegate<ForceTrafficLightsDelegate>(
+                        typeof(TrainAI),
+                        "ForceTrafficLights",
+                        true);
 
                 return new TrainAIConnection(
                     updatePathTargetPositionsDelegate,
@@ -49,7 +54,8 @@ namespace TrafficManager.Patch._VehicleAI._TrainAI.Connection {
                     calculateMaxSpeedDelegate,
                     reverseDelegate,
                     calculateTargetSpeedDelegate,
-                    checkOverlapDelegate);
+                    checkOverlapDelegate,
+                    forceTrafficLightsDelegate);
             } catch (Exception e) {
                 Log.Error(e.Message);
                 return null;

--- a/TLM/TLM/Patch/_VehicleAI/_TrainAI/SimulationStep2Patch.cs
+++ b/TLM/TLM/Patch/_VehicleAI/_TrainAI/SimulationStep2Patch.cs
@@ -28,6 +28,7 @@ namespace TrafficManager.Patch._VehicleAI._TrainAI {
         private static CalculateMaxSpeedDelegate CalculateMaxSpeed;
         private static ReverseDelegate Reverse;
         private static CalculateTargetSpeedTrainDelegate CalculateTargetSpeed;
+        private static ForceTrafficLightsDelegate ForceTrafficLights;
 
         [UsedImplicitly]
         public static void Prepare() {
@@ -37,6 +38,7 @@ namespace TrafficManager.Patch._VehicleAI._TrainAI {
             CalculateMaxSpeed = GameConnectionManager.Instance.TrainAIConnection.CalculateMaxSpeed;
             Reverse = GameConnectionManager.Instance.TrainAIConnection.Reverse;
             CalculateTargetSpeed = GameConnectionManager.Instance.TrainAIConnection.CalculateTargetSpeed;
+            ForceTrafficLights = GameConnectionManager.Instance.TrainAIConnection.ForceTrafficLights;
         }
 
         [UsedImplicitly]
@@ -353,7 +355,7 @@ namespace TrafficManager.Patch._VehicleAI._TrainAI {
                 if ((leaderData.m_flags & (Vehicle.Flags.WaitingPath
                                            | Vehicle.Flags.Stopped)) == 0
                     && ___m_info.m_vehicleType != VehicleInfo.VehicleType.Monorail) {
-                    // this.ForceTrafficLights(vehicleID, ref vehicleData, curSpeed > 0.1f);
+                    ForceTrafficLights(__instance, vehicleID, ref vehicleData, curSpeed > 0.1f);
                     // NON-STOCK CODE
                 }
 

--- a/TLM/TLM/Patch/_VehicleAI/_TrainAI/SimulationStepPatch.cs
+++ b/TLM/TLM/Patch/_VehicleAI/_TrainAI/SimulationStepPatch.cs
@@ -1,5 +1,6 @@
 namespace TrafficManager.Patch._VehicleAI._TrainAI {
     using System.Collections.Generic;
+    using System.Linq;
     using System.Reflection;
     using System.Reflection.Emit;
     using HarmonyLib;
@@ -14,7 +15,7 @@ namespace TrafficManager.Patch._VehicleAI._TrainAI {
         private delegate void TargetDelegate(ushort vehicleID, ref Vehicle data, Vector3 physicsLodRefPos);
 
         [UsedImplicitly]
-        public static MethodBase TargetMethod() => TranspilerUtil.DeclaredMethod<TargetDelegate>(typeof(TrainAI), nameof(TramBaseAI.SimulationStep));
+        public static MethodBase TargetMethod() => TranspilerUtil.DeclaredMethod<TargetDelegate>(typeof(TrainAI), nameof(TrainAI.SimulationStep));
 
         [UsedImplicitly]
         public static IEnumerable<CodeInstruction> Transpiler(ILGenerator il, IEnumerable<CodeInstruction> instructions) {


### PR DESCRIPTION
Fixes #1173 

- wrong label target resulted in completely skipped code at normal conditions.
- added missing call to `ForceTrafficLights()` (I think I forgot to fix that while migrating to Harmony)