### PR TITLE
Fixed recalculation after lane connection remove

### DIFF
--- a/TLM/TLM/Manager/Impl/LaneConnectionManager.cs
+++ b/TLM/TLM/Manager/Impl/LaneConnectionManager.cs
@@ -257,8 +257,8 @@ namespace TrafficManager.Manager.Impl {
             RecalculateLaneArrows(laneId1, commonNodeId, startNode1);
             RecalculateLaneArrows(laneId2, commonNodeId, startNode2);
 
-            RoutingManager.Instance.RequestRecalculation(segmentId1, false);
-            RoutingManager.Instance.RequestRecalculation(segmentId2, false);
+            ref NetNode commonNode = ref commonNodeId.ToNode();
+            RoutingManager.Instance.RequestNodeRecalculation(ref commonNode);
 
             if (OptionsManager.Instance.MayPublishSegmentChanges()) {
                 ExtSegmentManager extSegmentManager = ExtSegmentManager.Instance;

--- a/TLM/TLM/Manager/Impl/RoutingManager.cs
+++ b/TLM/TLM/Manager/Impl/RoutingManager.cs
@@ -167,24 +167,21 @@ namespace TrafficManager.Manager.Impl {
             }
 
             if (propagate) {
-                //TODO refactor into RequestRecalculation(ushort nodeId)
-
                 ref NetSegment netSegment = ref segmentId.ToSegment();
 
                 ref NetNode startNode = ref netSegment.m_startNode.ToNode();
-                for (int i = 0; i < 8; ++i) {
-                    ushort otherSegmentId = startNode.GetSegment(i);
-                    if (otherSegmentId != 0) {
-                        RequestRecalculation(otherSegmentId, false);
-                    }
-                }
+                RequestNodeRecalculation(ref startNode);
 
                 ref NetNode endNode = ref netSegment.m_endNode.ToNode();
-                for (int i = 0; i < 8; ++i) {
-                    ushort otherSegmentId = endNode.GetSegment(i);
-                    if (otherSegmentId != 0) {
-                        RequestRecalculation(otherSegmentId, false);
-                    }
+                RequestNodeRecalculation(ref endNode);
+            }
+        }
+
+        public void RequestNodeRecalculation(ref NetNode node) {
+            for (int i = 0; i < 8; ++i) {
+                ushort otherSegmentId = node.GetSegment(i);
+                if (otherSegmentId != 0) {
+                    RequestRecalculation(otherSegmentId, false);
                 }
             }
         }

--- a/TLM/TLM/Manager/Impl/RoutingManager.cs
+++ b/TLM/TLM/Manager/Impl/RoutingManager.cs
@@ -178,10 +178,10 @@ namespace TrafficManager.Manager.Impl {
         }
 
         public void RequestNodeRecalculation(ref NetNode node) {
-            for (int i = 0; i < 8; ++i) {
-                ushort otherSegmentId = node.GetSegment(i);
-                if (otherSegmentId != 0) {
-                    RequestRecalculation(otherSegmentId, false);
+            for (int i = 0; i < Constants.MAX_SEGMENTS_OF_NODE; ++i) {
+                ushort segmentId = node.GetSegment(i);
+                if (segmentId != 0) {
+                    RequestRecalculation(segmentId, false);
                 }
             }
         }


### PR DESCRIPTION
- fixed recalculation after lane connection removal, 
- refactored `RequestRecalculation(segmentId, propagate)`

Closes #1198 