### PR TITLE
Apply default speed limits to all elevations

### DIFF
--- a/TLM/TLM/Constants.cs
+++ b/TLM/TLM/Constants.cs
@@ -20,7 +20,7 @@ namespace TrafficManager {
         /// Conversion rate from MPH to game speed (also exists in TrafficManager.API.Constants)
         /// </summary>
         [UsedImplicitly]
-        public const float SPEED_TO_MPH = 32.06f; // 50 km/h converted to mph
+        public const float SPEED_TO_MPH = 31.06f; // 50 km/h converted to mph
 
         /// <summary>
         /// Screen pixel size for overlay signs, such as one-per-segment speed limits.

--- a/TLM/TLM/Manager/Impl/SpeedLimitManager.cs
+++ b/TLM/TLM/Manager/Impl/SpeedLimitManager.cs
@@ -3,7 +3,6 @@ namespace TrafficManager.Manager.Impl {
     using CSUtil.Commons;
     using JetBrains.Annotations;
     using System.Collections.Generic;
-    using System.Diagnostics;
     using System;
     using TrafficManager.API.Manager;
     using TrafficManager.API.Traffic.Data;
@@ -11,9 +10,7 @@ namespace TrafficManager.Manager.Impl {
 #if DEBUG
     using TrafficManager.State.ConfigData;
 #endif
-    using TrafficManager.UI.SubTools.SpeedLimits;
     using TrafficManager.Util;
-    using UnityEngine;
     using System.Text;
     using TrafficManager.API.Traffic;
     using TrafficManager.Util.Extensions;
@@ -23,74 +20,56 @@ namespace TrafficManager.Manager.Impl {
           ICustomDataManager<List<Configuration.LaneSpeedLimit>>,
           ICustomDataManager<Dictionary<string, float>>,
           ISpeedLimitManager {
+        /// <summary>Interested only in these lane types.</summary>
         public const NetInfo.LaneType LANE_TYPES =
             NetInfo.LaneType.Vehicle | NetInfo.LaneType.TransportVehicle;
 
+        /// <summary>Support speed limits only for these vehicle types.</summary>
         public const VehicleInfo.VehicleType VEHICLE_TYPES =
             VehicleInfo.VehicleType.Car | VehicleInfo.VehicleType.Tram |
             VehicleInfo.VehicleType.Metro | VehicleInfo.VehicleType.Train |
             VehicleInfo.VehicleType.Monorail | VehicleInfo.VehicleType.Trolleybus;
 
+        private readonly object laneSpeedLimitLock_ = new();
+
+        /// <summary>For each lane: Defines the currently set speed limit. Units: Game speed units (1.0 = 50 km/h).</summary>
+        private readonly Dictionary<uint, float> laneSpeedLimit_ = new();
+
+        /// <summary>For faster, lock-free access, 1st index: segment id, 2nd index: lane index.</summary>
+        private readonly float?[][] laneSpeedLimitArray_;
+
         public NetInfo.LaneType LaneTypes => LANE_TYPES;
 
         public VehicleInfo.VehicleType VehicleTypes => VEHICLE_TYPES;
 
-        public static readonly SpeedLimitManager Instance = new();
-
-        // For each NetInfo (by name) and lane index: custom speed limit
-        private readonly Dictionary<string, float> customLaneSpeedLimitByNetInfoName_;
-
-        // For each name: NetInfo
-        private readonly Dictionary<string, NetInfo> netInfoByName_;
-
         /// <summary>Ingame speed units, minimal speed.</summary>
         private const float MIN_SPEED = 0.1f; // 5 km/h
 
-        /// <summary>For each NetInfo (by name) and lane index: game default speed limit.</summary>
-        private readonly Dictionary<string, float[]> vanillaLaneSpeedLimitsByNetInfoName_;
+        public static readonly SpeedLimitManager Instance = new();
 
-        /// <summary>For each NetInfo (by name): Parent NetInfo (name).</summary>
-        private readonly Dictionary<string, List<string>>
-            childNetInfoNamesByCustomizableNetInfoName_;
+        /// <summary>For each NetInfo name: custom speed limit.</summary>
+        private readonly Dictionary<string, float> customLaneSpeedLimit_ = new();
 
-        private List<NetInfo> customizableNetInfos_;
+        /// <summary>NetInfo lookup by name.</summary>
+        private readonly Dictionary<string, NetInfo> netInfoByName_ = new();
+
+        /// <summary>For each NetInfo name: game default speed limit.</summary>
+        private readonly Dictionary<string, float[]> vanillaLaneSpeedLimits_ = new();
+
+        /// <summary>
+        /// For each NetInfo name: list of child NetInfo names.
+        /// Netinfos are grouped together, roads of same type but different builds (slope, bridge
+        /// etc) have different netinfo names, but belong to the same asset.
+        /// </summary>
+        private readonly Dictionary<string, List<string>> childNetinfoNames_ = new();
+
+        /// <summary>For each <see cref="NetInfo"/> name store its parent name.</summary>
+        private readonly Dictionary<string, string> parentNetinfoNames_ = new();
+
+        private List<NetInfo> customizableNetInfos_ = new();
 
         private SpeedLimitManager() {
-            this.vanillaLaneSpeedLimitsByNetInfoName_ = new Dictionary<string, float[]>();
-            this.customLaneSpeedLimitByNetInfoName_ = new Dictionary<string, float>();
-            this.customizableNetInfos_ = new List<NetInfo>();
-            this.childNetInfoNamesByCustomizableNetInfoName_ =
-                new Dictionary<string, List<string>>();
-            this.netInfoByName_ = new Dictionary<string, NetInfo>();
-        }
-
-        /// <summary>Check whether custom speed limits may be assigned to the given segment.</summary>
-        /// <param name="segment">Reference to affected segment.</param>
-        /// <returns>Success.</returns>
-        public bool MayHaveCustomSpeedLimits(ref NetSegment segment) {
-            if ((segment.m_flags & NetSegment.Flags.Created) == NetSegment.Flags.None) {
-                return false;
-            }
-
-            ItemClass connectionClass = segment.Info.GetConnectionClass();
-            ItemClass.SubService subService = connectionClass.m_subService;
-            ItemClass.Service service = connectionClass.m_service;
-
-            return service == ItemClass.Service.Road
-                   || (service == ItemClass.Service.PublicTransport
-                       && subService
-                           is ItemClass.SubService.PublicTransportTrain
-                           or ItemClass.SubService.PublicTransportTram
-                           or ItemClass.SubService.PublicTransportMetro
-                           or ItemClass.SubService.PublicTransportMonorail);
-        }
-
-        /// <summary>Check whether custom speed limits may be assigned to the given lane info.</summary>
-        /// <param name="laneInfo">The <see cref="NetInfo.Lane"/> that you wish to check.</param>
-        /// <returns>Whether lane for this lane type can have speed limit override.</returns>
-        private bool MayHaveCustomSpeedLimits([NotNull] NetInfo.Lane laneInfo) {
-            return (laneInfo.m_laneType & LANE_TYPES) != NetInfo.LaneType.None
-                   && (laneInfo.m_vehicleType & VEHICLE_TYPES) != VehicleInfo.VehicleType.None;
+            laneSpeedLimitArray_ = new float?[NetManager.MAX_SEGMENT_COUNT][];
         }
 
         /// <summary>Determines the currently set speed limit for the given segment and lane
@@ -125,11 +104,11 @@ namespace TrafficManager.Manager.Impl {
                     goto nextIter;
                 }
 
-                if (!this.MayHaveCustomSpeedLimits(laneInfo)) {
+                if (!laneInfo.MayHaveCustomSpeedLimits()) {
                     goto nextIter;
                 }
 
-                SpeedValue? setSpeedLimit = Flags.GetLaneSpeedLimit(curLaneId);
+                SpeedValue? setSpeedLimit = this.GetLaneSpeedLimit(curLaneId);
 
                 if (setSpeedLimit.HasValue) {
                     // custom speed limit
@@ -146,12 +125,9 @@ namespace TrafficManager.Manager.Impl {
                 laneIndex++;
             }
 
-            switch (validLanes) {
-                case 0:
-                    return null;
-                case > 0:
-                    return meanSpeedLimit.Scale(1.0f / validLanes);
-            }
+            return validLanes == 0
+                       ? null
+                       : meanSpeedLimit.Scale(1.0f / validLanes);
         }
 
         /// <summary>
@@ -165,7 +141,7 @@ namespace TrafficManager.Manager.Impl {
             //----------------------------------------
             // check custom speed limit for the lane
             //----------------------------------------
-            SpeedValue? overrideValue = Flags.GetLaneSpeedLimit(laneId);
+            SpeedValue? overrideValue = this.GetLaneSpeedLimit(laneId);
 
             //----------------------------
             // check default speed limit
@@ -174,7 +150,7 @@ namespace TrafficManager.Manager.Impl {
             ushort segmentId = laneBuffer[laneId].m_segment;
             ref NetSegment netSegment = ref segmentId.ToSegment();
 
-            if (!this.MayHaveCustomSpeedLimits(ref netSegment)) {
+            if (!netSegment.MayHaveCustomSpeedLimits()) {
                 // Don't have override, and default is not known
                 return new GetSpeedLimitResult(
                     overrideValue: null,
@@ -190,7 +166,7 @@ namespace TrafficManager.Manager.Impl {
                     NetInfo.Lane laneInfo = segmentInfo.m_lanes[laneIndex];
                     SpeedValue knownDefault = new SpeedValue(laneInfo.m_speedLimit);
 
-                    if (this.MayHaveCustomSpeedLimits(laneInfo)) {
+                    if (laneInfo.MayHaveCustomSpeedLimits()) {
                         // May possibly have override, also the default is known
                         return new GetSpeedLimitResult(
                             overrideValue: overrideValue,
@@ -217,11 +193,9 @@ namespace TrafficManager.Manager.Impl {
         /// <param name="laneId">The lane id.</param>
         /// <returns>Game units.</returns>
         public float GetGameSpeedLimit(uint laneId) {
-            GetSpeedLimitResult overrideSpeedlimit = this.GetCustomSpeedLimit(laneId);
-            if (overrideSpeedlimit.DefaultValue != null) {
-                SpeedValue activeLimit = overrideSpeedlimit.OverrideValue != null
-                                             ? overrideSpeedlimit.OverrideValue.Value
-                                             : overrideSpeedlimit.DefaultValue.Value;
+            GetSpeedLimitResult overrideSpeedLimit = this.GetCustomSpeedLimit(laneId);
+            if (overrideSpeedLimit.DefaultValue != null) {
+                SpeedValue activeLimit = overrideSpeedLimit.OverrideValue ?? overrideSpeedLimit.DefaultValue.Value;
                 return ToGameSpeedLimit(activeLimit.GameUnits);
             }
 
@@ -232,12 +206,12 @@ namespace TrafficManager.Manager.Impl {
                                                byte laneIndex,
                                                uint laneId,
                                                NetInfo.Lane laneInfo) {
-            if (!Options.customSpeedLimitsEnabled || !MayHaveCustomSpeedLimits(laneInfo)) {
+            if (!Options.customSpeedLimitsEnabled || !laneInfo.MayHaveCustomSpeedLimits()) {
                 return laneInfo.m_speedLimit;
             }
 
             float speedLimit;
-            float?[] fastArray = Flags.laneSpeedLimitArray[segmentId];
+            float?[] fastArray = this.laneSpeedLimitArray_[segmentId];
 
             if (fastArray != null
                 && fastArray.Length > laneIndex
@@ -255,138 +229,33 @@ namespace TrafficManager.Manager.Impl {
         /// </summary>
         /// <param name="customSpeedLimit">Custom speed limit which can be zero</param>
         /// <returns>Speed limit in game speed units</returns>
-        public float ToGameSpeedLimit(float customSpeedLimit) {
+        private static float ToGameSpeedLimit(float customSpeedLimit) {
             return FloatUtil.IsZero(customSpeedLimit)
                        ? SpeedValue.UNLIMITED
                        : customSpeedLimit;
         }
 
         /// <summary>
-        /// Explicitly stores currently set speed limits for all segments of the specified NetInfo
-        /// </summary>
-        /// <param name="info">The <see cref="NetInfo"/> for which speed limits should be stored.</param>
-        [Obsolete("Delete this when speed limits refactor lands in master")]
-        public void FixCurrentSpeedLimits(NetInfo info) {
-            if (info == null) {
-#if DEBUG
-                Log.Warning("SpeedLimitManager.FixCurrentSpeedLimits: info is null!");
-#endif
-                return;
-            }
-
-            // Resharper warning: condition always false
-            // if (info.name == null) {
-            //    Log._DebugOnlyWarning($"SpeedLimitManager.FixCurrentSpeedLimits: info.name is null!");
-            //    return;
-            // }
-
-            if (!customizableNetInfos_.Contains(info)) {
-                return;
-            }
-
-            for (uint laneId = 1; laneId < NetManager.MAX_LANE_COUNT; ++laneId) {
-                ref NetLane netLane = ref laneId.ToLane();
-
-                if (!netLane.IsValidWithSegment()) {
-                    continue;
-                }
-
-                ushort segmentId = netLane.m_segment;
-                NetInfo laneInfo = segmentId.ToSegment().Info;
-
-                if (laneInfo.name != info.name
-                    && (!childNetInfoNamesByCustomizableNetInfoName_.ContainsKey(info.name)
-                        || !childNetInfoNamesByCustomizableNetInfoName_[info.name]
-                            .Contains(laneInfo.name))) {
-                    continue;
-                }
-
-                GetSpeedLimitResult laneSpeedLimit = GetCustomSpeedLimit(laneId);
-                if (laneSpeedLimit.OverrideValue.HasValue) {
-                    Flags.SetLaneSpeedLimit(
-                        laneId: laneId,
-                        action: SetSpeedLimitAction.SetOverride(laneSpeedLimit.OverrideValue.Value));
-                }
-
-                Notifier.Instance.OnSegmentModified(segmentId, this);
-            }
-        }
-
-        /// <summary>
-        /// Explicitly clear currently set speed limits for all segments of the specified NetInfo
-        /// </summary>
-        /// <param name="info">The <see cref="NetInfo"/> for which speed limits should be cleared.</param>
-        [Obsolete("Delete this when speed limits refactor lands in master")]
-        public void ClearCurrentSpeedLimits(NetInfo info) {
-            if (info == null) {
-                Log._DebugOnlyWarning("SpeedLimitManager.ClearCurrentSpeedLimits: info is null!");
-                return;
-            }
-
-            // Resharper warning: condition always false
-            // if (info.name == null) {
-            //    Log._DebugOnlyWarning($"SpeedLimitManager.ClearCurrentSpeedLimits: info.name is null!");
-            //    return;
-            // }
-
-            if (!customizableNetInfos_.Contains(info)) {
-                return;
-            }
-
-            for (uint laneId = 1; laneId < NetManager.MAX_LANE_COUNT; ++laneId) {
-                ref NetLane netLane = ref laneId.ToLane();
-                if (!netLane.IsValidWithSegment()) {
-                    continue;
-                }
-
-                NetInfo laneInfo = Singleton<NetManager>
-                                   .instance.m_segments
-                                   .m_buffer[Singleton<NetManager>
-                                             .instance.m_lanes.m_buffer[laneId].m_segment]
-                                   .Info;
-
-                if (laneInfo.name != info.name &&
-                    (!childNetInfoNamesByCustomizableNetInfoName_.ContainsKey(info.name) ||
-                     !childNetInfoNamesByCustomizableNetInfoName_[info.name]
-                         .Contains(laneInfo.name))) {
-                    continue;
-                }
-
-                Flags.RemoveLaneSpeedLimit(laneId);
-            }
-        }
-
-        /// <summary>
         /// Determines the game default speed limit of the given NetInfo.
         /// </summary>
         /// <param name="info">the NetInfo of which the game default speed limit should be determined</param>
-        /// <param name="roundToSignLimits">if true, custom speed limit are rounded to speed limits
-        /// available as speed limit sign</param>
         /// <returns>The vanilla speed limit, in game units.</returns>
-        public float GetVanillaNetInfoSpeedLimit(NetInfo info, bool roundToSignLimits = true) {
+        private float GetVanillaNetInfoSpeedLimit(NetInfo info) {
             if (info == null) {
-                Log._DebugOnlyWarning(
-                    "SpeedLimitManager.GetVanillaNetInfoSpeedLimit: info is null!");
-                return 0;
+                Log._DebugOnlyWarning("SpeedLimitManager.GetVanillaNetInfoSpeedLimit: info is null!");
+                return 0f;
             }
 
             if (info.m_netAI == null) {
-                Log._DebugOnlyWarning(
-                    "SpeedLimitManager.GetVanillaNetInfoSpeedLimit: info.m_netAI is null!");
-                return 0;
+                Log._DebugOnlyWarning("SpeedLimitManager.GetVanillaNetInfoSpeedLimit: info.m_netAI is null!");
+                return 0f;
             }
 
-            // Resharper warning: condition always false
-            // if (info.name == null) {
-            //    Log._DebugOnlyWarning($"SpeedLimitManager.GetVanillaNetInfoSpeedLimit: info.name is null!");
-            //    return 0;
-            // }
-
             string infoName = info.name;
-            if (!vanillaLaneSpeedLimitsByNetInfoName_.TryGetValue(
+            if (!vanillaLaneSpeedLimits_.TryGetValue(
                     infoName,
                     out float[] vanillaSpeedLimits)) {
-                return 0;
+                return 0f;
             }
 
             float? maxSpeedLimit = null;
@@ -397,7 +266,7 @@ namespace TrafficManager.Manager.Impl {
                 }
             }
 
-            return maxSpeedLimit ?? 0;
+            return maxSpeedLimit ?? 0f;
         }
 
         /// <summary>
@@ -405,57 +274,66 @@ namespace TrafficManager.Manager.Impl {
         /// </summary>
         /// <param name="info">the NetInfo of which the custom speed limit should be determined</param>
         /// <returns>-1 if no custom speed limit was set</returns>
-        public float GetCustomNetInfoSpeedLimit(NetInfo info) {
+        public float GetCustomNetinfoSpeedLimit(NetInfo info) {
             if (info == null) {
-                Log._DebugOnlyWarning(
-                    $"SpeedLimitManager.SetCustomNetInfoSpeedLimitIndex: info is null!");
-                return -1;
+                Log._DebugOnlyWarning($"SpeedLimitManager.GetCustomNetinfoSpeedLimit: info is null!");
+                return -1f;
             }
 
-            // Resharper warning: condition always false
-            // if (info.name == null) {
-            //    Log._DebugOnlyWarning($"SpeedLimitManager.SetCustomNetInfoSpeedLimitIndex: info.name is null!");
-            //    return -1;
-            // }
-
-            string infoName = info.name;
-            return !customLaneSpeedLimitByNetInfoName_.TryGetValue(infoName, out float speedLimit)
-                       ? GetVanillaNetInfoSpeedLimit(info, true)
+            return !customLaneSpeedLimit_.TryGetValue(info.name, out float speedLimit)
+                       ? GetVanillaNetInfoSpeedLimit(info)
                        : speedLimit;
+        }
+
+        /// <summary>
+        /// Go into parent netinfo names and child netinfo names, and restore the collection of all
+        /// netinfo names belonging to the same asset.
+        /// </summary>
+        /// <param name="netinfoName">The name to begin from.</param>
+        /// <param name="result">The resulting name set, also used to avoid infinite loops.</param>
+        private void GetRelatedNetinfos(string netinfoName, [NotNull] HashSet<string> result) {
+            if (result.Contains(netinfoName)) {
+                return; // avoid infinite loops
+            }
+
+            result.Add(netinfoName);
+
+            if (this.parentNetinfoNames_.TryGetValue(netinfoName, out string parentNetinfoName)) {
+                GetRelatedNetinfos(parentNetinfoName, result);
+            }
+
+            if (this.childNetinfoNames_.TryGetValue(netinfoName, out var childNetinfoNames)) {
+                foreach (var childName in childNetinfoNames) {
+                    GetRelatedNetinfos(childName, result);
+                }
+            }
         }
 
         /// <summary>
         /// Sets the custom speed limit of the given NetInfo.
         /// </summary>
-        /// <param name="info">the NetInfo for which the custom speed limit should be set</param>
+        /// <param name="netinfo">the NetInfo for which the custom speed limit should be set</param>
         /// <param name="customSpeedLimit">The speed value to set in game speed units</param>
-        public void SetCustomNetInfoSpeedLimit(NetInfo info, float customSpeedLimit) {
-            if (info == null) {
+        public void SetCustomNetinfoSpeedLimit(NetInfo netinfo, float customSpeedLimit) {
+            if (netinfo == null) {
                 Log._DebugOnlyWarning($"SetCustomNetInfoSpeedLimitIndex: info is null!");
                 return;
             }
 
-            string infoName = info.name;
-            customLaneSpeedLimitByNetInfoName_[infoName] = customSpeedLimit;
             float gameSpeedLimit = ToGameSpeedLimit(customSpeedLimit);
 
-            // save speed limit in all NetInfos
-#if DEBUGLOAD
-            Log._Debug($"Updating parent NetInfo {infoName}: Setting speed limit to {gameSpeedLimit}");
-#endif
-            UpdateNetInfoGameSpeedLimit(info, gameSpeedLimit);
+            HashSet<string> relatedNetinfoNames = new();
+            this.GetRelatedNetinfos(netinfo.name, relatedNetinfoNames);
 
-            if (childNetInfoNamesByCustomizableNetInfoName_.TryGetValue(
-                infoName,
-                out List<string> childNetInfoNames)) {
-                foreach (string childNetInfoName in childNetInfoNames) {
-                    if (netInfoByName_.TryGetValue(childNetInfoName, out NetInfo childNetInfo)) {
+            foreach (var netinfoName in relatedNetinfoNames) {
+                customLaneSpeedLimit_[netinfoName] = customSpeedLimit;
+
 #if DEBUGLOAD
-                        Log._Debug($"Updating child NetInfo {childNetInfoName}: Setting speed limit to {gameSpeedLimit}");
+                Log._Debug($"Updating parent NetInfo {infoName}: Setting speed limit to {gameSpeedLimit}");
 #endif
-                        customLaneSpeedLimitByNetInfoName_[childNetInfoName] = customSpeedLimit;
-                        UpdateNetInfoGameSpeedLimit(childNetInfo, gameSpeedLimit);
-                    }
+                // save speed limit in all NetInfos
+                if (this.netInfoByName_.TryGetValue(netinfoName, out var relatedNetinfo)) {
+                    UpdateNetinfoSpeedLimit(relatedNetinfo, gameSpeedLimit);
                 }
             }
         }
@@ -465,36 +343,30 @@ namespace TrafficManager.Manager.Impl {
             Log.NotImpl("InternalPrintDebugInfo for SpeedLimitManager");
         }
 
-        private void UpdateNetInfoGameSpeedLimit(NetInfo info, float gameSpeedLimit) {
+        private void UpdateNetinfoSpeedLimit(NetInfo info, float gameSpeedLimit) {
             if (info == null) {
-                Log._DebugOnlyWarning(
-                    $"SpeedLimitManager.UpdateNetInfoGameSpeedLimit: info is null!");
+                Log._DebugOnlyWarning($"SpeedLimitManager.UpdateNetinfoSpeedLimit: info is null!");
                 return;
             }
 
-            // Resharper warning: condition always false
-            // if (info.name == null) {
-            //    Log._DebugOnlyWarning($"SpeedLimitManager.UpdateNetInfoGameSpeedLimit: info.name is null!");
-            //    return;
-            // }
-
             if (info.m_lanes == null) {
-                Log._DebugOnlyWarning(
-                    $"SpeedLimitManager.UpdateNetInfoGameSpeedLimit: info.name is null!");
+                Log._DebugOnlyWarning($"SpeedLimitManager.UpdateNetinfoSpeedLimit: info.lanes is null!");
                 return;
             }
 
             Log._Trace($"Updating speed limit of NetInfo {info.name} to {gameSpeedLimit}");
 
+            var mask = this.VehicleTypes;
+
             foreach (NetInfo.Lane lane in info.m_lanes) {
-                // TODO refactor check
-                if ((lane.m_vehicleType & VEHICLE_TYPES) != VehicleInfo.VehicleType.None) {
+                if ((lane.m_vehicleType & mask) != VehicleInfo.VehicleType.None) {
                     lane.m_speedLimit = gameSpeedLimit;
                 }
             }
 
             for(ushort segmentId = 1; segmentId < NetManager.MAX_SEGMENT_COUNT; ++segmentId) {
                 ref var segment = ref segmentId.ToSegment();
+
                 if (segment.IsValid() && segment.Info == info) {
                     Notifier.Instance.OnSegmentModified(segmentId, this);
                 }
@@ -509,12 +381,12 @@ namespace TrafficManager.Manager.Impl {
                                       NetInfo.Lane laneInfo,
                                       uint laneId,
                                       SetSpeedLimitAction action) {
-            if (!this.MayHaveCustomSpeedLimits(laneInfo)) {
+            if (!laneInfo.MayHaveCustomSpeedLimits()) {
                 return false;
             }
 
             if (action.Type == SetSpeedLimitAction.ActionType.ResetToDefault) {
-                Flags.RemoveLaneSpeedLimit(laneId);
+                RemoveLaneSpeedLimit(laneId);
                 Notifier.Instance.OnSegmentModified(segmentId, this);
                 return true;
             }
@@ -529,24 +401,43 @@ namespace TrafficManager.Manager.Impl {
                 return false;
             }
 
-            Flags.SetLaneSpeedLimit(segmentId, laneIndex, laneId, action);
+            SetLaneSpeedLimit(segmentId, laneIndex, laneId, action);
 
             Notifier.Instance.OnSegmentModified(segmentId, this);
             return true;
         }
 
-        public void ResetCustomDefaultSpeedlimit([NotNull] string netinfoName) {
-            if (this.customLaneSpeedLimitByNetInfoName_.ContainsKey(netinfoName)) {
-                this.customLaneSpeedLimitByNetInfoName_.Remove(netinfoName);
+        /// <summary>
+        /// Resets default speed limit for netinfo and all child netinfos.
+        /// Mostly repeats the code of <see cref="SetCustomNetinfoSpeedLimit"/>.
+        /// </summary>
+        public void ResetCustomNetinfoSpeedLimit([NotNull] NetInfo netinfo) {
+            if (netinfo == null) {
+                Log._DebugOnlyWarning($"SetCustomNetInfoSpeedLimitIndex: info is null!");
+                return;
+            }
+
+            Log.Info($"Resetting custom default speed for netinfo '{netinfo.name}'");
+
+            var vanillaSpeedLimit = GetVanillaNetInfoSpeedLimit(netinfo);
+
+            HashSet<string> relatedNetinfoNames = new();
+            this.GetRelatedNetinfos(netinfo.name, relatedNetinfoNames);
+
+            foreach (var netinfoName in relatedNetinfoNames) {
+                if (this.customLaneSpeedLimit_.ContainsKey(netinfoName)) {
+                    this.customLaneSpeedLimit_.Remove(netinfoName);
+                }
+
+                if (this.netInfoByName_.TryGetValue(netinfoName, out var relatedNetinfo)) {
+                    this.UpdateNetinfoSpeedLimit(relatedNetinfo, vanillaSpeedLimit);
+                }
             }
         }
 
         /// <summary>Sets speed limit for all configurable lanes.</summary>
         /// <param name="action">Speed limit in game units, or null to restore defaults.</param>
-        /// <returns>
-        /// <c>false</c>if there are no configurable lanes.
-        /// <c>true</c> if any speed limits were applied.
-        /// </returns>
+        /// <returns><c>true</c> if speed limits were applied to at least one lane.</returns>
         public bool SetSegmentSpeedLimit(ushort segmentId, SetSpeedLimitAction action) {
             bool ret = false;
 
@@ -567,7 +458,7 @@ namespace TrafficManager.Manager.Impl {
                                          SetSpeedLimitAction action) {
             ref NetSegment netSegment = ref segmentId.ToSegment();
 
-            if (!this.MayHaveCustomSpeedLimits(ref netSegment)) {
+            if (!netSegment.MayHaveCustomSpeedLimits()) {
                 return false;
             }
 
@@ -590,7 +481,6 @@ namespace TrafficManager.Manager.Impl {
 
             uint curLaneId = netSegment.m_lanes;
             int laneIndex = 0;
-            NetLane[] laneBuffer = Singleton<NetManager>.instance.m_lanes.m_buffer;
 
             //-------------------------
             // For each affected lane
@@ -599,33 +489,29 @@ namespace TrafficManager.Manager.Impl {
                 NetInfo.Lane laneInfo = segmentInfo.m_lanes[laneIndex];
                 NetInfo.Direction d = laneInfo.m_finalDirection;
 
-                if (d == finalDir && this.MayHaveCustomSpeedLimits(laneInfo)) {
+                if (d == finalDir && laneInfo.MayHaveCustomSpeedLimits()) {
                     if (action.Type == SetSpeedLimitAction.ActionType.ResetToDefault) {
                         // Setting to 'Default' will instead remove the override
                         Log._Debug(
                             $"SpeedLimitManager: Setting speed limit of lane {curLaneId} " +
                             $"to default");
-                        Flags.RemoveLaneSpeedLimit(curLaneId);
+                        RemoveLaneSpeedLimit(curLaneId);
                     } else {
                         bool showMph = GlobalConfig.Instance.Main.DisplaySpeedLimitsMph;
                         string overrideStr = action.GuardedValue.Override.FormatStr(showMph);
 
                         Log._Debug(
                             $"SpeedLimitManager: Setting lane {curLaneId} to {overrideStr}");
-                        Flags.SetLaneSpeedLimit(curLaneId, action);
+                        SetLaneSpeedLimit(curLaneId, action);
                     }
                 }
 
-                curLaneId = laneBuffer[curLaneId].m_nextLane;
+                curLaneId = curLaneId.ToLane().m_nextLane;
                 laneIndex++;
             }
 
             Notifier.Instance.OnSegmentModified(segmentId, this);
             return true;
-        }
-
-        public List<NetInfo> GetCustomizableNetInfos() {
-            return customizableNetInfos_;
         }
 
         public override void OnBeforeLoadData() {
@@ -642,11 +528,12 @@ namespace TrafficManager.Manager.Impl {
             int numLoaded = PrefabCollection<NetInfo>.LoadedCount();
 
             // todo: move this to a Reset() or Clear() method?
-            vanillaLaneSpeedLimitsByNetInfoName_.Clear();
-            customizableNetInfos_.Clear();
-            customLaneSpeedLimitByNetInfoName_.Clear();
-            childNetInfoNamesByCustomizableNetInfoName_.Clear();
-            netInfoByName_.Clear();
+            this.vanillaLaneSpeedLimits_.Clear();
+            this.customizableNetInfos_.Clear();
+            this.customLaneSpeedLimit_.Clear();
+            this.childNetinfoNames_.Clear();
+            this.parentNetinfoNames_.Clear();
+            this.netInfoByName_.Clear();
 
             List<NetInfo> mainNetInfos = new List<NetInfo>();
 
@@ -722,7 +609,7 @@ namespace TrafficManager.Manager.Impl {
                     continue;
                 }
 
-                if (!vanillaLaneSpeedLimitsByNetInfoName_.ContainsKey(infoName)) {
+                if (!vanillaLaneSpeedLimits_.ContainsKey(infoName)) {
                     if (info.m_lanes == null) {
                         log.AppendFormat(
                             "- Skipped: NetInfo #{0} ({1}) - m_lanes is null!\n",
@@ -745,66 +632,65 @@ namespace TrafficManager.Manager.Impl {
                         vanillaLaneSpeedLimits[k] = info.m_lanes[k].m_speedLimit;
                     }
 
-                    vanillaLaneSpeedLimitsByNetInfoName_[infoName] = vanillaLaneSpeedLimits;
+                    vanillaLaneSpeedLimits_[infoName] = vanillaLaneSpeedLimits;
                 }
             }
 
             log.Append("SpeedLimitManager.OnBeforeLoadData: Scan complete.\n");
             Log.Info(log.ToString());
 
-            mainNetInfos.Sort(
-                (NetInfo a, NetInfo b) => {
-                    // todo: move arrow function somewhere else?
-                    bool aRoad = a.m_netAI is RoadBaseAI;
-                    bool bRoad = b.m_netAI is RoadBaseAI;
+            int CompareNetinfos(NetInfo a, NetInfo b) {
+                bool aRoad = a.m_netAI is RoadBaseAI;
+                bool bRoad = b.m_netAI is RoadBaseAI;
 
-                    if (aRoad != bRoad) {
-                        return aRoad ? -1 : 1;
+                if (aRoad != bRoad) {
+                    return aRoad ? -1 : 1;
+                }
+
+                bool aTrain = a.m_netAI is TrainTrackBaseAI;
+                bool bTrain = b.m_netAI is TrainTrackBaseAI;
+
+                if (aTrain != bTrain) {
+                    return aTrain ? 1 : -1;
+                }
+
+                bool aMetro = a.m_netAI is MetroTrackAI;
+                bool bMetro = b.m_netAI is MetroTrackAI;
+
+                if (aMetro != bMetro) {
+                    return aMetro ? 1 : -1;
+                }
+
+                if (aRoad && bRoad) {
+                    bool aHighway = ((RoadBaseAI)a.m_netAI).m_highwayRules;
+                    bool bHighway = ((RoadBaseAI)b.m_netAI).m_highwayRules;
+
+                    if (aHighway != bHighway) {
+                        return aHighway ? 1 : -1;
                     }
+                }
 
-                    bool aTrain = a.m_netAI is TrainTrackBaseAI;
-                    bool bTrain = b.m_netAI is TrainTrackBaseAI;
-
-                    if (aTrain != bTrain) {
-                        return aTrain ? 1 : -1;
+                int aNumVehicleLanes = 0;
+                foreach (NetInfo.Lane lane in a.m_lanes) {
+                    if ((lane.m_laneType & LANE_TYPES) != NetInfo.LaneType.None) {
+                        ++aNumVehicleLanes;
                     }
+                }
 
-                    bool aMetro = a.m_netAI is MetroTrackAI;
-                    bool bMetro = b.m_netAI is MetroTrackAI;
+                int bNumVehicleLanes = 0;
+                foreach (NetInfo.Lane lane in b.m_lanes) {
+                    if ((lane.m_laneType & LANE_TYPES) != NetInfo.LaneType.None) ++bNumVehicleLanes;
+                }
 
-                    if (aMetro != bMetro) {
-                        return aMetro ? 1 : -1;
-                    }
+                int res = aNumVehicleLanes.CompareTo(bNumVehicleLanes);
+                if (res == 0) {
+                    return a.name.CompareTo(b.name);
+                }
 
-                    if (aRoad && bRoad) {
-                        bool aHighway = ((RoadBaseAI)a.m_netAI).m_highwayRules;
-                        bool bHighway = ((RoadBaseAI)b.m_netAI).m_highwayRules;
+                return res;
+            }
 
-                        if (aHighway != bHighway) {
-                            return aHighway ? 1 : -1;
-                        }
-                    }
-
-                    int aNumVehicleLanes = 0;
-                    foreach (NetInfo.Lane lane in a.m_lanes) {
-                        if ((lane.m_laneType & LANE_TYPES) != NetInfo.LaneType.None) {
-                            ++aNumVehicleLanes;
-                        }
-                    }
-
-                    int bNumVehicleLanes = 0;
-                    foreach (NetInfo.Lane lane in b.m_lanes) {
-                        if ((lane.m_laneType & LANE_TYPES) != NetInfo.LaneType.None)
-                            ++bNumVehicleLanes;
-                    }
-
-                    int res = aNumVehicleLanes.CompareTo(bNumVehicleLanes);
-                    if (res == 0) {
-                        return a.name.CompareTo(b.name);
-                    } else {
-                        return res;
-                    }
-                });
+            mainNetInfos.Sort(CompareNetinfos);
 
             // identify parent NetInfos
             int x = 0;
@@ -818,17 +704,17 @@ namespace TrafficManager.Manager.Impl {
                     if (info.m_placementStyle == ItemClass.Placement.Procedural
                         && !infoName.Equals(parentInfo.name)
                         && infoName.StartsWith(parentInfo.name)) {
-                        Log._Trace(
-                            $"Identified child NetInfo {infoName} of parent {parentInfo.name}");
+                        Log._Trace($"Identified child NetInfo {infoName} of parent {parentInfo.name}");
 
-                        if (!childNetInfoNamesByCustomizableNetInfoName_.TryGetValue(
+                        if (!childNetinfoNames_.TryGetValue(
                                 parentInfo.name,
                                 out List<string> childNetInfoNames)) {
-                            childNetInfoNamesByCustomizableNetInfoName_[parentInfo.name] =
-                                childNetInfoNames = new List<string>();
+                            childNetinfoNames_[parentInfo.name] = childNetInfoNames = new();
                         }
 
                         childNetInfoNames.Add(info.name);
+                        parentNetinfoNames_.Add(info.name, parentInfo.name);
+
                         netInfoByName_[infoName] = info;
                         foundParent = true;
                         break;
@@ -855,7 +741,7 @@ namespace TrafficManager.Manager.Impl {
             while (laneIndex < segmentInfo.m_lanes.Length && curLaneId != 0u) {
                 // NetInfo.Lane laneInfo = segmentInfo.m_lanes[laneIndex];
                 // float? setSpeedLimit = Flags.getLaneSpeedLimit(curLaneId);
-                Flags.SetLaneSpeedLimit(curLaneId, SetSpeedLimitAction.ResetToDefault());
+                SetLaneSpeedLimit(curLaneId, SetSpeedLimitAction.ResetToDefault());
 
                 curLaneId = Singleton<NetManager>.instance.m_lanes.m_buffer[curLaneId].m_nextLane;
                 laneIndex++;
@@ -889,7 +775,7 @@ namespace TrafficManager.Manager.Impl {
                                                             .m_buffer[laneSpeedLimit.laneId]
                                                             .m_segment;
                     NetInfo info = segmentId.ToSegment().Info;
-                    float customSpeedLimit = GetCustomNetInfoSpeedLimit(info);
+                    float customSpeedLimit = GetCustomNetinfoSpeedLimit(info);
 #if DEBUG
                     Log._DebugIf(
                         debugSpeedLimits,
@@ -911,7 +797,7 @@ namespace TrafficManager.Manager.Impl {
                         // convert to game units
                         float units = laneSpeedLimit.speedLimit / ApiConstants.SPEED_TO_KMPH;
 
-                        Flags.SetLaneSpeedLimit(
+                        SetLaneSpeedLimit(
                             laneSpeedLimit.laneId,
                             SetSpeedLimitAction.SetOverride(new SpeedValue(units)));
                     } else {
@@ -935,10 +821,16 @@ namespace TrafficManager.Manager.Impl {
             return success;
         }
 
-        List<Configuration.LaneSpeedLimit> ICustomDataManager<List<Configuration.LaneSpeedLimit>>.
-            SaveData(ref bool success) {
-            var ret = new List<Configuration.LaneSpeedLimit>();
-            foreach (KeyValuePair<uint, float> e in Flags.GetAllLaneSpeedLimits()) {
+        /// <summary>Impl. for Lane speed limits data manager.</summary>
+        List<Configuration.LaneSpeedLimit> ICustomDataManager<List<Configuration.LaneSpeedLimit>>.SaveData(ref bool success)
+        {
+            return this.SaveLanes(ref success);
+        }
+
+        private List<Configuration.LaneSpeedLimit> SaveLanes(ref bool success) {
+            var result = new List<Configuration.LaneSpeedLimit>();
+
+            foreach (KeyValuePair<uint, float> e in this.GetAllLaneSpeedLimits()) {
                 try {
                     var laneSpeedLimit = new Configuration.LaneSpeedLimit(
                         e.Key,
@@ -947,7 +839,7 @@ namespace TrafficManager.Manager.Impl {
                     Log._Debug($"Saving speed limit of lane {laneSpeedLimit.laneId}: " +
                         $"{laneSpeedLimit.speedLimit*SpeedLimit.SPEED_TO_KMPH} km/h");
 #endif
-                    ret.Add(laneSpeedLimit);
+                    result.Add(laneSpeedLimit);
                 }
                 catch (Exception ex) {
                     Log.Error($"Exception occurred while saving lane speed limit @ {e.Key}: {ex}");
@@ -955,10 +847,13 @@ namespace TrafficManager.Manager.Impl {
                 }
             }
 
-            return ret;
+            return result;
         }
 
-        public bool LoadData(Dictionary<string, float> data) {
+        /// <summary>Called to load our data from the savegame or config options.</summary>
+        /// <param name="data"></param>
+        /// <returns></returns>
+        public bool LoadData([NotNull] Dictionary<string, float> data) {
             Log.Info($"Loading custom default speed limit data. {data.Count} elements");
             foreach (KeyValuePair<string, float> e in data) {
                 if (!netInfoByName_.TryGetValue(e.Key, out NetInfo netInfo)) {
@@ -966,21 +861,26 @@ namespace TrafficManager.Manager.Impl {
                 }
 
                 if (e.Value >= 0f) {
-                    SetCustomNetInfoSpeedLimit(netInfo, e.Value);
+                    SetCustomNetinfoSpeedLimit(netInfo, e.Value);
                 }
             }
 
             return true; // true = success
         }
 
-        Dictionary<string, float> ICustomDataManager<Dictionary<string, float>>.SaveData(
-            ref bool success) {
-            var ret = new Dictionary<string, float>();
-            foreach (KeyValuePair<string, float> e in customLaneSpeedLimitByNetInfoName_) {
+        /// <summary>Impl. for Custom default speed limits data manager.</summary>
+        Dictionary<string, float> ICustomDataManager<Dictionary<string, float>>.SaveData(ref bool success) {
+            return this.SaveCustomDefaultLimits(ref success);
+        }
+
+        private Dictionary<string, float> SaveCustomDefaultLimits(ref bool success) {
+            var result = new Dictionary<string, float>();
+
+            foreach (KeyValuePair<string, float> e in customLaneSpeedLimit_) {
                 try {
                     float gameSpeedLimit = ToGameSpeedLimit(e.Value);
 
-                    ret.Add(e.Key, gameSpeedLimit);
+                    result.Add(e.Key, gameSpeedLimit);
                 }
                 catch (Exception ex) {
                     Log.Error(
@@ -989,46 +889,16 @@ namespace TrafficManager.Manager.Impl {
                 }
             }
 
-            return ret;
+            return result;
         }
 
-#if DEBUG
-//        public Dictionary<NetInfo, ushort> GetDefaultSpeedLimits() {
-//            Dictionary<NetInfo, ushort> ret = new Dictionary<NetInfo, ushort>();
-//            int numLoaded = PrefabCollection<NetInfo>.LoadedCount();
-//            for (uint i = 0; i < numLoaded; ++i) {
-//                NetInfo info = PrefabCollection<NetInfo>.GetLoaded(i);
-//                var defaultSpeedLimit =
-//                    (ushort)GetAverageDefaultCustomSpeedLimit(info, NetInfo.Direction.Forward);
-//                ret.Add(info, defaultSpeedLimit);
-//                Log._DebugFormat(
-//                    "Loaded NetInfo: {0}, placementStyle={1}, availableIn={2}, thumbnail={3} " +
-//                    "connectionClass.service: {4}, connectionClass.subService: {5}, " +
-//                    "avg. default speed limit: {6}",
-//                    info.name,
-//                    info.m_placementStyle,
-//                    info.m_availableIn,
-//                    info.m_Thumbnail,
-//                    info.GetConnectionClass().m_service,
-//                    info.GetConnectionClass().m_subService,
-//                    defaultSpeedLimit);
-//            }
-//
-//            return ret;
-//        }
-#endif
-
-        /// <summary>
-        /// Used for loading and saving lane speed limits
-        /// </summary>
+        /// <summary>Used for loading and saving lane speed limits.</summary>
         /// <returns>ICustomDataManager with custom lane speed limits</returns>
         public static ICustomDataManager<List<Configuration.LaneSpeedLimit>> AsLaneSpeedLimitsDM() {
             return Instance;
         }
 
-        /// <summary>
-        /// Used for loading and saving custom default speed limits
-        /// </summary>
+        /// <summary>Used for loading and saving custom default speed limits.</summary>
         /// <returns>ICustomDataManager with custom default speed limits</returns>
         public static ICustomDataManager<Dictionary<string, float>> AsCustomDefaultSpeedLimitsDM() {
             return Instance;
@@ -1044,7 +914,175 @@ namespace TrafficManager.Manager.Impl {
         /// </summary>
         // ReSharper restore Unity.ExpensiveCode
         public bool IsKnownNetinfoName(string infoName) {
-            return this.vanillaLaneSpeedLimitsByNetInfoName_.ContainsKey(infoName);
+            return this.vanillaLaneSpeedLimits_.ContainsKey(infoName);
+        }
+
+        /// <summary>Private: Do not call from the outside.</summary>
+        private void SetLaneSpeedLimit(uint laneId, SetSpeedLimitAction action) {
+            if (!Flags.CheckLane(laneId)) {
+                return;
+            }
+
+            ushort segmentId = Singleton<NetManager>.instance.m_lanes.m_buffer[laneId].m_segment;
+            ref NetSegment netSegment = ref segmentId.ToSegment();
+            NetInfo segmentInfo = netSegment.Info;
+            uint curLaneId = netSegment.m_lanes;
+            uint laneIndex = 0;
+
+            while (laneIndex < segmentInfo.m_lanes.Length && curLaneId != 0u) {
+                if (curLaneId == laneId) {
+                    SetLaneSpeedLimit(segmentId, laneIndex, laneId, action);
+                    return;
+                }
+
+                laneIndex++;
+                curLaneId = Singleton<NetManager>.instance.m_lanes.m_buffer[curLaneId].m_nextLane;
+            }
+        }
+
+        /// <summary>Private: Do not call from the outside.</summary>
+        public void RemoveLaneSpeedLimit(uint laneId) {
+            SetLaneSpeedLimit(laneId, SetSpeedLimitAction.ResetToDefault());
+        }
+
+        /// <summary>Private: Do not call from the outside.</summary>
+        public void SetLaneSpeedLimit(ushort segmentId,
+                                      uint laneIndex,
+                                      uint laneId,
+                                      SetSpeedLimitAction action) {
+            if (segmentId <= 0 || laneId <= 0) {
+                return;
+            }
+
+            ref NetSegment netSegment = ref segmentId.ToSegment();
+
+            if ((netSegment.m_flags & (NetSegment.Flags.Created | NetSegment.Flags.Deleted)) != NetSegment.Flags.Created) {
+                return;
+            }
+
+            NetLane[] lanesBuffer = Singleton<NetManager>.instance.m_lanes.m_buffer;
+
+            if (((NetLane.Flags)lanesBuffer[laneId].m_flags &
+                 (NetLane.Flags.Created | NetLane.Flags.Deleted)) != NetLane.Flags.Created) {
+                return;
+            }
+
+            NetInfo segmentInfo = netSegment.Info;
+            if (laneIndex >= segmentInfo.m_lanes.Length) {
+                return;
+            }
+
+            lock(laneSpeedLimitLock_) {
+#if DEBUGFLAGS
+                Log._Debug(
+                    $"Flags.setLaneSpeedLimit: setting speed limit of lane index {laneIndex} @ seg. " +
+                    $"{segmentId} to {speedLimit}");
+#endif
+                switch (action.Type) {
+                    case SetSpeedLimitAction.ActionType.ResetToDefault: {
+                        laneSpeedLimit_.Remove(laneId);
+
+                        if (laneSpeedLimitArray_[segmentId] == null) {
+                            return;
+                        }
+
+                        if (laneIndex >= laneSpeedLimitArray_[segmentId].Length) {
+                            return;
+                        }
+
+                        laneSpeedLimitArray_[segmentId][laneIndex] = null;
+                        break;
+                    }
+                    case SetSpeedLimitAction.ActionType.Unlimited:
+                    case SetSpeedLimitAction.ActionType.SetOverride: {
+                        float gameUnits = action.GuardedValue.Override.GameUnits;
+                        laneSpeedLimit_[laneId] = gameUnits;
+
+                        // save speed limit into the fast-access array.
+                        // (1) ensure that the array is defined and large enough
+                        //-----------------------------------------------------
+                        if (laneSpeedLimitArray_[segmentId] == null) {
+                            laneSpeedLimitArray_[segmentId] = new float?[segmentInfo.m_lanes.Length];
+                        } else if (laneSpeedLimitArray_[segmentId].Length < segmentInfo.m_lanes.Length) {
+                            float?[] oldArray = laneSpeedLimitArray_[segmentId];
+                            laneSpeedLimitArray_[segmentId] = new float?[segmentInfo.m_lanes.Length];
+                            Array.Copy(sourceArray: oldArray,
+                                       destinationArray: laneSpeedLimitArray_[segmentId],
+                                       length: oldArray.Length);
+                        }
+
+                        // (2) insert the custom speed limit
+                        //-----------------------------------------------------
+                        laneSpeedLimitArray_[segmentId][laneIndex] = gameUnits;
+                        break;
+                    }
+                }
+            }
+        }
+
+        public SpeedValue? GetLaneSpeedLimit(uint laneId) {
+            lock(laneSpeedLimitLock_) {
+                if (laneId <= 0 || !laneSpeedLimit_.TryGetValue(laneId, out float gameUnitsOverride)) {
+                    return null;
+                }
+
+                // assumption: speed limit is stored in km/h
+                return new SpeedValue(gameUnitsOverride);
+            }
+        }
+
+        internal IDictionary<uint, float> GetAllLaneSpeedLimits() {
+            IDictionary<uint, float> ret;
+
+            lock(laneSpeedLimitLock_) {
+                ret = new Dictionary<uint, float>(laneSpeedLimit_);
+            }
+
+            return ret;
+        }
+
+        public void ResetSpeedLimits() {
+            lock(laneSpeedLimitLock_) {
+                laneSpeedLimit_.Clear();
+
+                uint segmentsCount = Singleton<NetManager>.instance.m_segments.m_size;
+
+                for (int i = 0; i < segmentsCount; ++i) {
+                    laneSpeedLimitArray_[i] = null;
+                }
+            }
+        }
+
+        /// <summary>Called from Debug Panel via IAbstractCustomManager.</summary>
+        internal new void PrintDebugInfo() {
+            Log.Info("-------------------------");
+            Log.Info("--- LANE SPEED LIMITS ---");
+            Log.Info("-------------------------");
+            for (uint i = 0; i < laneSpeedLimitArray_.Length; ++i) {
+                if (laneSpeedLimitArray_[i] == null) {
+                    continue;
+                }
+
+                ref NetSegment netSegment = ref ((ushort)i).ToSegment();
+
+                Log.Info($"Segment {i}: valid? {netSegment.IsValid()}");
+                for (int x = 0; x < laneSpeedLimitArray_[i].Length; ++x) {
+                    if (laneSpeedLimitArray_[i][x] == null)
+                        continue;
+                    Log.Info($"\tLane idx {x}: {laneSpeedLimitArray_[i][x]}");
+                }
+            }
+        }
+
+        /// <summary>Called by the Lifecycle.</summary>
+        public override void OnLevelUnloading() {
+            for (uint i = 0; i < laneSpeedLimitArray_.Length; ++i) {
+                laneSpeedLimitArray_[i] = null;
+            }
+
+            lock (laneSpeedLimitLock_) {
+                laneSpeedLimit_.Clear();
+            }
         }
     } // end class
 }

--- a/TLM/TLM/Manager/Impl/SpeedLimitManager.cs
+++ b/TLM/TLM/Manager/Impl/SpeedLimitManager.cs
@@ -302,7 +302,7 @@ namespace TrafficManager.Manager.Impl {
                 customLaneSpeedLimit_[netinfo2.name] = customSpeedLimit;
 
 #if DEBUGLOAD
-                Log._Debug($"Updating parent NetInfo {netinfoName}: Setting speed limit to {gameSpeedLimit}");
+                Log._Debug($"Updating NetInfo {netinfoName}: Setting speed limit to {gameSpeedLimit}");
 #endif
                 // save speed limit in all NetInfos
                 if (this.netInfoByName_.TryGetValue(netinfoName, out var relatedNetinfo)) {

--- a/TLM/TLM/Manager/Impl/SpeedLimitManager.cs
+++ b/TLM/TLM/Manager/Impl/SpeedLimitManager.cs
@@ -417,8 +417,6 @@ namespace TrafficManager.Manager.Impl {
                 return;
             }
 
-            Log.Info($"Resetting custom default speed for netinfo '{netinfo.name}'");
-
             var vanillaSpeedLimit = GetVanillaNetInfoSpeedLimit(netinfo);
 
             HashSet<string> relatedNetinfoNames = new();
@@ -492,16 +490,13 @@ namespace TrafficManager.Manager.Impl {
                 if (d == finalDir && laneInfo.MayHaveCustomSpeedLimits()) {
                     if (action.Type == SetSpeedLimitAction.ActionType.ResetToDefault) {
                         // Setting to 'Default' will instead remove the override
-                        Log._Debug(
-                            $"SpeedLimitManager: Setting speed limit of lane {curLaneId} " +
-                            $"to default");
+                        Log._Debug($"SpeedLimitManager: Setting speed limit of lane {curLaneId} to default");
                         RemoveLaneSpeedLimit(curLaneId);
                     } else {
                         bool showMph = GlobalConfig.Instance.Main.DisplaySpeedLimitsMph;
                         string overrideStr = action.GuardedValue.Override.FormatStr(showMph);
 
-                        Log._Debug(
-                            $"SpeedLimitManager: Setting lane {curLaneId} to {overrideStr}");
+                        Log._Debug($"SpeedLimitManager: Setting lane {curLaneId} to {overrideStr}");
                         SetLaneSpeedLimit(curLaneId, action);
                     }
                 }

--- a/TLM/TLM/Manager/Impl/SpeedLimitManagerExt.cs
+++ b/TLM/TLM/Manager/Impl/SpeedLimitManagerExt.cs
@@ -12,6 +12,11 @@
                 return false;
             }
 
+            // Collapsed roads cannot have speed limit, but will be restored if you upgrade in place
+            if ((segment.m_flags & NetSegment.Flags.Collapsed) != NetSegment.Flags.None) {
+                return false;
+            }
+
             ItemClass connectionClass = segment.Info.GetConnectionClass();
             ItemClass.SubService subService = connectionClass.m_subService;
             ItemClass.Service service = connectionClass.m_service;

--- a/TLM/TLM/Manager/Impl/SpeedLimitManagerExt.cs
+++ b/TLM/TLM/Manager/Impl/SpeedLimitManagerExt.cs
@@ -1,0 +1,39 @@
+﻿namespace TrafficManager.Manager.Impl {
+    /// <summary>Adds extra helper functions to NetSegment and NetInfo.Lane, etc.</summary>
+    public static class SpeedLimitManagerExt {
+        /// <summary>
+        /// Extension method. Call via 'segment.MayHaveCustomSpeedLimits()`.
+        /// Check whether custom speed limits may be assigned to the given segment.
+        /// </summary>
+        /// <param name="segment">Reference to affected segment.</param>
+        /// <returns>True if this segment type can have custom speed limits set.</returns>
+        public static bool MayHaveCustomSpeedLimits(this ref NetSegment segment) {
+            if ((segment.m_flags & NetSegment.Flags.Created) == NetSegment.Flags.None) {
+                return false;
+            }
+
+            ItemClass connectionClass = segment.Info.GetConnectionClass();
+            ItemClass.SubService subService = connectionClass.m_subService;
+            ItemClass.Service service = connectionClass.m_service;
+
+            return service == ItemClass.Service.Road
+                   || (service == ItemClass.Service.PublicTransport
+                       && subService
+                           is ItemClass.SubService.PublicTransportTrain
+                           or ItemClass.SubService.PublicTransportTram
+                           or ItemClass.SubService.PublicTransportMetro
+                           or ItemClass.SubService.PublicTransportMonorail);
+        }
+
+        /// <summary>
+        /// Extension method. Call via 'segment.MayHaveCustomSpeedLimits()`.
+        /// Check whether custom speed limits may be assigned to the given lane info.
+        /// </summary>
+        /// <param name="laneInfo">The <see cref="NetInfo.Lane"/> that you wish to check.</param>
+        /// <returns>Whether lane for this lane type can have speed limit override.</returns>
+        public static bool MayHaveCustomSpeedLimits(this NetInfo.Lane laneInfo) {
+            return (laneInfo.m_laneType & SpeedLimitManager.LANE_TYPES) != NetInfo.LaneType.None
+                   && (laneInfo.m_vehicleType & SpeedLimitManager.VEHICLE_TYPES) != VehicleInfo.VehicleType.None;
+        }
+    }
+}

--- a/TLM/TLM/Manager/Impl/UtilityManager.cs
+++ b/TLM/TLM/Manager/Impl/UtilityManager.cs
@@ -58,6 +58,7 @@ namespace TrafficManager.Manager.Impl {
             Log._Debug("=== Flags.PrintDebugInfo() ===");
             try {
                 Flags.PrintDebugInfo();
+                SpeedLimitManager.Instance.PrintDebugInfo();
             }
             catch (Exception e) {
                 Log.Error($"Error occurred while printing debug info for flags: {e}");

--- a/TLM/TLM/State/Flags.cs
+++ b/TLM/TLM/State/Flags.cs
@@ -29,12 +29,6 @@ namespace TrafficManager.State {
         /// </summary>
         internal static uint[][][] laneConnections;
 
-        /// <summary>For each lane: Defines the currently set speed limit. Units: Game speed units (1.0 = 50 km/h).</summary>
-        private static readonly Dictionary<uint, float> laneSpeedLimit;
-
-        /// <summary>For faster, lock-free access, 1st index: segment id, 2nd index: lane index.</summary>
-        internal static readonly float?[][] laneSpeedLimitArray;
-
         /// <summary>
         /// For each lane: Defines the lane arrows which are set in highway rule mode (they are not saved)
         /// </summary>
@@ -45,17 +39,14 @@ namespace TrafficManager.State {
         /// </summary>
         internal static ExtVehicleType?[][] laneAllowedVehicleTypesArray; // for faster, lock-free access, 1st index: segment id, 2nd index: lane index
 
-        private static object laneSpeedLimitLock = new object();
-
         static Flags() {
             laneConnections = new uint[NetManager.MAX_LANE_COUNT][][];
-            laneSpeedLimitArray = new float?[NetManager.MAX_SEGMENT_COUNT][];
-            laneSpeedLimit = new Dictionary<uint, float>();
             laneAllowedVehicleTypesArray = new ExtVehicleType?[NetManager.MAX_SEGMENT_COUNT][];
             laneArrowFlags = new LaneArrows?[NetManager.MAX_LANE_COUNT];
             highwayLaneArrowFlags = new LaneArrows?[NetManager.MAX_LANE_COUNT];
         }
 
+        /// <summary>Called from Debug Panel.</summary>
         internal static void PrintDebugInfo() {
             Log.Info("------------------------");
             Log.Info("--- LANE ARROW FLAGS ---");
@@ -109,24 +100,6 @@ namespace TrafficManager.State {
 
                         Log.Info($"\t\tEntry {y}: {laneIdOfConnection} (valid? {netLaneOfConnection.IsValidWithSegment()})");
                     }
-                }
-            }
-
-            Log.Info("-------------------------");
-            Log.Info("--- LANE SPEED LIMITS ---");
-            Log.Info("-------------------------");
-            for (uint i = 0; i < laneSpeedLimitArray.Length; ++i) {
-                if (laneSpeedLimitArray[i] == null) {
-                    continue;
-                }
-
-                ref NetSegment netSegment = ref ((ushort)i).ToSegment();
-
-                Log.Info($"Segment {i}: valid? {netSegment.IsValid()}");
-                for (int x = 0; x < laneSpeedLimitArray[i].Length; ++x) {
-                    if (laneSpeedLimitArray[i][x] == null)
-                        continue;
-                    Log.Info($"\tLane idx {x}: {laneSpeedLimitArray[i][x]}");
                 }
             }
 
@@ -506,106 +479,6 @@ namespace TrafficManager.State {
             return (netSegment.m_flags & (NetSegment.Flags.Created | NetSegment.Flags.Deleted)) == NetSegment.Flags.Created;
         }
 
-        public static void SetLaneSpeedLimit(uint laneId, SetSpeedLimitAction action) {
-            if (!CheckLane(laneId)) {
-                return;
-            }
-
-            ushort segmentId = Singleton<NetManager>.instance.m_lanes.m_buffer[laneId].m_segment;
-            ref NetSegment netSegment = ref segmentId.ToSegment();
-            NetInfo segmentInfo = netSegment.Info;
-            uint curLaneId = netSegment.m_lanes;
-            uint laneIndex = 0;
-
-            while (laneIndex < segmentInfo.m_lanes.Length && curLaneId != 0u) {
-                if (curLaneId == laneId) {
-                    SetLaneSpeedLimit(segmentId, laneIndex, laneId, action);
-                    return;
-                }
-
-                laneIndex++;
-                curLaneId = Singleton<NetManager>.instance.m_lanes.m_buffer[curLaneId].m_nextLane;
-            }
-        }
-
-        public static void RemoveLaneSpeedLimit(uint laneId) {
-            SetLaneSpeedLimit(laneId, SetSpeedLimitAction.ResetToDefault());
-        }
-
-        public static void SetLaneSpeedLimit(ushort segmentId,
-                                             uint laneIndex,
-                                             uint laneId,
-                                             SetSpeedLimitAction action) {
-            if (segmentId <= 0 || laneId <= 0) {
-                return;
-            }
-
-            ref NetSegment netSegment = ref segmentId.ToSegment();
-
-            if ((netSegment.m_flags & (NetSegment.Flags.Created | NetSegment.Flags.Deleted)) != NetSegment.Flags.Created) {
-                return;
-            }
-
-            NetLane[] lanesBuffer = Singleton<NetManager>.instance.m_lanes.m_buffer;
-
-            if (((NetLane.Flags)lanesBuffer[laneId].m_flags &
-                 (NetLane.Flags.Created | NetLane.Flags.Deleted)) != NetLane.Flags.Created) {
-                return;
-            }
-
-            NetInfo segmentInfo = netSegment.Info;
-            if (laneIndex >= segmentInfo.m_lanes.Length) {
-                return;
-            }
-
-            lock(laneSpeedLimitLock) {
-#if DEBUGFLAGS
-                Log._Debug(
-                    $"Flags.setLaneSpeedLimit: setting speed limit of lane index {laneIndex} @ seg. " +
-                    $"{segmentId} to {speedLimit}");
-#endif
-                switch (action.Type) {
-                    case SetSpeedLimitAction.ActionType.ResetToDefault: {
-                        laneSpeedLimit.Remove(laneId);
-
-                        if (laneSpeedLimitArray[segmentId] == null) {
-                            return;
-                        }
-
-                        if (laneIndex >= laneSpeedLimitArray[segmentId].Length) {
-                            return;
-                        }
-
-                        laneSpeedLimitArray[segmentId][laneIndex] = null;
-                        break;
-                    }
-                    case SetSpeedLimitAction.ActionType.Unlimited:
-                    case SetSpeedLimitAction.ActionType.SetOverride: {
-                        float gameUnits = action.GuardedValue.Override.GameUnits;
-                        laneSpeedLimit[laneId] = gameUnits;
-
-                        // save speed limit into the fast-access array.
-                        // (1) ensure that the array is defined and large enough
-                        //-----------------------------------------------------
-                        if (laneSpeedLimitArray[segmentId] == null) {
-                            laneSpeedLimitArray[segmentId] = new float?[segmentInfo.m_lanes.Length];
-                        } else if (laneSpeedLimitArray[segmentId].Length < segmentInfo.m_lanes.Length) {
-                            float?[] oldArray = laneSpeedLimitArray[segmentId];
-                            laneSpeedLimitArray[segmentId] = new float?[segmentInfo.m_lanes.Length];
-                            Array.Copy(sourceArray: oldArray,
-                                       destinationArray: laneSpeedLimitArray[segmentId],
-                                       length: oldArray.Length);
-                        }
-
-                        // (2) insert the custom speed limit
-                        //-----------------------------------------------------
-                        laneSpeedLimitArray[segmentId][laneIndex] = gameUnits;
-                        break;
-                    }
-                }
-            }
-        }
-
         public static void SetLaneAllowedVehicleTypes(uint laneId, ExtVehicleType vehicleTypes) {
             if (laneId <= 0) {
                 return;
@@ -894,27 +767,6 @@ namespace TrafficManager.State {
             return false;
         }
 
-        public static SpeedValue? GetLaneSpeedLimit(uint laneId) {
-            lock(laneSpeedLimitLock) {
-                if (laneId <= 0 || !laneSpeedLimit.TryGetValue(laneId, out float gameUnitsOverride)) {
-                    return null;
-                }
-
-                // assumption: speed limit is stored in km/h
-                return new SpeedValue(gameUnitsOverride);
-            }
-        }
-
-        internal static IDictionary<uint, float> GetAllLaneSpeedLimits() {
-            IDictionary<uint, float> ret;
-
-            lock(laneSpeedLimitLock) {
-                ret = new Dictionary<uint, float>(laneSpeedLimit);
-            }
-
-            return ret;
-        }
-
         internal static IDictionary<uint, ExtVehicleType> GetAllLaneAllowedVehicleTypes() {
             IDictionary<uint, ExtVehicleType> ret = new Dictionary<uint, ExtVehicleType>();
             ExtSegmentManager extSegmentManager = ExtSegmentManager.Instance;
@@ -1085,29 +937,9 @@ namespace TrafficManager.State {
             }
         }
 
-        public static void ResetSpeedLimits() {
-            lock(laneSpeedLimitLock) {
-                laneSpeedLimit.Clear();
-
-                uint segmentsCount = Singleton<NetManager>.instance.m_segments.m_size;
-
-                for (int i = 0; i < segmentsCount; ++i) {
-                    laneSpeedLimitArray[i] = null;
-                }
-            }
-        }
-
         internal static void OnLevelUnloading() {
             for (uint i = 0; i < laneConnections.Length; ++i) {
                 laneConnections[i] = null;
-            }
-
-            for (uint i = 0; i < laneSpeedLimitArray.Length; ++i) {
-                laneSpeedLimitArray[i] = null;
-            }
-
-            lock (laneSpeedLimitLock) {
-                laneSpeedLimit.Clear();
             }
 
             for (uint i = 0; i < laneAllowedVehicleTypesArray.Length; ++i) {

--- a/TLM/TLM/State/OptionsTabs/OptionsMaintenanceTab.cs
+++ b/TLM/TLM/State/OptionsTabs/OptionsMaintenanceTab.cs
@@ -174,7 +174,7 @@ namespace TrafficManager.State {
                 return;
             }
 
-            Flags.ResetSpeedLimits();
+            SpeedLimitManager.Instance.ResetSpeedLimits();
         }
 
         private static void OnClickReloadGlobalConf() {
@@ -182,7 +182,7 @@ namespace TrafficManager.State {
         }
 
         private static void OnClickResetGlobalConf() {
-            GlobalConfig.Reset(null, true);
+            GlobalConfig.Reset(oldConfig: null, resetAll: true);
         }
 
 #if QUEUEDSTATS

--- a/TLM/TLM/TLM.csproj
+++ b/TLM/TLM/TLM.csproj
@@ -152,6 +152,7 @@
     <Compile Include="Manager\Impl\GetSegmentLaneIdsEnumerator.cs" />
     <Compile Include="Manager\Impl\LaneIdAndIndex.cs" />
     <Compile Include="Manager\Impl\LanePos.cs" />
+    <Compile Include="Manager\Impl\SpeedLimitManagerExt.cs" />
     <Compile Include="Notifier.cs" />
     <Compile Include="Patch\CustomPathFindPatchAttribute.cs" />
     <Compile Include="Patch\PatchCommons.cs" />

--- a/TLM/TLM/TLM.csproj
+++ b/TLM/TLM/TLM.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -424,6 +424,7 @@
     <Compile Include="Util\Extensions\VehicleExtensions.cs" />
     <Compile Include="Util\InGameUtil.cs" />
     <Compile Include="Util\IntVector2.cs" />
+    <Compile Include="Util\RoadFamilyUtil.cs" />
     <Compile Include="Util\Spiral.cs" />
     <Compile Include="Util\Caching\CameraTransformValue.cs" />
     <Compile Include="Util\Caching\GenericArrayCache.cs" />

--- a/TLM/TLM/UI/MainMenu/DebugMenu.cs
+++ b/TLM/TLM/UI/MainMenu/DebugMenu.cs
@@ -13,6 +13,7 @@ namespace TrafficManager.UI.MainMenu {
     using UnityEngine;
     using TrafficManager.Util;
     using TrafficManager.Lifecycle;
+    using TrafficManager.Manager.Impl;
 
 #if DEBUG // whole class coverage
     public class DebugMenuPanel : UIPanel
@@ -354,6 +355,7 @@ namespace TrafficManager.UI.MainMenu {
         private void ClickPrintFlagsDebugInfo(UIComponent component,
                                               UIMouseEventParameter eventParam) {
             Flags.PrintDebugInfo();
+            SpeedLimitManager.Instance.PrintDebugInfo();
         }
 
         [UsedImplicitly]

--- a/TLM/TLM/UI/SubTools/SpeedLimits/Overlay/OverlayLaneSpeedlimitHandle.cs
+++ b/TLM/TLM/UI/SubTools/SpeedLimits/Overlay/OverlayLaneSpeedlimitHandle.cs
@@ -192,7 +192,7 @@
                     break;
                 case SetSpeedLimitTarget.LaneDefault:
                     // TODO: The speed limit manager only supports default speed limit overrides per road type, not per lane
-                    OverlaySegmentSpeedlimitHandle.SetDefaultSpeedLimit(segmentId, netInfo, action);
+                    OverlaySegmentSpeedlimitHandle.ApplyDefaultSpeedLimit(segmentId, netInfo, action);
                     break;
                 default:
                     Log.Error(

--- a/TLM/TLM/UI/SubTools/SpeedLimits/Overlay/OverlaySegmentSpeedlimitHandle.cs
+++ b/TLM/TLM/UI/SubTools/SpeedLimits/Overlay/OverlaySegmentSpeedlimitHandle.cs
@@ -113,16 +113,15 @@
                     break;
                 case SetSpeedLimitTarget.SegmentDefault:
                 case SetSpeedLimitTarget.LaneDefault:
-                    SetDefaultSpeedLimit(segmentId, netInfo, action);
+                    ApplyDefaultSpeedLimit(segmentId, netInfo, action);
                     break;
                 default:
-                    Log.Error(
-                        $"Target for SEGMENT speed handle click is not supported {nameof(target)}");
+                    Log.Error($"Target for SEGMENT speed handle click is not supported {nameof(target)}");
                     throw new NotSupportedException();
             }
         }
 
-        internal static void SetDefaultSpeedLimit(ushort segmentId,
+        internal static void ApplyDefaultSpeedLimit(ushort segmentId,
                                                   [NotNull] NetInfo netInfo,
                                                   SetSpeedLimitAction action) {
             switch (action.Type) {
@@ -130,12 +129,13 @@
                 case SetSpeedLimitAction.ActionType.Unlimited:
                     bool displayMph = GlobalConfig.Instance.Main.DisplaySpeedLimitsMph;
                     SpeedValue value = action.GuardedValue.Override;
-                    Log.Info($"Setting speed limit for netinfo '{netInfo.name}' seg={segmentId} to={value.FormatStr(displayMph)}");
+                    Log._Debug($"Setting speed limit for netinfo '{netInfo.name}' seg={segmentId} to={value.FormatStr(displayMph)}");
                     SpeedLimitManager.Instance.SetCustomNetinfoSpeedLimit(
                         netinfo: netInfo,
                         customSpeedLimit: value.GameUnits);
                     break;
                 case SetSpeedLimitAction.ActionType.ResetToDefault:
+                    Log._Debug($"Resetting custom default speed for netinfo '{netInfo.name}'");
                     SpeedLimitManager.Instance.ResetCustomNetinfoSpeedLimit(netInfo);
                     break;
                 default:

--- a/TLM/TLM/UI/SubTools/SpeedLimits/Overlay/OverlaySegmentSpeedlimitHandle.cs
+++ b/TLM/TLM/UI/SubTools/SpeedLimits/Overlay/OverlaySegmentSpeedlimitHandle.cs
@@ -2,6 +2,7 @@
     using System;
     using ColossalFramework;
     using CSUtil.Commons;
+    using JetBrains.Annotations;
     using TrafficManager.API.Traffic.Data;
     using TrafficManager.Manager.Impl;
     using TrafficManager.State;
@@ -112,7 +113,6 @@
                     break;
                 case SetSpeedLimitTarget.SegmentDefault:
                 case SetSpeedLimitTarget.LaneDefault:
-                    // SpeedLimitManager.Instance.FixCurrentSpeedLimits(netInfo);
                     SetDefaultSpeedLimit(segmentId, netInfo, action);
                     break;
                 default:
@@ -122,20 +122,21 @@
             }
         }
 
-        internal static void SetDefaultSpeedLimit(ushort segmentId, NetInfo netInfo, SetSpeedLimitAction action) {
+        internal static void SetDefaultSpeedLimit(ushort segmentId,
+                                                  [NotNull] NetInfo netInfo,
+                                                  SetSpeedLimitAction action) {
             switch (action.Type) {
                 case SetSpeedLimitAction.ActionType.SetOverride:
                 case SetSpeedLimitAction.ActionType.Unlimited:
-                    SpeedValue value = action.GuardedValue.Override;
                     bool displayMph = GlobalConfig.Instance.Main.DisplaySpeedLimitsMph;
+                    SpeedValue value = action.GuardedValue.Override;
                     Log.Info($"Setting speed limit for netinfo '{netInfo.name}' seg={segmentId} to={value.FormatStr(displayMph)}");
-                    SpeedLimitManager.Instance.SetCustomNetInfoSpeedLimit(
-                        info: netInfo,
+                    SpeedLimitManager.Instance.SetCustomNetinfoSpeedLimit(
+                        netinfo: netInfo,
                         customSpeedLimit: value.GameUnits);
                     break;
                 case SetSpeedLimitAction.ActionType.ResetToDefault:
-                    Log.Info($"Setting default speed limit for netinfo '{netInfo.name}' seg={segmentId}");
-                    SpeedLimitManager.Instance.ResetCustomDefaultSpeedlimit(netInfo.name);
+                    SpeedLimitManager.Instance.ResetCustomNetinfoSpeedLimit(netInfo);
                     break;
                 default:
                     throw new ArgumentOutOfRangeException();

--- a/TLM/TLM/UI/SubTools/SpeedLimits/Overlay/SpeedLimitsOverlay.cs
+++ b/TLM/TLM/UI/SubTools/SpeedLimits/Overlay/SpeedLimitsOverlay.cs
@@ -420,7 +420,7 @@
                 }
 
                 // Ignore: Can't have speed limits set
-                if (!speedLimitManager.MayHaveCustomSpeedLimits(ref segment)) {
+                if (!segment.MayHaveCustomSpeedLimits()) {
                     continue;
                 }
 
@@ -532,7 +532,7 @@
             NetSegment segment = segmentId.ToSegment();
             NetInfo neti = segment.Info;
             var defaultSpeedLimit = new SpeedValue(
-                gameUnits: SpeedLimitManager.Instance.GetCustomNetInfoSpeedLimit(info: neti));
+                gameUnits: SpeedLimitManager.Instance.GetCustomNetinfoSpeedLimit(info: neti));
 
             // Render override if interactive, or if readonly info layer and override exists
             if (drawEnv.drawDefaults_) {

--- a/TLM/TLM/Util/RoadFamilyUtil.cs
+++ b/TLM/TLM/Util/RoadFamilyUtil.cs
@@ -1,0 +1,75 @@
+namespace TrafficManager.Util {
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    public static class RoadFamilyUtil {
+        public static IEnumerable<NetInfo> LoadedNetInfos() {
+            int n = PrefabCollection<NetInfo>.LoadedCount();
+            for(uint i = 0; i < n; ++i) {
+                NetInfo netinfo = PrefabCollection<NetInfo>.GetLoaded(i);
+                if (netinfo)
+                    yield return netinfo;
+            }
+        }
+
+        public static IEnumerable<NetInfo> GetElevations(this NetInfo basic) {
+            if (basic == null) yield break;
+
+            NetInfo elevated = AssetEditorRoadUtils.TryGetElevated(basic);
+            NetInfo bridge = AssetEditorRoadUtils.TryGetBridge(basic);
+            NetInfo slope = AssetEditorRoadUtils.TryGetSlope(basic);
+            NetInfo tunnel = AssetEditorRoadUtils.TryGetTunnel(basic);
+            // TODO: add outside connections.
+
+            yield return basic;
+            if (elevated != null) yield return elevated;
+            if (bridge != null) yield return bridge;
+            if (slope != null) yield return slope;
+            if (tunnel != null) yield return tunnel;
+        }
+
+        /// <summary>
+        /// returns a list of all elevations that are directly or indirectly linked to <c>currentInfo</c>.
+        /// sometimes one elevation belongs to multiple basic elevations.
+        /// the return family will contain all of them.
+        /// </summary>
+        public static IEnumerable<NetInfo> GetRelatives(this NetInfo netinfo) {
+            try {
+                if (netinfo == null) return null;
+
+                HashSet<NetInfo> family = new HashSet<NetInfo>(netinfo.GetDirectlyRelated());
+
+                // get elevations that are indirectly linked to currentInfo.
+                foreach (var netinfo2 in family.ToArray()) {
+                    family.AddRange(netinfo2.GetDirectlyRelated());
+                }
+
+                return family;
+            } catch(Exception ex) {
+                ex.LogException();
+                return new[] { netinfo };
+            }
+        }
+
+        /// <summary>
+        /// returns a list containing <c>currentInfo</c>, base elevation, and all its other elevations.
+        /// </summary>
+        private static IEnumerable<NetInfo> GetDirectlyRelated(this NetInfo netinfo) {
+            foreach (var netinfo2 in LoadedNetInfos()) {
+                var elevations = netinfo2.GetElevations();
+                if (elevations.Contains(netinfo)) {
+                    foreach (var elevation in elevations) {
+                        yield return elevation;
+                    }
+                }
+            }
+        }
+
+        private static void AddRange(this HashSet<NetInfo> hashset, IEnumerable<NetInfo> elements) {
+            foreach (var element in elements) {
+                hashset.Add(element);
+            }
+        }
+    }
+}

--- a/TLM/TLM/Util/RoundaboutMassEdit.cs
+++ b/TLM/TLM/Util/RoundaboutMassEdit.cs
@@ -28,7 +28,7 @@ namespace TrafficManager.Util {
 
             if (OptionsMassEditTab.RoundAboutQuickFix_RealisticSpeedLimits) {
                 SpeedValue? targetSpeed = CalculatePreferedSpeed(segmentId);
-                float defaultSpeed = SpeedLimitManager.Instance.GetCustomNetInfoSpeedLimit(segmentId.ToSegment().Info);
+                float defaultSpeed = SpeedLimitManager.Instance.GetCustomNetinfoSpeedLimit(segmentId.ToSegment().Info);
 
                 if (targetSpeed != null && targetSpeed.Value.GetKmph() < defaultSpeed) {
                     SpeedLimitManager.Instance.SetSegmentSpeedLimit(

--- a/TLM/TMPE.API/Manager/ICustomDataManager.cs
+++ b/TLM/TMPE.API/Manager/ICustomDataManager.cs
@@ -1,6 +1,12 @@
 ﻿namespace TrafficManager.API.Manager {
+    using JetBrains.Annotations;
+
     public interface ICustomDataManager<T> {
-        // TODO documentation
+        /// <summary>Loads data from a configuration field into the class which implements this interface.
+        /// </summary>
+        /// <param name="data">Data comes from here.</param>
+        /// <returns>Success.</returns>
+        [UsedImplicitly] // While this seems to be not called from anywhere, it is in fact called
         bool LoadData(T data);
 
         T SaveData(ref bool success);


### PR DESCRIPTION
Fixes #1226 

* Related netinfo names are now calculated for set/reset speed defaults, both child and parent netinfo names are accounted for, restoring entire netinfo tree from any netinfo name, and then setting or clearing speed limits for all of it.
* Refactor: Moved speedlimits data ownership out of [Obsolete] Flags to the speedlimits manager.
* Refactor: New extension methods `MayHaveCustomSpeedLimits` for `NetSegment` and for `NetInfo.Lane`, moved from standalone static method.
* Somewhat hesitant with renames. `NetInfo` is two words but in a function name it looks better as one word `Netinfo`. Same with `SpeedLimits` in a function name they look much better as one word `Speedlimits`. Any agreement on capitals in the naming?