### PR TITLE
improve lifecycle of TMPE tool

### DIFF
--- a/TLM/TLM/Patch/_DefaultTool/OnToolGUIPatch.cs
+++ b/TLM/TLM/Patch/_DefaultTool/OnToolGUIPatch.cs
@@ -15,7 +15,8 @@ namespace TrafficManager.Patch._DefaultTool {
         public static void Postfix(Event e) {
             if (TMPELifecycle.PlayMode && !TrafficManagerTool.IsCurrentTool) {
                 if (UI.SubTools.PrioritySigns.MassEditOverlay.IsActive) {
-                    ModUI.GetTrafficManagerTool(true).OnToolGUIImpl(e);
+                    ModUI.
+                        GetTrafficManagerTool()?.OnToolGUIImpl(e);
                 }
             }
         }

--- a/TLM/TLM/Patch/_DefaultTool/RenderOverlayPatch.cs
+++ b/TLM/TLM/Patch/_DefaultTool/RenderOverlayPatch.cs
@@ -15,7 +15,7 @@ namespace TrafficManager.Patch._DefaultTool {
         public static void Postfix(RenderManager.CameraInfo cameraInfo) {
             if (TMPELifecycle.PlayMode && !TrafficManagerTool.IsCurrentTool) {
                 if (UI.SubTools.PrioritySigns.MassEditOverlay.IsActive) {
-                    ModUI.GetTrafficManagerTool(true).RenderOverlayImpl(cameraInfo);
+                    ModUI.GetTrafficManagerTool()?.RenderOverlayImpl(cameraInfo);
                 }
                 RoadSelectionPanels.Root.RenderOverlay();
             }

--- a/TLM/TLM/State/OptionsTabs/OptionsGeneralTab.cs
+++ b/TLM/TLM/State/OptionsTabs/OptionsGeneralTab.cs
@@ -223,7 +223,7 @@ namespace TrafficManager.State {
             Log._Debug($"Use UUI set to {newValue}");
             GlobalConfig.Instance.Main.UseUUI = newValue;
             GlobalConfig.WriteConfig();
-            var button = ModUI.GetTrafficManagerTool(false)?.UUIButton;
+            var button = ModUI.GetTrafficManagerTool()?.UUIButton;
             if (button) {
                 button.isVisible = newValue;
             }

--- a/TLM/TLM/State/OptionsTabs/OptionsOverlaysTab.cs
+++ b/TLM/TLM/State/OptionsTabs/OptionsOverlaysTab.cs
@@ -90,7 +90,7 @@ namespace TrafficManager.State {
                 _prioritySignsOverlayToggle.isChecked = newPrioritySignsOverlay;
             }
 
-            ModUI.GetTrafficManagerTool(false)?.InitializeSubTools();
+            ModUI.GetTrafficManagerTool()?.InitializeSubTools();
         }
 
         public static void SetTimedLightsOverlay(bool newTimedLightsOverlay) {
@@ -100,7 +100,7 @@ namespace TrafficManager.State {
                 _timedLightsOverlayToggle.isChecked = newTimedLightsOverlay;
             }
 
-            ModUI.GetTrafficManagerTool(false)?.InitializeSubTools();
+            ModUI.GetTrafficManagerTool()?.InitializeSubTools();
         }
 
         public static void SetSpeedLimitsOverlay(bool newSpeedLimitsOverlay) {
@@ -110,7 +110,7 @@ namespace TrafficManager.State {
                 _speedLimitsOverlayToggle.isChecked = newSpeedLimitsOverlay;
             }
 
-            ModUI.GetTrafficManagerTool(false)?.InitializeSubTools();
+            ModUI.GetTrafficManagerTool()?.InitializeSubTools();
         }
 
         public static void SetVehicleRestrictionsOverlay(bool newVehicleRestrictionsOverlay) {
@@ -120,7 +120,7 @@ namespace TrafficManager.State {
                 _vehicleRestrictionsOverlayToggle.isChecked = newVehicleRestrictionsOverlay;
             }
 
-            ModUI.GetTrafficManagerTool(false)?.InitializeSubTools();
+            ModUI.GetTrafficManagerTool()?.InitializeSubTools();
         }
 
         public static void SetParkingRestrictionsOverlay(bool newParkingRestrictionsOverlay) {
@@ -130,7 +130,7 @@ namespace TrafficManager.State {
                 _parkingRestrictionsOverlayToggle.isChecked = newParkingRestrictionsOverlay;
             }
 
-            ModUI.GetTrafficManagerTool(false)?.InitializeSubTools();
+            ModUI.GetTrafficManagerTool()?.InitializeSubTools();
         }
 
         public static void SetJunctionRestrictionsOverlay(bool newValue) {
@@ -140,7 +140,7 @@ namespace TrafficManager.State {
                 _junctionRestrictionsOverlayToggle.isChecked = newValue;
             }
 
-            ModUI.GetTrafficManagerTool(false)?.InitializeSubTools();
+            ModUI.GetTrafficManagerTool()?.InitializeSubTools();
         }
 
         public static void SetConnectedLanesOverlay(bool newValue) {
@@ -158,7 +158,7 @@ namespace TrafficManager.State {
                 _nodesOverlayToggle.isChecked = newNodesOverlay;
             }
 
-            ModUI.GetTrafficManagerTool(false)?.InitializeSubTools();
+            ModUI.GetTrafficManagerTool()?.InitializeSubTools();
         }
 
         public static void SetVehicleOverlay(bool newVal) {
@@ -177,7 +177,7 @@ namespace TrafficManager.State {
             Log._Debug($"prioritySignsOverlay changed to {newPrioritySignsOverlay}");
             Options.prioritySignsOverlay = newPrioritySignsOverlay;
 
-            ModUI.GetTrafficManagerTool(false)?.InitializeSubTools();
+            ModUI.GetTrafficManagerTool()?.InitializeSubTools();
         }
 
         private static void OnTimedLightsOverlayChanged(bool newTimedLightsOverlay) {
@@ -188,7 +188,7 @@ namespace TrafficManager.State {
             Log._Debug($"timedLightsOverlay changed to {newTimedLightsOverlay}");
             Options.timedLightsOverlay = newTimedLightsOverlay;
 
-            ModUI.GetTrafficManagerTool(false)?.InitializeSubTools();
+            ModUI.GetTrafficManagerTool()?.InitializeSubTools();
         }
 
         private static void OnSpeedLimitsOverlayChanged(bool newSpeedLimitsOverlay) {
@@ -199,7 +199,7 @@ namespace TrafficManager.State {
             Log._Debug($"speedLimitsOverlay changed to {newSpeedLimitsOverlay}");
             Options.speedLimitsOverlay = newSpeedLimitsOverlay;
 
-            ModUI.GetTrafficManagerTool(false)?.InitializeSubTools();
+            ModUI.GetTrafficManagerTool()?.InitializeSubTools();
         }
 
         private static void OnVehicleRestrictionsOverlayChanged(bool newVehicleRestrictionsOverlay) {
@@ -210,7 +210,7 @@ namespace TrafficManager.State {
             Log._Debug($"vehicleRestrictionsOverlay changed to {newVehicleRestrictionsOverlay}");
             Options.vehicleRestrictionsOverlay = newVehicleRestrictionsOverlay;
 
-            ModUI.GetTrafficManagerTool(false)?.InitializeSubTools();
+            ModUI.GetTrafficManagerTool()?.InitializeSubTools();
         }
 
         private static void OnParkingRestrictionsOverlayChanged(bool newParkingRestrictionsOverlay) {
@@ -221,7 +221,7 @@ namespace TrafficManager.State {
             Log._Debug($"parkingRestrictionsOverlay changed to {newParkingRestrictionsOverlay}");
             Options.parkingRestrictionsOverlay = newParkingRestrictionsOverlay;
 
-            ModUI.GetTrafficManagerTool(false)?.InitializeSubTools();
+            ModUI.GetTrafficManagerTool()?.InitializeSubTools();
         }
 
         private static void OnJunctionRestrictionsOverlayChanged(bool newValue) {
@@ -232,7 +232,7 @@ namespace TrafficManager.State {
             Log._Debug($"junctionRestrictionsOverlay changed to {newValue}");
             Options.junctionRestrictionsOverlay = newValue;
 
-            ModUI.GetTrafficManagerTool(false)?.InitializeSubTools();
+            ModUI.GetTrafficManagerTool()?.InitializeSubTools();
         }
 
         private static void OnConnectedLanesOverlayChanged(bool newValue) {
@@ -243,7 +243,7 @@ namespace TrafficManager.State {
             Log._Debug($"connectedLanesOverlay changed to {newValue}");
             Options.connectedLanesOverlay = newValue;
 
-            ModUI.GetTrafficManagerTool(false)?.InitializeSubTools();
+            ModUI.GetTrafficManagerTool()?.InitializeSubTools();
         }
 
         private static void onNodesOverlayChanged(bool newNodesOverlay) {

--- a/TLM/TLM/State/OptionsTabs/OptionsVehicleRestrictionsTab.cs
+++ b/TLM/TLM/State/OptionsTabs/OptionsVehicleRestrictionsTab.cs
@@ -298,7 +298,7 @@ namespace TrafficManager.State {
             Log._Debug($"banRegularTrafficOnBusLanes changed to {newValue}");
             Options.banRegularTrafficOnBusLanes = newValue;
             VehicleRestrictionsManager.Instance.ClearCache();
-            ModUI.GetTrafficManagerTool(false)?.InitializeSubTools();
+            ModUI.GetTrafficManagerTool()?.InitializeSubTools();
         }
 
         private static void OnHighwayRulesChanged(bool newHighwayRules) {
@@ -343,7 +343,7 @@ namespace TrafficManager.State {
             }
 
             Constants.ManagerFactory.JunctionRestrictionsManager.UpdateAllDefaults();
-            ModUI.GetTrafficManagerTool(false)?.InitializeSubTools();
+            ModUI.GetTrafficManagerTool()?.InitializeSubTools();
         }
 
         public static void SetPrioritySignsEnabled(bool newValue) {
@@ -380,7 +380,7 @@ namespace TrafficManager.State {
             }
 
             Constants.ManagerFactory.JunctionRestrictionsManager.UpdateAllDefaults();
-            ModUI.GetTrafficManagerTool(false)?.InitializeSubTools();
+            ModUI.GetTrafficManagerTool()?.InitializeSubTools();
         }
 
         public static void SetAllowNearTurnOnRed(bool newValue) {
@@ -391,7 +391,7 @@ namespace TrafficManager.State {
             }
 
             Constants.ManagerFactory.JunctionRestrictionsManager.UpdateAllDefaults();
-            ModUI.GetTrafficManagerTool(false)?.InitializeSubTools();
+            ModUI.GetTrafficManagerTool()?.InitializeSubTools();
         }
 
         public static void SetAllowFarTurnOnRed(bool newValue) {
@@ -402,7 +402,7 @@ namespace TrafficManager.State {
             }
 
             Constants.ManagerFactory.JunctionRestrictionsManager.UpdateAllDefaults();
-            ModUI.GetTrafficManagerTool(false)?.InitializeSubTools();
+            ModUI.GetTrafficManagerTool()?.InitializeSubTools();
         }
 
         public static void SetAllowLaneChangesWhileGoingStraight(bool value) {
@@ -410,7 +410,7 @@ namespace TrafficManager.State {
             if (_allowLaneChangesWhileGoingStraightToggle != null)
                 _allowLaneChangesWhileGoingStraightToggle.isChecked = value;
             Constants.ManagerFactory.JunctionRestrictionsManager.UpdateAllDefaults();
-            ModUI.GetTrafficManagerTool(false)?.InitializeSubTools();
+            ModUI.GetTrafficManagerTool()?.InitializeSubTools();
         }
 
         public static void SetRelaxedBusses(bool newRelaxedBusses) {
@@ -473,7 +473,7 @@ namespace TrafficManager.State {
             }
 
             VehicleRestrictionsManager.Instance.ClearCache();
-            ModUI.GetTrafficManagerTool(false)?.InitializeSubTools();
+            ModUI.GetTrafficManagerTool()?.InitializeSubTools();
         }
 
         public static void SetAddTrafficLightsIfApplicable(bool value) {

--- a/TLM/TLM/UI/MainMenu/BaseMenuToolModeButton.cs
+++ b/TLM/TLM/UI/MainMenu/BaseMenuToolModeButton.cs
@@ -1,4 +1,4 @@
-﻿namespace TrafficManager.UI.MainMenu {
+namespace TrafficManager.UI.MainMenu {
     using ColossalFramework.UI;
     using TrafficManager.UI;
 
@@ -9,11 +9,11 @@
         protected abstract ToolMode ToolMode { get; }
 
         protected override bool IsActive() =>
-            ToolMode.Equals(ModUI.GetTrafficManagerTool(false)?.GetToolMode());
+            ToolMode.Equals(ModUI.GetTrafficManagerTool()?.GetToolMode());
 
         protected override void OnClick(UIMouseEventParameter p) {
             ModUI.GetTrafficManagerTool()
-                 .SetToolMode(IsActive() ? ToolMode.None : ToolMode);
+                 ?.SetToolMode(IsActive() ? ToolMode.None : ToolMode);
             base.OnClick(p);
         }
     }

--- a/TLM/TLM/UI/MainMenu/ClearTrafficButton.cs
+++ b/TLM/TLM/UI/MainMenu/ClearTrafficButton.cs
@@ -35,7 +35,7 @@ namespace TrafficManager.UI.MainMenu {
                             () => UtilityManager.Instance.ClearTraffic());
                     }
 
-                    ModUI.GetTrafficManagerTool(true).SetToolMode(ToolMode.None);
+                    ModUI.GetTrafficManagerTool()?.SetToolMode(ToolMode.None);
                 });
             base.OnClick(p);
         }

--- a/TLM/TLM/UI/MainMenu/DespawnButton.cs
+++ b/TLM/TLM/UI/MainMenu/DespawnButton.cs
@@ -32,7 +32,7 @@ namespace TrafficManager.UI.MainMenu {
 
         protected override void OnClick(UIMouseEventParameter p) {
             // Immediately unclick the tool button, but toggle the option
-            ModUI.GetTrafficManagerTool(true).SetToolMode(ToolMode.None);
+            ModUI.GetTrafficManagerTool()?.SetToolMode(ToolMode.None);
 
             // Toggle the despawning value
             OptionsGameplayTab.SetDisableDespawning(!Options.disableDespawning);

--- a/TLM/TLM/UI/MainMenu/MainMenuWindow.cs
+++ b/TLM/TLM/UI/MainMenu/MainMenuWindow.cs
@@ -310,7 +310,7 @@ namespace TrafficManager.UI.MainMenu {
             Log._Debug($"Toggle value of KeybindsPanelVisible to {value}");
 
             // Refer to the TrafficManager tool asking it to request help from the current tool
-            ModUI.GetTrafficManagerTool().RequestOnscreenDisplayUpdate();
+            ModUI.GetTrafficManagerTool()?.RequestOnscreenDisplayUpdate();
         }
 
         private void SetupControls_DebugLabels(UBuilder builder,

--- a/TLM/TLM/UI/ModUI.cs
+++ b/TLM/TLM/UI/ModUI.cs
@@ -244,7 +244,6 @@ namespace TrafficManager.UI {
             EnsureTrafficManagerTool();
 
             ToolsModifierControl.toolController.CurrentTool = GetTrafficManagerTool();
-            ToolsModifierControl.SetTool<TrafficManagerTool>();
         }
 
         public static void OnLevelLoaded() {
@@ -268,7 +267,7 @@ namespace TrafficManager.UI {
             } else if (ToolsModifierControl.toolController.CurrentTool != trafficManagerTool_) {
                 Log.Info("ModUI.DisableTool: CurrentTool is not traffic manager tool!");
             } else {
-                trafficManagerTool_.enabled = false;
+                ToolsModifierControl.SetTool<DefaultTool>();
             }
         }
 

--- a/TLM/TLM/UI/RoadSelectionPanels.cs
+++ b/TLM/TLM/UI/RoadSelectionPanels.cs
@@ -69,9 +69,6 @@ namespace TrafficManager.UI {
 
         public void Start() {
             Root = this;
-            // this code prevents a rare bug that RoadWorldInfoPanel some times does not show.
-            EnqueueAction(ModUI.Instance.ShowMainMenu);
-            EnqueueAction(ModUI.Instance.CloseMainMenu);
 
             panels_ = new List<PanelExt>();
 
@@ -184,7 +181,8 @@ namespace TrafficManager.UI {
         }
 
         internal void UpdateMassEditOverlay() {
-            if (ModUI.GetTrafficManagerTool().GetToolMode() == ToolMode.None) {
+            var tool = ModUI.GetTrafficManagerTool();
+            if (tool && tool.GetToolMode() == ToolMode.None) {
                 if (!UI.SubTools.PrioritySigns.MassEditOverlay.IsActive) {
                     if (ShouldShowMassEditOverlay()) {
                         ShowMassEditOverlay();
@@ -242,9 +240,9 @@ namespace TrafficManager.UI {
         /// Enables and refreshes overrlay for various traffic rules influenced by road selection pannel.
         /// </summary>
         private void ShowMassEditOverlay() {
-            var tmTool = ModUI.GetTrafficManagerTool(true);
+            var tmTool = ModUI.GetTrafficManagerTool();
             if (tmTool == null) {
-                Log.Error("ModUI.GetTrafficManagerTool(true) returned null");
+                Log.Error("ModUI.GetTrafficManagerTool() returned null");
                 return;
             }
             UI.SubTools.PrioritySigns.MassEditOverlay.Show = true;

--- a/TLM/TLM/UI/SubTools/PrioritySigns/PrioritySignsTool.cs
+++ b/TLM/TLM/UI/SubTools/PrioritySigns/PrioritySignsTool.cs
@@ -149,7 +149,7 @@ namespace TrafficManager.UI.SubTools.PrioritySigns {
             // even when the user lets go of the mass edit overlay hotkey.
             MassEditOverlay.SetTimer(float.MaxValue);
 
-            ModUI.GetTrafficManagerTool(false)?.InitializeSubTools();
+            ModUI.GetTrafficManagerTool()?.InitializeSubTools();
             RefreshCurrentPriorityNodeIds();
 
             // keep active for one more second so that the user
@@ -277,7 +277,7 @@ namespace TrafficManager.UI.SubTools.PrioritySigns {
                 return;
             }
 
-            if (ModUI.GetTrafficManagerTool(false)?.GetToolMode()
+            if (ModUI.GetTrafficManagerTool()?.GetToolMode()
                 == ToolMode.JunctionRestrictions)
             {
                 return;

--- a/TLM/TLM/UI/TrafficManagerTool.cs
+++ b/TLM/TLM/UI/TrafficManagerTool.cs
@@ -248,11 +248,16 @@ namespace TrafficManager.UI {
         }
 
         protected override void Awake() {
-            Log._Debug($"TrafficManagerTool: Awake {GetHashCode()}");
-            nopeCursor_ = ScriptableObject.CreateInstance<CursorInfo>();
-            nopeCursor_.m_texture = UIView.GetAView().defaultAtlas["Niet"]?.texture;
-            nopeCursor_.m_hotspot = new Vector2(45,45);
-            base.Awake();
+            try {
+                Log._Debug($"TrafficManagerTool: Awake {GetHashCode()}");
+                base.Awake();
+                nopeCursor_ = ScriptableObject.CreateInstance<CursorInfo>();
+                nopeCursor_.m_texture = UIView.GetAView().defaultAtlas["Niet"]?.texture;
+                nopeCursor_.m_hotspot = new Vector2(45, 45);
+                Initialize();
+            } catch(Exception ex) {
+                ex.LogException();
+            }
         }
 
         /// <summary>Only used from CustomRoadBaseAI.</summary>


### PR DESCRIPTION
UUI button is created when TMPE tool is created so we need this to be created on startup. also the Road selection panels need it. for this reason I ensure TMPE tool is created as soon as game is loaded.

Additionally there was a buggy recursion issue when TMPE tool is enabled for the first time outside of EnableTool(). I solved it by only creating the TMPE tool inside EnableTool() and making the function private.

This will not only get rid of hackish code in RoadSelectionPanels but also solve the issue that UUI button is not created in asset editor.

PS: I also had to change a transpiler. instead of modifying il instructions I called a function instead which is easier to maintain.

[TMPE.zip](https://ci.appveyor.com/api/projects/krzychu124/tmpe/artifacts/TMPE.zip?branch=uui-fix)