### PR TITLE
Adds checkbox label text wrap for some very long options

### DIFF
--- a/TLM/TLM/State/Options.cs
+++ b/TLM/TLM/State/Options.cs
@@ -15,6 +15,8 @@ namespace TrafficManager.State {
     using UI.Textures;
 
     public class Options : MonoBehaviour {
+        private const int CHECKBOX_LABEL_MAX_WIDTH = 695;
+        private const int CHECKBOX_LABEL_MAX_WIDTH_INDENTED = 680;
 #if DEBUG
         private static List<UICheckBox> debugSwitchFields = new List<UICheckBox>();
         private static List<UITextField> debugValueFields = new List<UITextField>();
@@ -167,6 +169,29 @@ namespace TrafficManager.State {
 
             if (check != null) {
                 check.relativePosition += new Vector3(22.0f, 0);
+            }
+        }
+
+        /// <summary>
+        /// Allows long checkbox label text to wrap and adds padding to checkbox
+        /// </summary>
+        /// <param name="checkBox">Checkbox instance</param>
+        /// <param name="indented">Is checkbox indented</param>
+        public static void AllowTextWrap(UICheckBox checkBox, bool indented = false) {
+            UILabel label = checkBox.label;
+            bool requireTextWrap;
+            int maxWidth = indented ? CHECKBOX_LABEL_MAX_WIDTH_INDENTED : CHECKBOX_LABEL_MAX_WIDTH;
+            using (UIFontRenderer renderer = label.ObtainRenderer()) {
+                Vector2 size = renderer.MeasureString(label.text);
+                requireTextWrap = size.x > maxWidth;
+            }
+            label.autoSize = false;
+            label.wordWrap = true;
+            label.verticalAlignment = UIVerticalAlignment.Middle;
+            label.textAlignment = UIHorizontalAlignment.Left;
+            label.size = new Vector2(maxWidth, requireTextWrap ? 40 : 20);
+            if (requireTextWrap) {
+                checkBox.height = 42; // set new height + top/bottom 1px padding
             }
         }
 

--- a/TLM/TLM/State/OptionsTabs/OptionsGameplayTab.cs
+++ b/TLM/TLM/State/OptionsTabs/OptionsGameplayTab.cs
@@ -88,6 +88,7 @@ namespace TrafficManager.State {
                       Translation.Options.Get("Gameplay.Checkbox:No excessive transfers"),
                       Options.realisticPublicTransport,
                       OnRealisticPublicTransportChanged) as UICheckBox;
+            Options.AllowTextWrap(_realisticPublicTransportToggle);
         }
 
         private static void OnRecklessDriversChanged(int newRecklessDrivers) {

--- a/TLM/TLM/State/OptionsTabs/OptionsVehicleRestrictionsTab.cs
+++ b/TLM/TLM/State/OptionsTabs/OptionsVehicleRestrictionsTab.cs
@@ -79,6 +79,7 @@ namespace TrafficManager.State {
                       Options.allowFarTurnOnRed,
                       OnAllowFarTurnOnRedChanged) as UICheckBox;
             Options.Indent(_allowFarTurnOnRedToggle);
+            Options.AllowTextWrap(_allowFarTurnOnRedToggle, indented: true);
             _allowLaneChangesWhileGoingStraightToggle
                 = atJunctionsGroup.AddCheckbox(
                       Translation.Options.Get("VR.Checkbox:Vehicles going straight may change lanes at junctions"),
@@ -89,6 +90,7 @@ namespace TrafficManager.State {
                       Translation.Options.Get("VR.Checkbox:Vehicles follow priority rules at junctions with timedTL"),
                       Options.trafficLightPriorityRules,
                       OnTrafficLightPriorityRulesChanged) as UICheckBox;
+            Options.AllowTextWrap(_trafficLightPriorityRulesToggle);
             _automaticallyAddTrafficLightsIfApplicableToggle
                 = atJunctionsGroup.AddCheckbox(
                       Translation.Options.Get("VR.Checkbox:Automatically add traffic lights if applicable"),

--- a/TLM/TLM/UI/Helpers/CheckboxOption.cs
+++ b/TLM/TLM/UI/Helpers/CheckboxOption.cs
@@ -1,6 +1,7 @@
 namespace TrafficManager.UI.Helpers {
     using ICities;
     using ColossalFramework.UI;
+    using State;
 
     public class CheckboxOption : SerializableUIOptionBase<bool, UICheckBox> {
         public CheckboxOption(string fieldName) : base(fieldName) {
@@ -38,6 +39,7 @@ namespace TrafficManager.UI.Helpers {
             if (Indent) {
                 State.Options.Indent(_ui);
             }
+            Options.AllowTextWrap(_ui, Indent);
         }
     }
 }


### PR DESCRIPTION
_see title_

Fixes #401 

Mostly `Policies` tab, affected languages: French, German, Italian, Polish, Portuguese, Russian, 

[Build](https://ci.appveyor.com/api/projects/krzychu124/tmpe/artifacts/TMPE.zip?branch=bugfix/401-text-wrap-checkbox-labels)