### PR TITLE
fix uturn policy on T junctions

### DIFF
--- a/TLM/TLM/Manager/Impl/RoutingManager.cs
+++ b/TLM/TLM/Manager/Impl/RoutingManager.cs
@@ -903,8 +903,11 @@ namespace TrafficManager.Manager.Impl {
                                             hasRightArrow);
                                     }
 
+                                    bool hasUTurnRule = JunctionRestrictionsManager.Instance.IsUturnAllowed(
+                                        nextSegmentId,
+                                        isNextStartNodeOfNextSegment);
                                     bool hasFarTurnArrow = (Shortcuts.LHT && hasRightArrow) || (Shortcuts.RHT && hasLeftArrow);
-                                    bool canTurn = !nextIsRealJunction || nextIsEndOrOneWayOut || hasFarTurnArrow;
+                                    bool canTurn = !nextIsRealJunction || nextIsEndOrOneWayOut || hasFarTurnArrow || hasUTurnRule;
 
                                     if (applyHighwayRules || // highway rules enabled
                                         (nextIncomingDir == ArrowDirection.Right && hasLeftArrow) || // valid incoming right
@@ -975,7 +978,8 @@ namespace TrafficManager.Manager.Impl {
 
                                     // routed vehicle that does not follow lane arrows (trains, trams,
                                     // metros, monorails)
-                                    transitionType = LaneEndTransitionType.Default;
+                                    // TODO [issue #1053] this causes cars to turn on mixed car/track lanes against lane arrows
+                                    transitionType = LaneEndTransitionType.Default; 
 
                                     if (numNextForcedTransitionDatas < MAX_NUM_TRANSITIONS) {
                                         nextForcedTransitionDatas[numNextForcedTransitionDatas].Set(
@@ -1967,7 +1971,7 @@ namespace TrafficManager.Manager.Impl {
                                     // force u-turns to happen on the innermost lane
                                     ++compatibleLaneDist;
                                     nextCompatibleTransitionDatas[nextTransitionIndex].type =
-                                        LaneEndTransitionType.Relaxed; // TODO : normal when u-turn allowed
+                                        LaneEndTransitionType.Relaxed;
 
                                     if (extendedLogRouting) {
                                         Log._DebugFormat(

--- a/TLM/TLM/Manager/Impl/RoutingManager.cs
+++ b/TLM/TLM/Manager/Impl/RoutingManager.cs
@@ -903,15 +903,14 @@ namespace TrafficManager.Manager.Impl {
                                             hasRightArrow);
                                     }
 
+                                    bool hasFarTurnArrow = (Shortcuts.LHT && hasRightArrow) || (Shortcuts.RHT && hasLeftArrow);
+                                    bool canTurn = !nextIsRealJunction || nextIsEndOrOneWayOut || hasFarTurnArrow;
+
                                     if (applyHighwayRules || // highway rules enabled
                                         (nextIncomingDir == ArrowDirection.Right && hasLeftArrow) || // valid incoming right
                                         (nextIncomingDir == ArrowDirection.Left && hasRightArrow) || // valid incoming left
                                         (nextIncomingDir == ArrowDirection.Forward && hasForwardArrow) || // valid incoming straight
-                                        (nextIncomingDir == ArrowDirection.Turn
-                                         && (!nextIsRealJunction
-                                             || nextIsEndOrOneWayOut
-                                             || ((Shortcuts.LHT && hasRightArrow)
-                                                 || (!Shortcuts.LHT && hasLeftArrow))))) // valid turning lane
+                                        (nextIncomingDir == ArrowDirection.Turn && canTurn)) // valid turning lane
                                     {
                                         if (extendedLogRouting) {
                                             Log._DebugFormat(
@@ -1968,7 +1967,7 @@ namespace TrafficManager.Manager.Impl {
                                     // force u-turns to happen on the innermost lane
                                     ++compatibleLaneDist;
                                     nextCompatibleTransitionDatas[nextTransitionIndex].type =
-                                        LaneEndTransitionType.Relaxed;
+                                        LaneEndTransitionType.Relaxed; // TODO : normal when u-turn allowed
 
                                     if (extendedLogRouting) {
                                         Log._DebugFormat(


### PR DESCRIPTION
fixes #347 
fixes #900

2 commits:
1st commit : simplifies code without any effective change the code.
2nd commit: fixes the u-turn issue

here U-turn routing of type `LaneEndTransitionType.Default` happens if it is a junction with 2 segments  but not when it is a junction with 3 segments.
https://github.com/CitiesSkylinesMods/TMPE/blob/a7d644629bd2b5ceeff5b5e61b4dca9e07550e8d/TLM/TLM/Manager/Impl/RoutingManager.cs#L907
note : `nextIsRealJunction = nextNode.CountSegments() >= 3`


So basically what this means is we have the picture bellow: 
![image](https://user-images.githubusercontent.com/26344691/144434383-d05cd6cb-3b72-490e-8746-b116ce07e0a2.png)
an orange relaxed u-turn routing on one side and a green default u-turn routing on the other side

----
How to test:

TMPE build:  https://ci.appveyor.com/api/projects/krzychu124/tmpe/artifacts/TMPE.zip?branch=T-uturn-347

We can  use bus stops to see if u-turn is possible. By using the "Buses may ignore lane arrows" policy we can test relaxed/default lane routing.
Buses may Ignore lane arrows policy (in original TMPE. this PR fixes this) = off
![image](https://user-images.githubusercontent.com/26344691/144442304-89220ae8-ae03-4b39-957d-cbe4e83039d7.png)
![image](https://user-images.githubusercontent.com/26344691/144442343-0aced977-0dfe-4b9c-944d-79d064c35b79.png)


Buses may Ignore lane arrows policy = on
![image](https://user-images.githubusercontent.com/26344691/144442158-b2dc0e4e-70b5-4cfe-a6a0-45002a35973b.png)

