### PR TITLE
fix position of lane arrow tool for different resolutions.

### DIFF
--- a/TLM/TLM/U/Panel/BaseUWindowPanel.cs
+++ b/TLM/TLM/U/Panel/BaseUWindowPanel.cs
@@ -7,6 +7,7 @@ namespace TrafficManager.U.Panel {
     using TrafficManager.State;
     using TrafficManager.U.Autosize;
     using TrafficManager.UI;
+    using TrafficManager.Util;
     using UnityEngine;
 
     /// <summary>
@@ -112,9 +113,14 @@ namespace TrafficManager.U.Panel {
             base.OnDestroy();
         }
 
-        // protected override void OnResolutionChanged(Vector2 previousResolution, Vector2 currentResolution) {
-        //     Log._Debug("Changed");
-        //     base.OnResolutionChanged(previousResolution, currentResolution);
-        // }
+        /// <summary>
+        /// moves the center of the window to a position in the world (e.g. node).
+        /// </summary>
+        public void MoveCenterToWorldPosition(Vector3 worldPos) {
+            GeometryUtil.WorldToScreenPoint(worldPos, out Vector3 screenPos);
+            screenPos /= GetUIView().inputScale;
+            screenPos -= (Vector3)size * 0.5f;
+            relativePosition = screenPos.RoundToInt();
+        }
     }
 }

--- a/TLM/TLM/U/Panel/BaseUWindowPanel.cs
+++ b/TLM/TLM/U/Panel/BaseUWindowPanel.cs
@@ -114,7 +114,7 @@ namespace TrafficManager.U.Panel {
         }
 
         /// <summary>
-        /// moves the center of the window to a position in the world (e.g. node).
+        /// Moves the center of the window to a position in the world (e.g. node).
         /// </summary>
         public void MoveCenterToWorldPosition(Vector3 worldPos) {
             GeometryUtil.WorldToScreenPoint(worldPos, out Vector3 screenPos);

--- a/TLM/TLM/UI/SubTools/LaneArrows/LaneArrowTool.cs
+++ b/TLM/TLM/UI/SubTools/LaneArrows/LaneArrowTool.cs
@@ -460,17 +460,11 @@ namespace TrafficManager.UI.SubTools.LaneArrows {
         }
 
         private void RepositionWindowToNode() {
-            if (ToolWindow == null || SelectedNodeId == 0) {
+            if (!ToolWindow || SelectedNodeId == 0) {
                 return;
             }
 
-            Vector3 nodePos = SelectedNodeId.ToNode().m_position;
-
-            // Cast to screen and center the window on node
-            GeometryUtil.WorldToScreenPoint(nodePos, out Vector3 screenPixelPos);
-            Vector2 guiPosition = UIScaler.ScreenPointToGuiPoint(screenPixelPos);
-            ToolWindow.absolutePosition =
-                guiPosition - new Vector2(ToolWindow.size.x * 0.5f, ToolWindow.size.y * 0.5f);
+            ToolWindow.MoveCenterToWorldPosition(SelectedNodeId.ToNode().m_position);
         }
 
         /// <summary>


### PR DESCRIPTION
for resolution other than FHD, lane arrow tool would not appear in the right place.  I fixed the code.
- I put the code in the base class to avoid duplicate code in future.
- deleted some commented out code that kvakvs forgot to delete.
- I tested will various resolutions, aspect ratios, UI Scale, and UI resolution mod. All tests pass