### PR TITLE
fix: routing manager lane connection check

### DIFF
--- a/TLM/TLM/Manager/Impl/RoutingManager.cs
+++ b/TLM/TLM/Manager/Impl/RoutingManager.cs
@@ -398,7 +398,7 @@ namespace TrafficManager.Manager.Impl {
 
             ushort prevSegmentId = segmentId;
             int prevLaneIndex = laneIndex;
-            uint prevLaneId = laneId; // this is variable is duplicate (prevLaneId == laneId always)
+            uint prevLaneId = laneId; // this variable is duplicate (prevLaneId == laneId always)
             ushort nextNodeId = prevEnd.nodeId; // common node
 
             NetInfo.Lane prevLaneInfo = prevSegmentInfo.m_lanes[prevLaneIndex];

--- a/TLM/TLM/Manager/Impl/RoutingManager.cs
+++ b/TLM/TLM/Manager/Impl/RoutingManager.cs
@@ -398,8 +398,8 @@ namespace TrafficManager.Manager.Impl {
 
             ushort prevSegmentId = segmentId;
             int prevLaneIndex = laneIndex;
-            uint prevLaneId = laneId;
-            ushort nextNodeId = prevEnd.nodeId;
+            uint prevLaneId = laneId; // this is variable is duplicate (prevLaneId == laneId always)
+            ushort nextNodeId = prevEnd.nodeId; // common node
 
             NetInfo.Lane prevLaneInfo = prevSegmentInfo.m_lanes[prevLaneIndex];
             if (!prevLaneInfo.CheckType(ROUTED_LANE_TYPES, ROUTED_VEHICLE_TYPES)) {
@@ -748,9 +748,9 @@ namespace TrafficManager.Manager.Impl {
                                 if (nextHasOutgoingConnections) {
                                     nextIsConnectedWithPrev =
                                         LaneConnectionManager.Instance.AreLanesConnected(
-                                            prevLaneId,
                                             nextLaneId,
-                                            startNode);
+                                            prevLaneId,
+                                            isNextStartNodeOfNextSegment);
                                 }
 
                                 if (extendedLogRouting) {


### PR DESCRIPTION
routing manager checks if target lane is connected to source. it should check of source is connected to target.
see https://discord.com/channels/545065285862948894/545066721854357515/915706580643758090

Currently Lane connection manager has bidirectional connections  (see #784) so this hides the problem.

blocks #784 

[TMPE.zip](https://ci.appveyor.com/api/projects/krzychu124/tmpe/artifacts/TMPE.zip?branch=fix-RM-source-target)

~~made draft until a decision is made about how to handle this: https://github.com/CitiesSkylinesMods/TMPE/pull/1210#issuecomment-984065380~~