### PR TITLE
GetNode/Segment -> ToNode/Segment

### DIFF
--- a/TLM/TLM/Manager/Impl/GeometryNotifier.cs
+++ b/TLM/TLM/Manager/Impl/GeometryNotifier.cs
@@ -15,7 +15,7 @@ namespace TrafficManager.Manager.Impl {
                 } else if (subject.segment is ExtSegment segmentExt) {
                     Notifier.Instance.OnSegmentModified(segmentExt.segmentId, this);
                 }else  if (subject.replacement.newSegmentEndId is ISegmentEndId newSegmentEndId) {
-                    ushort nodeId2 = newSegmentEndId.SegmentId.ToSegment().GetNode(newSegmentEndId.StartNode);
+                    ushort nodeId2 = newSegmentEndId.SegmentId.ToSegment().GetNodeId(newSegmentEndId.StartNode);
                     Notifier.Instance.OnNodeModified(nodeId2, this);
                 }
             } catch (Exception ex) {

--- a/TLM/TLM/Manager/Impl/JunctionRestrictionsManager.cs
+++ b/TLM/TLM/Manager/Impl/JunctionRestrictionsManager.cs
@@ -868,11 +868,8 @@ namespace TrafficManager.Manager.Impl {
             }
         }
 
-        private static ref NetNode GetNode(ushort segmentId, bool startNode) {
-            ref NetSegment segment = ref GetSeg(segmentId);
-            ushort nodeId = startNode ? segment.m_startNode : segment.m_endNode;
-            return ref Shortcuts.GetNode(nodeId);
-        }
+        private static ref NetNode GetNode(ushort segmentId, bool startNode) =>
+            ref segmentId.ToSegment().GetNodeId(startNode).ToNode();
 
         #region Set<Traffic Rule>Allowed: TernaryBool 
 
@@ -1026,7 +1023,7 @@ namespace TrafficManager.Manager.Impl {
                 }
             }
 
