### PR TITLE
Replace hardcoded CitizenUnit buffer limits with buffer size detection

### DIFF
--- a/TLM/TLM/Manager/Impl/ExtVehicleManager.cs
+++ b/TLM/TLM/Manager/Impl/ExtVehicleManager.cs
@@ -81,6 +81,7 @@ namespace TrafficManager.Manager.Impl {
             // (stock code from PassengerCarAI.GetDriverInstance)
             CitizenManager citizenManager = Singleton<CitizenManager>.instance;
             uint citizenUnitId = data.m_citizenUnits;
+            uint maxUnitCount = citizenManager.m_units.m_size;
             int numIter = 0;
 
             while (citizenUnitId != 0) {
@@ -99,7 +100,7 @@ namespace TrafficManager.Manager.Impl {
                 }
 
                 citizenUnitId = nextCitizenUnitId;
-                if (++numIter > CitizenManager.MAX_UNIT_COUNT) {
+                if (++numIter > maxUnitCount) {
                     CODebugBase<LogChannel>.Error(
                         LogChannel.Core,
                         "Invalid list detected!\n" + Environment.StackTrace);

--- a/TLM/TLM/Manager/Impl/VehicleBehaviorManager.cs
+++ b/TLM/TLM/Manager/Impl/VehicleBehaviorManager.cs
@@ -90,6 +90,7 @@ namespace TrafficManager.Manager.Impl {
             CitizenManager citizenManager = Singleton<CitizenManager>.instance;
             NetManager netManager = Singleton<NetManager>.instance;
             VehicleManager vehicleManager = Singleton<VehicleManager>.instance;
+            uint maxUnitCount = citizenManager.m_units.m_size;
 
             // NON-STOCK CODE START
             bool prohibitPocketCars = false;
@@ -456,7 +457,7 @@ namespace TrafficManager.Manager.Impl {
 
                         curUnitId = nextUnit;
 
-                        if (++numIter > CitizenManager.MAX_UNIT_COUNT) {
+                        if (++numIter > maxUnitCount) {
                             CODebugBase<LogChannel>.Error(
                                 LogChannel.Core,
                                 $"Invalid list detected!\n{Environment.StackTrace}");
@@ -531,7 +532,7 @@ namespace TrafficManager.Manager.Impl {
 
                     curCitizenUnitId = nextUnit;
 
-                    if (++numIter > CitizenManager.MAX_UNIT_COUNT) {
+                    if (++numIter > maxUnitCount) {
                         CODebugBase<LogChannel>.Error(
                             LogChannel.Core,
                             $"Invalid list detected!\n{Environment.StackTrace}");

--- a/TLM/TLM/Patch/_VehicleAI/_PassengerCarAI/ParkVehiclePatch.cs
+++ b/TLM/TLM/Patch/_VehicleAI/_PassengerCarAI/ParkVehiclePatch.cs
@@ -19,6 +19,7 @@ namespace TrafficManager.Patch._VehicleAI._PassengerCarAI {
                                   int nextPositionIndex,
                                   out byte segmentOffset) {
              CitizenManager citizenManager = Singleton<CitizenManager>.instance;
+            uint maxUnitCount = citizenManager.m_units.m_size;
 
             uint driverCitizenId = 0u;
             ushort driverCitizenInstanceId = 0;
@@ -49,7 +50,7 @@ namespace TrafficManager.Patch._VehicleAI._PassengerCarAI {
                 }
 
                 curCitizenUnitId = nextUnit;
-                if (++numIterations > CitizenManager.MAX_UNIT_COUNT) {
+                if (++numIterations > maxUnitCount) {
                     CODebugBase<LogChannel>.Error(LogChannel.Core,
                                                   $"Invalid list detected!\n{Environment.StackTrace}");
                     break;


### PR DESCRIPTION
For compatibility with mods that change the size of the CitizenUnit buffer.

Tested for stability and performance both with and without More CitizenUnits mod (development versions); no issues detected.