### PR TITLE
update routings after modifying dedicated turning lanes policy

### DIFF
--- a/TLM/TLM/Manager/Impl/LaneArrowManager.cs
+++ b/TLM/TLM/Manager/Impl/LaneArrowManager.cs
@@ -141,9 +141,12 @@ namespace TrafficManager.Manager.Impl {
             }
         }
 
-        /// <summary>updates all road segments. Call this when policy changes.</summary>
-        /// <param name="dedicatedTurningLanes">
-        /// Narrow down updated roads to those that can have dedicated turning lanes.
+        /// <summary>
+        /// Updates all road relevant segments so that the dedicated turning lane policy would take effect.
+        /// </summary>
+        /// <param name="recalculateRoutings">
+        /// also recalculate lane transitions in routing manager.
+        /// Current car paths will not be recalculated (to save time). New paths will follow the new lane routings.
         /// </param>
         public void UpdateDedicatedTurningLanePolicy(bool recalculateRoutings) {
             Log.Info($"UpdateDedicatedTurningLanePolicy(recalculateRoutings:{recalculateRoutings}) was called.");

--- a/TLM/TLM/Manager/Impl/LaneArrowManager.cs
+++ b/TLM/TLM/Manager/Impl/LaneArrowManager.cs
@@ -145,8 +145,8 @@ namespace TrafficManager.Manager.Impl {
         /// <param name="dedicatedTurningLanes">
         /// Narrow down updated roads to those that can have dedicated turning lanes.
         /// </param>
-        public void UpdateDedicatedTurningLanePolicy() {
-            Log.Info("UpdateAllDefaults(dedicatedTurningLanes:{dedicatedTurningLanes}) was called.");
+        public void UpdateDedicatedTurningLanePolicy(bool recalculateRoutings) {
+            Log.Info("UpdateDedicatedTurningLanePolicy() was called.");
             SimulationManager.instance.AddAction(delegate () {
                 try {
                     Log._Debug($"Executing UpdateDedicatedTurningLanePolicy() in simulation thread ...");
@@ -174,6 +174,9 @@ namespace TrafficManager.Manager.Impl {
 
                         ai.UpdateLanes(segmentId, ref netSegment, true);
                         NetManager.instance.UpdateSegmentRenderer(segmentId, true);
+                        if (recalculateRoutings) {
+                            RoutingManager.Instance.RequestRecalculation(segmentId, false);
+                        }
                     }
                 } catch(Exception ex) {
                     ex.LogException();
@@ -216,7 +219,7 @@ namespace TrafficManager.Manager.Impl {
             base.OnLevelLoading();
             if (OptionsVehicleRestrictionsTab.DedicatedTurningLanes) {
                 // update dedicated turning lanes after patch has been applied.
-                UpdateDedicatedTurningLanePolicy();
+                UpdateDedicatedTurningLanePolicy(false);
             }
         }
 

--- a/TLM/TLM/Manager/Impl/LaneArrowManager.cs
+++ b/TLM/TLM/Manager/Impl/LaneArrowManager.cs
@@ -146,7 +146,7 @@ namespace TrafficManager.Manager.Impl {
         /// Narrow down updated roads to those that can have dedicated turning lanes.
         /// </param>
         public void UpdateDedicatedTurningLanePolicy(bool recalculateRoutings) {
-            Log.Info("UpdateDedicatedTurningLanePolicy() was called.");
+            Log.Info($"UpdateDedicatedTurningLanePolicy(recalculateRoutings:{recalculateRoutings}) was called.");
             SimulationManager.instance.AddAction(delegate () {
                 try {
                     Log._Debug($"Executing UpdateDedicatedTurningLanePolicy() in simulation thread ...");

--- a/TLM/TLM/State/OptionsTabs/OptionsVehicleRestrictionsTab.cs
+++ b/TLM/TLM/State/OptionsTabs/OptionsVehicleRestrictionsTab.cs
@@ -40,7 +40,7 @@ namespace TrafficManager.State {
             JunctionRestrictionsManager.Instance.UpdateAllDefaults();
 
         static void UpdateDedicatedTurningLanePolicyHandler(bool value) =>
-            LaneArrowManager.Instance.UpdateDedicatedTurningLanePolicy();
+            LaneArrowManager.Instance.UpdateDedicatedTurningLanePolicy(true);
 
         internal static void MakeSettings_VehicleRestrictions(ExtUITabstrip tabStrip) {
             UIHelper panelHelper = tabStrip.AddTabPage(Translation.Options.Get("Tab:Policies & Restrictions"));

--- a/TLM/TLM/Util/PlaceIntersectionUtil.cs
+++ b/TLM/TLM/Util/PlaceIntersectionUtil.cs
@@ -54,9 +54,9 @@ namespace TrafficManager.Util {
                 Asset2Data.Select(item => item.Key).ToSTR());
 
             if (Asset2Data.TryGetValue(intersectionInfo, out var assetData)) {
-                Log.Info("PlaceIntersectionUtil.ApplyTrafficRules(): assetData =" + assetData);
+                Log._Debug("PlaceIntersectionUtil.ApplyTrafficRules(): assetData =" + assetData);
             } else {
-                Log.Info("PlaceIntersectionUtil.ApplyTrafficRules(): assetData not found (the asset does not have TMPE data)");
+                Log._Debug("PlaceIntersectionUtil.ApplyTrafficRules(): assetData not found (the asset does not have TMPE data)");
                 return;
             }
 


### PR DESCRIPTION
fixes #1235 (see issue)

Tested and works in game. after deleted all cars new paths will obey dedicated lane arrows.
it is also pretty fast in 655k city (a few seconds)