### PR TITLE
fixed regression: Auto TTL should set-up dedicated turning lanes properly

### DIFF
--- a/TLM/TLM/State/OptionsTabs/OptionsVehicleRestrictionsTab.cs
+++ b/TLM/TLM/State/OptionsTabs/OptionsVehicleRestrictionsTab.cs
@@ -301,6 +301,9 @@ namespace TrafficManager.State {
             Options.banRegularTrafficOnBusLanes = newValue;
             VehicleRestrictionsManager.Instance.ClearCache();
             ModUI.GetTrafficManagerTool()?.InitializeSubTools();
+            if (DedicatedTurningLanes) {
+                LaneArrowManager.Instance.UpdateDedicatedTurningLanePolicy(false);
+            }
         }
 
         private static void OnHighwayRulesChanged(bool newHighwayRules) {

--- a/TLM/TLM/Util/AutoTimedTrafficLights.cs
+++ b/TLM/TLM/Util/AutoTimedTrafficLights.cs
@@ -117,7 +117,7 @@ namespace TrafficManager.Util {
             }
 
             if (SeparateLanes) {
-                SeparateTurningLanesUtil.SeparateNode(nodeId, out _);
+                SeparateTurningLanesUtil.SeparateNode(nodeId, out _, false);
             }
 
             //Is it special case:

--- a/TLM/TLM/Util/SeparateTurningLanesUtil.cs
+++ b/TLM/TLM/Util/SeparateTurningLanesUtil.cs
@@ -67,7 +67,7 @@ namespace TrafficManager.Util {
         /// <summary>
         /// separates turning lanes for all segments attached to nodeId,
         /// </summary>
-        public static void SeparateNode(ushort nodeId, out SetLaneArrow_Result res, bool alternativeMode = true) {
+        public static void SeparateNode(ushort nodeId, out SetLaneArrow_Result res, bool alternativeMode) {
             if (nodeId == 0) {
                 res = SetLaneArrow_Result.Invalid;
                 return;
@@ -113,9 +113,9 @@ namespace TrafficManager.Util {
                 nodeId,
                 out res,
                 builtIn: false,
-                alt2: alternativeMode && !hasBus,
-                alt3: alternativeMode && !hasBus,
-                altBus: alternativeMode);
+                alt2: alternativeMode,
+                alt3: alternativeMode,
+                altBus: !Options.banRegularTrafficOnBusLanes);
         }
 
         internal static void SeparateSegmentLanesBuiltIn(
@@ -128,7 +128,7 @@ namespace TrafficManager.Util {
                 builtIn: true,
                 alt2: true,
                 alt3: true,
-                altBus: false);
+                altBus: !Options.banRegularTrafficOnBusLanes);
         }
 
         /// <summary>
@@ -138,7 +138,7 @@ namespace TrafficManager.Util {
         /// <param name="alt2">alternativ mode for two lanes(true => dedicated far turn)</param>
         /// <param name="alt3">alternative mode for 3+ lanes(true => favour forward)</param>
         /// <param name="altBus">false => treat bus lanes differently</param>
-        private static void SeparateSegmentLanes(
+        public static void SeparateSegmentLanes(
             ushort segmentId,
             ushort nodeId,
             out SetLaneArrow_Result res,


### PR DESCRIPTION
fixes #1241 | touches #1106

Changes:
- TTL sets-up dedicated turning lanes properly again (see #1241):
    - Dedicated near turn when road has 2 lanes
    - prefer far turn (because its harder).

Bonus changes:
 - if cars are banned on bus lanes they are treated separately when allocating dedicated turning lanes (except single lane roads which are out of scope of this PR):
    - using TTL
    - using dedicated turning lane policy (partially fixes #1106).
    - using lane arrow tool. 
        - Note: the cycle options on bus lanes has changed.
        - it used to cycle between mixed/separate bus lane 
        - now on 2 lane roads: it cycles between dedicated near/far-turn.
        - and on 3+ lane roads: it cycles between prefer forward/far-turn
- if someone turns on the "ban cars on bus lanes" policy while "dedicated turning lanes" policy is on, then lane arrows are updated.

   
Scope:
This PR is meant to be a tiny fix and more complicated stuff are outside of the scope:
- if `cars are banned on bus lanes` and `dedicated turning lanes` policy is turned OFF, cars still cannot turn right (covered in #1106)
- if there is only 1 car lane, it is not touched (as before - see https://github.com/CitiesSkylinesMods/TMPE/issues/1106#issuecomment-998027126).

---

Test City: see https://github.com/CitiesSkylinesMods/TMPE/issues/1241#issuecomment-998067597
[TMPE.zip](https://ci.appveyor.com/api/projects/krzychu124/tmpe/artifacts/TMPE.zip?branch=1241-TTL-dedicated-lanes)