### PR TITLE
Incompatible detector improvements

### DIFF
--- a/TLM/TLM/Resources/incompatible_mods.txt
+++ b/TLM/TLM/Resources/incompatible_mods.txt
@@ -50,3 +50,4 @@
 417926819;Road Assistant
 631930385;Realistic Vehicle Speeds
 1072157697;Cargo Info
+1558438291;Cities Multiplayer Mod (CSM) [Beta]


### PR DESCRIPTION
 - added CSM (Cities Skylines Multiplayer) to the list of incompatible mods
 - improved detection and removal of local mods, 
 - extended scanning with potentially game-breaking mods (CSM)


[Compiled build](https://ci.appveyor.com/api/projects/krzychu124/tmpe/artifacts/TMPE.zip?branch=incompatible-detector-improvements)