### PR TITLE
Update `SPEED_TO_MPH` constant to correct value

### DIFF
--- a/TLM/TLM/Constants.cs
+++ b/TLM/TLM/Constants.cs
@@ -20,7 +20,7 @@ namespace TrafficManager {
         /// Conversion rate from MPH to game speed (also exists in TrafficManager.API.Constants)
         /// </summary>
         [UsedImplicitly]
-        public const float SPEED_TO_MPH = 32.06f; // 50 km/h converted to mph
+        public const float SPEED_TO_MPH = 31.06f; // 50 km/h converted to mph
 
         /// <summary>
         /// Screen pixel size for overlay signs, such as one-per-segment speed limits.


### PR DESCRIPTION
User @Glenwing reported in #988 that the speed constant was wrong; should be `31.06f` (not `32.06f`).

Fixes #988