### PR TITLE
fixed JRM transparency

### DIFF
--- a/TLM/TLM/UI/Helpers/TrafficRulesOverlay.cs
+++ b/TLM/TLM/UI/Helpers/TrafficRulesOverlay.cs
@@ -138,13 +138,11 @@ namespace TrafficManager.UI.Helpers {
                 if (viewOnly_) {
                     // Readonly signs look grey-ish
                     guiColor = Color.Lerp(guiColor, Color.gray, 0.5f);
-                } else {
-                    if (hoveredHandle) {
-                        guiColor = Color.Lerp(
-                            a: guiColor,
-                            b: new Color(r: 1f, g: .7f, b: 0f),
-                            t: 0.5f);
-                    }
+                } else if (hoveredHandle) {
+                    guiColor = Color.Lerp(
+                        a: guiColor,
+                        b: new Color(r: 1f, g: .7f, b: 0f),
+                        t: 0.5f);
                 }
                 guiColor.a = TrafficManagerTool.GetHandleAlpha(hoveredHandle);
 

--- a/TLM/TLM/UI/Helpers/TrafficRulesOverlay.cs
+++ b/TLM/TLM/UI/Helpers/TrafficRulesOverlay.cs
@@ -83,7 +83,7 @@ namespace TrafficManager.UI.Helpers {
 
                 dirX_ = (segmentEnd.LeftCorner - segmentEnd.RightCorner).normalized;
 
-                // for curved angled segements, corner1Direction may slightly differ from corner2Direction
+                // for curved angled segments, corner1Direction may slightly differ from corner2Direction
                 dirY_ = (segmentEnd.LeftCornerDir + segmentEnd.RightCornerDir) * 0.5f;
 
                 // origin point to start drawing sprites from.
@@ -138,11 +138,7 @@ namespace TrafficManager.UI.Helpers {
                 if (viewOnly_) {
                     // Readonly signs look grey-ish
                     guiColor = Color.Lerp(guiColor, Color.gray, 0.5f);
-                    guiColor.a = TrafficManagerTool.GetHandleAlpha(hovered: false);
                 } else {
-                    // Handles in edit mode are always visible. Hovered handles are also highlighted.
-                    guiColor.a = 1f;
-
                     if (hoveredHandle) {
                         guiColor = Color.Lerp(
                             a: guiColor,
@@ -150,7 +146,7 @@ namespace TrafficManager.UI.Helpers {
                             t: 0.5f);
                     }
                 }
-                // guiColor.a = TrafficManagerTool.GetHandleAlpha(hoveredHandle);
+                guiColor.a = TrafficManagerTool.GetHandleAlpha(hoveredHandle);
 
                 GUI.color = guiColor;
                 GUI.DrawTexture(boundingBox, signTexture);


### PR DESCRIPTION
fixes #1216 
see issue for details

This is now it looks like now:
![image](https://user-images.githubusercontent.com/26344691/144738728-78408c96-4b91-4ac1-8ca6-15261ee11adf.png)