-            Notifier.Instance.OnNodeModified(segmentId.ToSegment().GetNode(startNode), this);
+            Notifier.Instance.OnNodeModified(segmentId.ToSegment().GetNodeId(startNode), this);
         }
 
         public override void OnLevelUnloading() {

--- a/TLM/TLM/Manager/Impl/LaneArrowManager.cs
+++ b/TLM/TLM/Manager/Impl/LaneArrowManager.cs
@@ -121,7 +121,7 @@ namespace TrafficManager.Manager.Impl {
             ExtSegmentManager extSegmentManager = ExtSegmentManager.Instance;
             foreach (var lane in extSegmentManager.GetSortedLanes(
                 segmentId,
-                ref GetSeg(segmentId),
+                ref segmentId.ToSegment(),
                 startNode,
                 LANE_TYPES,
                 VEHICLE_TYPES)) {
@@ -182,11 +182,11 @@ namespace TrafficManager.Manager.Impl {
         private static void RecalculateFlags(uint laneId) {
             NetLane[] laneBuffer = NetManager.instance.m_lanes.m_buffer;
             ushort segmentId = laneBuffer[laneId].m_segment;
-            NetAI ai = GetSeg(segmentId).Info.m_netAI;
+            NetAI ai = segmentId.ToSegment().Info.m_netAI;
 #if DEBUGFLAGS
             Log._Debug($"Flags.RecalculateFlags: Recalculateing lane arrows of segment {segmentId}.");
 #endif
-            ai.UpdateLanes(segmentId, ref GetSeg(segmentId), true);
+            ai.UpdateLanes(segmentId, ref segmentId.ToSegment(), true);
         }
 
         private void OnLaneChange(uint laneId) {

--- a/TLM/TLM/Manager/Impl/LaneArrowManager.cs
+++ b/TLM/TLM/Manager/Impl/LaneArrowManager.cs
@@ -182,11 +182,12 @@ namespace TrafficManager.Manager.Impl {
         private static void RecalculateFlags(uint laneId) {
             NetLane[] laneBuffer = NetManager.instance.m_lanes.m_buffer;
             ushort segmentId = laneBuffer[laneId].m_segment;
-            NetAI ai = segmentId.ToSegment().Info.m_netAI;
+            ref NetSegment segment = ref segmentId.ToSegment();
+            NetAI ai = segment.Info.m_netAI;
 #if DEBUGFLAGS
             Log._Debug($"Flags.RecalculateFlags: Recalculateing lane arrows of segment {segmentId}.");
 #endif
-            ai.UpdateLanes(segmentId, ref segmentId.ToSegment(), true);
+            ai.UpdateLanes(segmentId, ref segment, true);
         }
 
         private void OnLaneChange(uint laneId) {

--- a/TLM/TLM/Manager/Impl/LaneConnectionManager.cs
+++ b/TLM/TLM/Manager/Impl/LaneConnectionManager.cs
@@ -71,7 +71,7 @@ namespace TrafficManager.Manager.Impl {
         private bool IsHeadingTowardsStartNode(uint sourceLaneId) {
             NetLane[] laneBuffer = NetManager.instance.m_lanes.m_buffer;
             ushort segmentId = laneBuffer[sourceLaneId].m_segment;
-            NetSegment segment = segmentId.ToSegment();
+            ref NetSegment segment = ref segmentId.ToSegment();
             uint laneId = segment.m_lanes;
             bool inverted = (segment.m_flags & NetSegment.Flags.Invert) != 0;
 

--- a/TLM/TLM/Manager/Impl/LaneConnectionManager.cs
+++ b/TLM/TLM/Manager/Impl/LaneConnectionManager.cs
@@ -71,7 +71,7 @@ namespace TrafficManager.Manager.Impl {
         private bool IsHeadingTowardsStartNode(uint sourceLaneId) {
             NetLane[] laneBuffer = NetManager.instance.m_lanes.m_buffer;
             ushort segmentId = laneBuffer[sourceLaneId].m_segment;
-            NetSegment segment = GetSeg(segmentId);
+            NetSegment segment = segmentId.ToSegment();
             uint laneId = segment.m_lanes;
             bool inverted = (segment.m_flags & NetSegment.Flags.Invert) != 0;
 

--- a/TLM/TLM/Manager/Impl/TrafficPriorityManager.cs
+++ b/TLM/TLM/Manager/Impl/TrafficPriorityManager.cs
@@ -335,7 +335,7 @@ namespace TrafficManager.Manager.Impl {
             }
 
             SegmentEndManager.Instance.UpdateSegmentEnd(segmentId, startNode);
-            Notifier.Instance.OnNodeModified(segmentId.ToSegment().GetNode(startNode), this);
+            Notifier.Instance.OnNodeModified(segmentId.ToSegment().GetNodeId(startNode), this);
         }
 
         public PriorityType GetPrioritySign(ushort segmentId, bool startNode) {

--- a/TLM/TLM/UI/SubTools/LaneArrows/LaneArrowTool.cs
+++ b/TLM/TLM/UI/SubTools/LaneArrows/LaneArrowTool.cs
@@ -261,7 +261,7 @@ namespace TrafficManager.UI.SubTools.LaneArrows {
             ExtSegmentManager extSegmentManager = ExtSegmentManager.Instance;
             foreach (var lanePos in extSegmentManager.GetSortedLanes(
                 segmentId,
-                ref GetSeg(segmentId),
+                ref segmentId.ToSegment(),
                 startNode,
                 LaneArrowManager.LANE_TYPES,
                 LaneArrowManager.VEHICLE_TYPES)) {

--- a/TLM/TLM/UI/SubTools/LaneConnectorTool.cs
+++ b/TLM/TLM/UI/SubTools/LaneConnectorTool.cs
@@ -1235,10 +1235,10 @@ namespace TrafficManager.UI.SubTools {
             // check track turning angles are within bounds
             ret &= isRoad || CheckSegmentsTurningAngle(
                     sourceSegmentId: source.SegmentId,
-                    sourceSegment: ref GetSeg(source.SegmentId),
+                    sourceSegment: ref source.SegmentId.ToSegment(),
                     sourceStartNode: source.StartNode,
                     targetSegmentId: target.SegmentId,
-                    targetSegment: ref GetSeg(target.SegmentId),
+                    targetSegment: ref target.SegmentId.ToSegment(),
                     targetStartNode: target.StartNode);
 
             return ret;

--- a/TLM/TLM/UI/TrafficManagerTool.cs
+++ b/TLM/TLM/UI/TrafficManagerTool.cs
@@ -1276,7 +1276,7 @@ namespace TrafficManager.UI {
             }
             prev_H = HitPos.y;
 
-            if (Shortcuts.GetSeg(HoveredSegmentId).GetClosestLanePosition(
+            if (HoveredSegmentId.ToSegment().GetClosestLanePosition(
                 HitPos,
                 NetInfo.LaneType.All,
                 VehicleInfo.VehicleType.All,

--- a/TLM/TLM/Util/PriorityRoad.cs
+++ b/TLM/TLM/Util/PriorityRoad.cs
@@ -174,8 +174,7 @@ namespace TrafficManager.Util {
         }
 
         private static bool IsStraighOneWay(ushort segmentId0, ushort segmentId1) {
-            ref NetSegment seg0 = ref GetSeg(segmentId0);
-            //ref NetSegment seg1 = ref GetSeg(segmentId1);
+            ref NetSegment seg0 = ref segmentId0.ToSegment();
             bool oneway = segMan.CalculateIsOneWay(segmentId0) &&
                           segMan.CalculateIsOneWay(segmentId1);
             if (!oneway) {
@@ -243,7 +242,7 @@ namespace TrafficManager.Util {
                 ExtSegmentManager extSegmentManager = ExtSegmentManager.Instance;
                 IList<LanePos> lanes = extSegmentManager.GetSortedLanes(
                                 segmentIdSrc,
-                                ref GetSeg(segmentIdSrc),
+                                ref segmentIdSrc.ToSegment(),
                                 extSegmentManager.IsStartNode(segmentIdSrc, nodeId),
                                 LaneArrowManager.LANE_TYPES,
                                 LaneArrowManager.VEHICLE_TYPES,
@@ -589,8 +588,8 @@ namespace TrafficManager.Util {
         /// returns a posetive value if seg1Id < seg2Id
         /// </summary>
         internal static int CompareSegments(ushort seg1Id, ushort seg2Id) {
-            ref NetSegment seg1 = ref GetSeg(seg1Id);
-            ref NetSegment seg2 = ref GetSeg(seg2Id);
+            ref NetSegment seg1 = ref seg1Id.ToSegment();
+            ref NetSegment seg2 = ref seg2Id.ToSegment();
             int diff = (int)Mathf.RoundToInt(seg2.Info.m_halfWidth - seg1.Info.m_halfWidth);
             if (diff == 0) {
                 diff = CountRoadVehicleLanes(seg2Id) - CountRoadVehicleLanes(seg1Id);

--- a/TLM/TLM/Util/RoundaboutMassEdit.cs
+++ b/TLM/TLM/Util/RoundaboutMassEdit.cs
@@ -63,7 +63,7 @@ namespace TrafficManager.Util {
                 IList<LanePos> laneList =
                     extSegmentManager.GetSortedLanes(
                         segmentId,
-                        ref GetSeg(segmentId),
+                        ref segmentId.ToSegment(),
                         startNode,
                         LaneArrowManager.LANE_TYPES,
                         LaneArrowManager.VEHICLE_TYPES,
@@ -73,7 +73,7 @@ namespace TrafficManager.Util {
                 // check for exits.
                 segEndMan.CalculateOutgoingLeftStraightRightSegments(
                     ref GetSegEnd(segmentId, nodeId),
-                    ref GetNode(nodeId),
+                    ref nodeId.ToNode(),
                     out bool bLeft,
                     out bool bForward,
                     out bool bRight);
@@ -175,7 +175,7 @@ namespace TrafficManager.Util {
             }
             int shortUnit = 4;
             int meterPerUnit = 8;
-            ref NetSegment seg = ref GetSeg(segmentId);
+            ref NetSegment seg = ref segmentId.ToSegment();
             ushort otherNodeId = seg.GetOtherNode(nodeId);
             if (OptionsMassEditTab.RoundAboutQuickFix_StayInLaneNearRabout &&
                 !HasJunctionFlag(otherNodeId) &&
@@ -185,7 +185,7 @@ namespace TrafficManager.Util {
         }
 
         private void FixMinor(ushort nodeId) {
-            ref NetNode node = ref GetNode(nodeId);
+            ref NetNode node = ref nodeId.ToNode();
             for (int i = 0; i < 8; ++i) {
                 //find connected segments.
                 ushort segmentId = node.GetSegment(i);

--- a/TLM/TLM/Util/Shortcuts.cs
+++ b/TLM/TLM/Util/Shortcuts.cs
@@ -59,13 +59,9 @@ namespace TrafficManager.Util {
 
         internal static IExtSegmentManager segMan => Constants.ManagerFactory.ExtSegmentManager;
 
-        internal static ref NetNode GetNode(ushort nodeId) => ref _nodeBuffer[nodeId];
-
         internal static ref NetNode ToNode(this ushort nodeId) => ref _nodeBuffer[nodeId];
 
         internal static ref NetLane ToLane(this uint laneId) => ref _laneBuffer[laneId];
-
-        internal static ref NetSegment GetSeg(ushort segmentId) => ref _segBuffer[segmentId];
 
         internal static ref NetSegment ToSegment(this ushort segmentId) => ref _segBuffer[segmentId];
 
@@ -84,10 +80,10 @@ namespace TrafficManager.Util {
         internal static ref ExtSegmentEnd GetSegEnd(ushort segmentId, bool startNode) =>
             ref _segEndBuff[segEndMan.GetIndex(segmentId, startNode)];
 
-        internal static ushort GetNode(this ref NetSegment segment, bool startNode) =>
+        internal static ushort GetNodeId(this ref NetSegment segment, bool startNode) =>
             startNode ? segment.m_startNode : segment.m_endNode;
 
-        internal static bool HasJunctionFlag(ushort nodeId) => HasJunctionFlag(ref GetNode(nodeId));
+        internal static bool HasJunctionFlag(ushort nodeId) => HasJunctionFlag(ref nodeId.ToNode());
 
         internal static bool HasJunctionFlag(ref NetNode node) =>
             (node.m_flags & NetNode.Flags.Junction) != NetNode.Flags.None;


### PR DESCRIPTION
GetNode(nodeID) with ToNode()
GetSeg(segmentID) with ToSegment()
renamed:
GetNode(segment, startNode) to GetNodeID(segment, startNode) because the return value is ushort not ref NetNode