### PR TITLE
Static texture classes are now proper CustomManagers

### DIFF
--- a/TLM/TLM/Lifecycle/TMPELifecycle.cs
+++ b/TLM/TLM/Lifecycle/TMPELifecycle.cs
@@ -108,6 +108,7 @@ namespace TrafficManager.Lifecycle {
 
             // Texture managers
             RegisteredManagers.Add(RoadSignThemes.Instance);
+            RegisteredManagers.Add(JunctionRestrictions.Instance);
 
             // depends on TurnOnRedManager, TrafficLightManager, TrafficLightSimulationManager
             RegisteredManagers.Add(JunctionRestrictionsManager.Instance);

--- a/TLM/TLM/Lifecycle/TMPELifecycle.cs
+++ b/TLM/TLM/Lifecycle/TMPELifecycle.cs
@@ -17,6 +17,7 @@ namespace TrafficManager.Lifecycle {
     using UnityEngine.SceneManagement;
     using UnityEngine;
     using JetBrains.Annotations;
+    using TrafficManager.UI.Textures;
 
     /// <summary>
     /// Do not use Singleton<TMPELifecycle>.instance to prevent memory leak.
@@ -104,6 +105,9 @@ namespace TrafficManager.Lifecycle {
             RegisteredManagers.Add(UtilityManager.Instance);
             RegisteredManagers.Add(VehicleRestrictionsManager.Instance);
             RegisteredManagers.Add(ExtVehicleManager.Instance);
+
+            // Texture managers
+            RegisteredManagers.Add(RoadSignThemes.Instance);
 
             // depends on TurnOnRedManager, TrafficLightManager, TrafficLightSimulationManager
             RegisteredManagers.Add(JunctionRestrictionsManager.Instance);

--- a/TLM/TLM/Lifecycle/TMPELifecycle.cs
+++ b/TLM/TLM/Lifecycle/TMPELifecycle.cs
@@ -109,6 +109,7 @@ namespace TrafficManager.Lifecycle {
             RegisteredManagers.Add(UI.Textures.RoadSignThemes.Instance);
             RegisteredManagers.Add(UI.Textures.JunctionRestrictions.Instance);
             RegisteredManagers.Add(UI.Textures.RoadUI.Instance);
+            RegisteredManagers.Add(UI.Textures.TrafficLightTextures.Instance);
 
             // depends on TurnOnRedManager, TrafficLightManager, TrafficLightSimulationManager
             RegisteredManagers.Add(JunctionRestrictionsManager.Instance);
@@ -146,8 +147,9 @@ namespace TrafficManager.Lifecycle {
 
 #if DEBUG
                 const bool installHarmonyASAP = false; // set true for fast testing
-                if (installHarmonyASAP)
+                if (installHarmonyASAP) {
                     HarmonyHelper.DoOnHarmonyReady(Patcher.Install);
+                }
 #endif
             } catch (Exception ex) {
                 ex.LogException(true);

--- a/TLM/TLM/Lifecycle/TMPELifecycle.cs
+++ b/TLM/TLM/Lifecycle/TMPELifecycle.cs
@@ -17,7 +17,6 @@ namespace TrafficManager.Lifecycle {
     using UnityEngine.SceneManagement;
     using UnityEngine;
     using JetBrains.Annotations;
-    using TrafficManager.UI.Textures;
 
     /// <summary>
     /// Do not use Singleton<TMPELifecycle>.instance to prevent memory leak.
@@ -107,8 +106,9 @@ namespace TrafficManager.Lifecycle {
             RegisteredManagers.Add(ExtVehicleManager.Instance);
 
             // Texture managers
-            RegisteredManagers.Add(RoadSignThemes.Instance);
-            RegisteredManagers.Add(JunctionRestrictions.Instance);
+            RegisteredManagers.Add(UI.Textures.RoadSignThemes.Instance);
+            RegisteredManagers.Add(UI.Textures.JunctionRestrictions.Instance);
+            RegisteredManagers.Add(UI.Textures.RoadUI.Instance);
 
             // depends on TurnOnRedManager, TrafficLightManager, TrafficLightSimulationManager
             RegisteredManagers.Add(JunctionRestrictionsManager.Instance);

--- a/TLM/TLM/State/Options.cs
+++ b/TLM/TLM/State/Options.cs
@@ -134,7 +134,7 @@ namespace TrafficManager.State {
                     ModUI.Instance.MainMenuButton.UpdateButtonSkinAndTooltip();
                 }
 
-                RoadUI.ReloadTexturesWithTranslation();
+                RoadUI.Instance.ReloadTexturesWithTranslation();
                 TrafficLightTextures.ReloadTexturesWithTranslation();
                 TMPELifecycle.Instance.TranslationDatabase.ReloadTutorialTranslations();
                 TMPELifecycle.Instance.TranslationDatabase.ReloadGuideTranslations();

--- a/TLM/TLM/State/Options.cs
+++ b/TLM/TLM/State/Options.cs
@@ -135,7 +135,7 @@ namespace TrafficManager.State {
                 }
 
                 RoadUI.Instance.ReloadTexturesWithTranslation();
-                TrafficLightTextures.ReloadTexturesWithTranslation();
+                TrafficLightTextures.Instance.ReloadTexturesWithTranslation();
                 TMPELifecycle.Instance.TranslationDatabase.ReloadTutorialTranslations();
                 TMPELifecycle.Instance.TranslationDatabase.ReloadGuideTranslations();
             } else {

--- a/TLM/TLM/State/OptionsTabs/OptionsGeneralTab.cs
+++ b/TLM/TLM/State/OptionsTabs/OptionsGeneralTab.cs
@@ -1,5 +1,6 @@
 namespace TrafficManager.State {
     using System;
+    using System.Collections.Generic;
     using System.Linq;
     using TrafficManager.API.Traffic.Enums;
     using ColossalFramework.UI;
@@ -176,17 +177,18 @@ namespace TrafficManager.State {
                 return Translation.SpeedLimits.Get($"RoadSignTheme:{themeName}");
             }
 
-            var themeOptions = RoadSignThemes.ThemeNames
-                                                    .Select(FormatThemeName)
-                                                    .ToArray();
-            int selectedThemeIndex = RoadSignThemes.ThemeNames.FindIndex(x => x == mainConfig.RoadSignTheme);
-            int defaultSignsThemeIndex = RoadSignThemes.FindDefaultThemeIndex(GlobalConfig.Instance.Main.DisplaySpeedLimitsMph);
+            List<string> themeNames = RoadSignThemes.Instance.ThemeNames;
+            var themeOptions = themeNames.Select(FormatThemeName).ToArray();
+            int selectedThemeIndex = themeNames.FindIndex(x => x == mainConfig.RoadSignTheme);
+            int defaultSignsThemeIndex = RoadSignThemes.Instance.FindDefaultThemeIndex(GlobalConfig.Instance.Main.DisplaySpeedLimitsMph);
+
             _roadSignsThemeDropdown
                 = generalGroup.AddDropdown(
                       text: Translation.SpeedLimits.Get("General.Dropdown:Road signs theme") + ":",
                       options: themeOptions,
                       defaultSelection: selectedThemeIndex >= 0 ? selectedThemeIndex : defaultSignsThemeIndex,
                       eventCallback: OnRoadSignsThemeChanged) as UIDropDown;
+
             _roadSignsThemeDropdown.width *= 2.0f;
         }
 
@@ -346,8 +348,8 @@ namespace TrafficManager.State {
 
             if (!supportedByTheme) {
                 // Reset to German road signs theme
-                _roadSignsThemeDropdown.selectedIndex = RoadSignThemes.FindDefaultThemeIndex(newMphValue);
-                mainConfig.RoadSignTheme = RoadSignThemes.GetDefaultThemeName(newMphValue);
+                _roadSignsThemeDropdown.selectedIndex = RoadSignThemes.Instance.FindDefaultThemeIndex(newMphValue);
+                mainConfig.RoadSignTheme = RoadSignThemes.Instance.GetDefaultThemeName(newMphValue);
                 Log.Info(
                     $"Display MPH changed to {newMphValue}, but was not supported by current theme, "
                     + "so theme was also reset to German_Kmph");
@@ -375,10 +377,10 @@ namespace TrafficManager.State {
                 return;
             }
 
-            var newTheme = RoadSignThemes.ThemeNames[newThemeIndex];
+            var newTheme = RoadSignThemes.Instance.ThemeNames[newThemeIndex];
 
             Main mainConfig = GlobalConfig.Instance.Main;
-            switch (RoadSignThemes.ChangeTheme(
+            switch (RoadSignThemes.Instance.ChangeTheme(
                         newTheme: newTheme,
                         mphEnabled: mainConfig.DisplaySpeedLimitsMph)) {
                 case RoadSignThemes.ChangeThemeResult.Success:

--- a/TLM/TLM/UI/Helpers/TrafficRulesOverlay.cs
+++ b/TLM/TLM/UI/Helpers/TrafficRulesOverlay.cs
@@ -246,8 +246,8 @@ namespace TrafficManager.UI.Helpers {
                         camPos: ref camPos,
                         guiColor: guiColor,
                         signTexture: allowed
-                                         ? JunctionRestrictions.LaneChangeAllowed
-                                         : JunctionRestrictions.LaneChangeForbidden);
+                                         ? JunctionRestrictions.Instance.LaneChangeAllowed
+                                         : JunctionRestrictions.Instance.LaneChangeForbidden);
 
                     if (signHovered && this.handleClick_) {
                         isAnyHovered = true;
@@ -280,8 +280,8 @@ namespace TrafficManager.UI.Helpers {
                         camPos: ref camPos,
                         guiColor: guiColor,
                         signTexture: allowed
-                                         ? JunctionRestrictions.UturnAllowed
-                                         : JunctionRestrictions.UturnForbidden);
+                                         ? JunctionRestrictions.Instance.UturnAllowed
+                                         : JunctionRestrictions.Instance.UturnForbidden);
 
                     if (signHovered && this.handleClick_) {
                         isAnyHovered = true;
@@ -321,8 +321,8 @@ namespace TrafficManager.UI.Helpers {
                         camPos: ref camPos,
                         guiColor: guiColor,
                         signTexture: allowed
-                                         ? JunctionRestrictions.EnterBlockedJunctionAllowed
-                                         : JunctionRestrictions.EnterBlockedJunctionForbidden);
+                                         ? JunctionRestrictions.Instance.EnterBlockedJunctionAllowed
+                                         : JunctionRestrictions.Instance.EnterBlockedJunctionForbidden);
 
                     if (signHovered && this.handleClick_) {
                         isAnyHovered = true;
@@ -353,8 +353,8 @@ namespace TrafficManager.UI.Helpers {
                         camPos: ref camPos,
                         guiColor: guiColor,
                         signTexture: allowed
-                                         ? JunctionRestrictions.PedestrianCrossingAllowed
-                                         : JunctionRestrictions.PedestrianCrossingForbidden);
+                                         ? JunctionRestrictions.Instance.PedestrianCrossingAllowed
+                                         : JunctionRestrictions.Instance.PedestrianCrossingForbidden);
 
                     if (signHovered && this.handleClick_) {
                         isAnyHovered = true;
@@ -402,8 +402,8 @@ namespace TrafficManager.UI.Helpers {
                         camPos: ref camPos,
                         guiColor: guiColor,
                         signTexture: allowed
-                                         ? JunctionRestrictions.LeftOnRedAllowed
-                                         : JunctionRestrictions.LeftOnRedForbidden);
+                                         ? JunctionRestrictions.Instance.LeftOnRedAllowed
+                                         : JunctionRestrictions.Instance.LeftOnRedForbidden);
 
                     if (signHovered && this.handleClick_) {
                         isAnyHovered = true;
@@ -443,8 +443,8 @@ namespace TrafficManager.UI.Helpers {
                         camPos: ref camPos,
                         guiColor: guiColor,
                         signTexture: allowed
-                                         ? JunctionRestrictions.RightOnRedAllowed
-                                         : JunctionRestrictions.RightOnRedForbidden);
+                                         ? JunctionRestrictions.Instance.RightOnRedAllowed
+                                         : JunctionRestrictions.Instance.RightOnRedForbidden);
 
                     if (signHovered && this.handleClick_) {
                         isAnyHovered = true;

--- a/TLM/TLM/UI/ModUI.cs
+++ b/TLM/TLM/UI/ModUI.cs
@@ -237,7 +237,7 @@ namespace TrafficManager.UI {
 
             // Do not handle ChangeTheme result assuming that savegame always has the selected theme
             // and MPH display in a consistent state
-            RoadSignThemes.ChangeTheme(
+            RoadSignThemes.Instance.ChangeTheme(
                 newTheme: GlobalConfig.Instance.Main.RoadSignTheme,
                 mphEnabled: GlobalConfig.Instance.Main.DisplaySpeedLimitsMph);
         }

--- a/TLM/TLM/UI/SubTools/ManualTrafficLightsTool.cs
+++ b/TLM/TLM/UI/SubTools/ManualTrafficLightsTool.cs
@@ -75,6 +75,7 @@ namespace TrafficManager.UI.SubTools {
             ExtSegmentManager extSegmentManager = ExtSegmentManager.Instance;
             IExtSegmentEndManager segEndMan = Constants.ManagerFactory.ExtSegmentEndManager;
             var hoveredSegment = false;
+            var vehicleInfoSignTextures = RoadUI.Instance.VehicleInfoSignTextures;
 
             if (SelectedNodeId != 0) {
                 CustomSegmentLightsManager customTrafficLightsManager = CustomSegmentLightsManager.Instance;
@@ -245,7 +246,7 @@ namespace TrafficManager.UI.SubTools {
 
                                 GUI.DrawTexture(
                                     infoRect,
-                                    RoadUI.VehicleInfoSignTextures[TrafficManagerTool.InfoSignsToDisplay[k]]);
+                                    vehicleInfoSignTextures[TrafficManagerTool.InfoSignsToDisplay[k]]);
 
                                 ++numInfos;
                             }

--- a/TLM/TLM/UI/SubTools/ManualTrafficLightsTool.cs
+++ b/TLM/TLM/UI/SubTools/ManualTrafficLightsTool.cs
@@ -81,6 +81,7 @@ namespace TrafficManager.UI.SubTools {
                 CustomSegmentLightsManager customTrafficLightsManager = CustomSegmentLightsManager.Instance;
                 TrafficLightSimulationManager tlsMan = TrafficLightSimulationManager.Instance;
                 JunctionRestrictionsManager junctionRestrictionsManager = JunctionRestrictionsManager.Instance;
+                var textures = TrafficLightTextures.Instance;
 
                 if (!tlsMan.HasManualSimulation(SelectedNodeId)) {
                     return;
@@ -168,7 +169,7 @@ namespace TrafficManager.UI.SubTools {
                             case RoadBaseAI.TrafficLightState.Green: {
                                 GUI.DrawTexture(
                                     myRect3,
-                                    TrafficLightTextures.PedestrianGreenLight);
+                                    textures.PedestrianGreenLight);
                                 break;
                             }
 
@@ -176,7 +177,7 @@ namespace TrafficManager.UI.SubTools {
                             default: {
                                 GUI.DrawTexture(
                                     myRect3,
-                                    TrafficLightTextures.PedestrianRedLight);
+                                    textures.PedestrianRedLight);
                                 break;
                             }
                         }
@@ -205,7 +206,7 @@ namespace TrafficManager.UI.SubTools {
                             modeWidth,
                             modeHeight);
 
-                        GUI.DrawTexture(myRect1, TrafficLightTextures.LightMode);
+                        GUI.DrawTexture(myRect1, textures.LightMode);
 
                         hoveredSegment = GetHoveredSegment(
                             myRect1,
@@ -409,8 +410,8 @@ namespace TrafficManager.UI.SubTools {
             GUI.DrawTexture(
                 myRect2,
                 segmentLights.ManualPedestrianMode
-                    ? TrafficLightTextures.PedestrianModeManual
-                    : TrafficLightTextures.PedestrianModeAutomatic);
+                    ? TrafficLightTextures.Instance.PedestrianModeManual
+                    : TrafficLightTextures.Instance.PedestrianModeAutomatic);
 
             if (!myRect2.Contains(Event.current.mousePosition)) {
                 return hoveredSegment;
@@ -493,7 +494,7 @@ namespace TrafficManager.UI.SubTools {
                 modeWidth,
                 modeHeight);
 
-            GUI.DrawTexture(myRectCounter, TrafficLightTextures.LightCounter);
+            GUI.DrawTexture(myRectCounter, TrafficLightTextures.Instance.LightCounter);
 
             float counterSize = 20f * zoom;
 
@@ -539,12 +540,12 @@ namespace TrafficManager.UI.SubTools {
 
             switch (segmentDict.LightMain) {
                 case RoadBaseAI.TrafficLightState.Green: {
-                    GUI.DrawTexture(myRect4, TrafficLightTextures.GreenLight);
+                    GUI.DrawTexture(myRect4, TrafficLightTextures.Instance.GreenLight);
                     break;
                 }
 
                 case RoadBaseAI.TrafficLightState.Red: {
-                    GUI.DrawTexture(myRect4, TrafficLightTextures.RedLight);
+                    GUI.DrawTexture(myRect4, TrafficLightTextures.Instance.RedLight);
                     break;
                 }
             }
@@ -589,12 +590,12 @@ namespace TrafficManager.UI.SubTools {
 
                 switch (segmentDict.LightLeft) {
                     case RoadBaseAI.TrafficLightState.Green: {
-                        GUI.DrawTexture(myRect4, TrafficLightTextures.GreenLightLeft);
+                        GUI.DrawTexture(myRect4, TrafficLightTextures.Instance.GreenLightLeft);
                         break;
                     }
 
                     case RoadBaseAI.TrafficLightState.Red: {
-                        GUI.DrawTexture(myRect4, TrafficLightTextures.RedLightLeft);
+                        GUI.DrawTexture(myRect4, TrafficLightTextures.Instance.RedLightLeft);
                         break;
                     }
                 }
@@ -623,36 +624,36 @@ namespace TrafficManager.UI.SubTools {
             if (hasForwardSegment && hasRightSegment) {
                 switch (segmentDict.LightMain) {
                     case RoadBaseAI.TrafficLightState.Green: {
-                        GUI.DrawTexture(myRect5, TrafficLightTextures.GreenLightForwardRight);
+                        GUI.DrawTexture(myRect5, TrafficLightTextures.Instance.GreenLightForwardRight);
                         break;
                     }
 
                     case RoadBaseAI.TrafficLightState.Red: {
-                        GUI.DrawTexture(myRect5, TrafficLightTextures.RedLightForwardRight);
+                        GUI.DrawTexture(myRect5, TrafficLightTextures.Instance.RedLightForwardRight);
                         break;
                     }
                 }
             } else if (!hasRightSegment) {
                 switch (segmentDict.LightMain) {
                     case RoadBaseAI.TrafficLightState.Green: {
-                        GUI.DrawTexture(myRect5, TrafficLightTextures.GreenLightStraight);
+                        GUI.DrawTexture(myRect5, TrafficLightTextures.Instance.GreenLightStraight);
                         break;
                     }
 
                     case RoadBaseAI.TrafficLightState.Red: {
-                        GUI.DrawTexture(myRect5, TrafficLightTextures.RedLightStraight);
+                        GUI.DrawTexture(myRect5, TrafficLightTextures.Instance.RedLightStraight);
                         break;
                     }
                 }
             } else {
                 switch (segmentDict.LightMain) {
                     case RoadBaseAI.TrafficLightState.Green: {
-                        GUI.DrawTexture(myRect5, TrafficLightTextures.GreenLightRight);
+                        GUI.DrawTexture(myRect5, TrafficLightTextures.Instance.GreenLightRight);
                         break;
                     }
 
                     case RoadBaseAI.TrafficLightState.Red: {
-                        GUI.DrawTexture(myRect5, TrafficLightTextures.RedLightRight);
+                        GUI.DrawTexture(myRect5, TrafficLightTextures.Instance.RedLightRight);
                         break;
                     }
                 }
@@ -696,12 +697,12 @@ namespace TrafficManager.UI.SubTools {
             if (hasForwardSegment && hasLeftSegment) {
                 switch (segmentDict.LightLeft) {
                     case RoadBaseAI.TrafficLightState.Green: {
-                        GUI.DrawTexture(myRect4, TrafficLightTextures.GreenLightForwardLeft);
+                        GUI.DrawTexture(myRect4, TrafficLightTextures.Instance.GreenLightForwardLeft);
                         break;
                     }
 
                     case RoadBaseAI.TrafficLightState.Red: {
-                        GUI.DrawTexture(myRect4, TrafficLightTextures.RedLightForwardLeft);
+                        GUI.DrawTexture(myRect4, TrafficLightTextures.Instance.RedLightForwardLeft);
                         break;
                     }
                 }
@@ -716,12 +717,12 @@ namespace TrafficManager.UI.SubTools {
 
                 switch (segmentDict.LightMain) {
                     case RoadBaseAI.TrafficLightState.Green: {
-                        GUI.DrawTexture(myRect4, TrafficLightTextures.GreenLightStraight);
+                        GUI.DrawTexture(myRect4, TrafficLightTextures.Instance.GreenLightStraight);
                         break;
                     }
 
                     case RoadBaseAI.TrafficLightState.Red: {
-                        GUI.DrawTexture(myRect4, TrafficLightTextures.RedLightStraight);
+                        GUI.DrawTexture(myRect4, TrafficLightTextures.Instance.RedLightStraight);
                         break;
                     }
                 }
@@ -736,12 +737,12 @@ namespace TrafficManager.UI.SubTools {
 
                 switch (segmentDict.LightMain) {
                     case RoadBaseAI.TrafficLightState.Green: {
-                        GUI.DrawTexture(myRect4, TrafficLightTextures.GreenLightLeft);
+                        GUI.DrawTexture(myRect4, TrafficLightTextures.Instance.GreenLightLeft);
                         break;
                     }
 
                     case RoadBaseAI.TrafficLightState.Red: {
-                        GUI.DrawTexture(myRect4, TrafficLightTextures.RedLightLeft);
+                        GUI.DrawTexture(myRect4, TrafficLightTextures.Instance.RedLightLeft);
                         break;
                     }
                 }
@@ -776,12 +777,12 @@ namespace TrafficManager.UI.SubTools {
 
             switch (segmentDict.LightRight) {
                 case RoadBaseAI.TrafficLightState.Green: {
-                    GUI.DrawTexture(myRect5, TrafficLightTextures.GreenLightRight);
+                    GUI.DrawTexture(myRect5, TrafficLightTextures.Instance.GreenLightRight);
                     break;
                 }
 
                 case RoadBaseAI.TrafficLightState.Red: {
-                    GUI.DrawTexture(myRect5, TrafficLightTextures.RedLightRight);
+                    GUI.DrawTexture(myRect5, TrafficLightTextures.Instance.RedLightRight);
                     break;
                 }
             }
@@ -833,10 +834,10 @@ namespace TrafficManager.UI.SubTools {
 
             switch (segmentDict.LightLeft) {
                 case RoadBaseAI.TrafficLightState.Green:
-                    GUI.DrawTexture(myRect4, TrafficLightTextures.GreenLightLeft);
+                    GUI.DrawTexture(myRect4, TrafficLightTextures.Instance.GreenLightLeft);
                     break;
                 case RoadBaseAI.TrafficLightState.Red:
-                    GUI.DrawTexture(myRect4, TrafficLightTextures.RedLightLeft);
+                    GUI.DrawTexture(myRect4, TrafficLightTextures.Instance.RedLightLeft);
                     break;
             }
 
@@ -887,12 +888,12 @@ namespace TrafficManager.UI.SubTools {
 
             switch (segmentDict.LightMain) {
                 case RoadBaseAI.TrafficLightState.Green: {
-                    GUI.DrawTexture(myRect6, TrafficLightTextures.GreenLightStraight);
+                    GUI.DrawTexture(myRect6, TrafficLightTextures.Instance.GreenLightStraight);
                     break;
                 }
 
                 case RoadBaseAI.TrafficLightState.Red: {
-                    GUI.DrawTexture(myRect6, TrafficLightTextures.RedLightStraight);
+                    GUI.DrawTexture(myRect6, TrafficLightTextures.Instance.RedLightStraight);
                     break;
                 }
             }
@@ -932,12 +933,12 @@ namespace TrafficManager.UI.SubTools {
 
             switch (segmentDict.LightRight) {
                 case RoadBaseAI.TrafficLightState.Green: {
-                    GUI.DrawTexture(myRect5, TrafficLightTextures.GreenLightRight);
+                    GUI.DrawTexture(myRect5, TrafficLightTextures.Instance.GreenLightRight);
                     break;
                 }
 
                 case RoadBaseAI.TrafficLightState.Red: {
-                    GUI.DrawTexture(myRect5, TrafficLightTextures.RedLightRight);
+                    GUI.DrawTexture(myRect5, TrafficLightTextures.Instance.RedLightRight);
                     break;
                 }
             }

--- a/TLM/TLM/UI/SubTools/PrioritySigns/PrioritySignsTool.cs
+++ b/TLM/TLM/UI/SubTools/PrioritySigns/PrioritySignsTool.cs
@@ -402,7 +402,7 @@ namespace TrafficManager.UI.SubTools.PrioritySigns {
                     // draw remove button and handle click
                     if (showRemoveButton
                         && Highlight.DrawHoverableSquareOverlayTexture(
-                            texture: RoadUI.SignClear,
+                            texture: RoadUI.Instance.SignClear,
                             camPos: camPos,
                             worldPos: nodePos,
                             size: 90f)

--- a/TLM/TLM/UI/SubTools/SpeedLimits/Overlay/SignRenderer.cs
+++ b/TLM/TLM/UI/SubTools/SpeedLimits/Overlay/SignRenderer.cs
@@ -46,7 +46,7 @@
                                      RoadSignThemes.RoadSignTheme theme) {
             Texture2D tex = speedlimit.HasValue
                                 ? theme.GetTexture(speedlimit.Value)
-                                : RoadSignThemes.NoOverride;
+                                : RoadSignThemes.Instance.NoOverride;
 
             GUI.DrawTexture(
                 position: this.screenRect_,
@@ -63,7 +63,7 @@
                                                 RoadSignThemes.RoadSignTheme theme) {
             return speedlimit.HasValue
                        ? theme.GetTexture(speedlimit.Value)
-                       : RoadSignThemes.NoOverride;
+                       : RoadSignThemes.Instance.NoOverride;
         }
 
         /// <summary>Draws the small texture in the Bottom-Right corner.</summary>

--- a/TLM/TLM/UI/SubTools/SpeedLimits/Overlay/SpeedLimitsOverlay.cs
+++ b/TLM/TLM/UI/SubTools/SpeedLimits/Overlay/SpeedLimitsOverlay.cs
@@ -575,7 +575,7 @@
                 //-----------------------
                 // Draw small arrow down
                 //-----------------------
-                signRenderer.DrawSmallTexture_TopLeft(RoadUI.Underground);
+                signRenderer.DrawSmallTexture_TopLeft(RoadUI.Instance.Underground);
             }
 
             if (!isHoveredHandle) {
@@ -611,6 +611,7 @@
             [NotNull] DrawEnv drawEnv,
             [NotNull] DrawArgs args)
         {
+            var vehicleInfoSignTextures = RoadUI.Instance.VehicleInfoSignTextures;
             bool ret = false;
             ref NetSegment segment = ref segmentId.ToSegment();
 
@@ -750,8 +751,7 @@
                     && !onlyMonorailLanes
                     && ((laneInfo.m_vehicleType & VehicleInfo.VehicleType.Monorail) != VehicleInfo.VehicleType.None))
                 {
-                    Texture2D tex1 = RoadUI.VehicleInfoSignTextures[
-                        LegacyExtVehicleType.ToNew(old: ExtVehicleType.PassengerTrain)];
+                    Texture2D tex1 = vehicleInfoSignTextures[LegacyExtVehicleType.ToNew(old: ExtVehicleType.PassengerTrain)];
 
                     // TODO: Replace with direct call to GUI.DrawTexture as in the func above
                     grid.DrawStaticSquareOverlayGridTexture(
@@ -767,7 +767,7 @@
                     //-------------------------------------
                     // Draw arrow down
                     //-------------------------------------
-                    signRenderer.DrawSmallTexture_TopLeft(RoadUI.Underground);
+                    signRenderer.DrawSmallTexture_TopLeft(RoadUI.Instance.Underground);
                 }
 
                 if (isHoveredHandle) {

--- a/TLM/TLM/UI/SubTools/SpeedLimits/Overlay/SpeedLimitsOverlay.cs
+++ b/TLM/TLM/UI/SubTools/SpeedLimits/Overlay/SpeedLimitsOverlay.cs
@@ -355,7 +355,7 @@
                     // Defaults can show normal textures if the user holds Alt
                     SpeedlimitsToolMode.Defaults => args.ToolMode == SpeedlimitsToolMode.Defaults
                                                         ? RoadSignThemes.ActiveTheme
-                                                        : RoadSignThemes.RoadDefaults,
+                                                        : RoadSignThemes.Instance.RoadDefaults,
                     _ => throw new ArgumentOutOfRangeException(),
                 },
                 drawDefaults_ = args.ToolMode == SpeedlimitsToolMode.Defaults,
@@ -540,7 +540,7 @@
                     size: size * RoadSignThemes.DefaultSpeedlimitsAspectRatio());
                 squareSignRenderer.DrawLargeTexture(
                     speedlimit: defaultSpeedLimit,
-                    theme: RoadSignThemes.RoadDefaults);
+                    theme: RoadSignThemes.Instance.RoadDefaults);
             } else {
                 //-------------------------------------
                 // Draw override, if exists, otherwise draw circle and small blue default
@@ -561,7 +561,7 @@
                         size: size * RoadSignThemes.DefaultSpeedlimitsAspectRatio());
                     Texture2D chosenTexture = SignRenderer.ChooseTexture(
                         speedlimit: defaultSpeedLimit,
-                        theme: RoadSignThemes.RoadDefaults);
+                        theme: RoadSignThemes.Instance.RoadDefaults);
                     squareSignRenderer.DrawLargeTexture(chosenTexture);
                     // squareSignRenderer.DrawSmallTexture_BottomRight(chosenTexture);
                 } else {
@@ -734,7 +734,7 @@
                         size: size * RoadSignThemes.DefaultSpeedlimitsAspectRatio());
                     Texture2D chosenTexture = SignRenderer.ChooseTexture(
                         speedlimit: overrideSpeedlimit.DefaultValue,
-                        theme: RoadSignThemes.RoadDefaults);
+                        theme: RoadSignThemes.Instance.RoadDefaults);
                     squareSignRenderer.DrawLargeTexture(chosenTexture);
                     // squareSignRenderer.DrawSmallTexture_BottomRight(chosenTexture);
                 } else {

--- a/TLM/TLM/UI/SubTools/TimedTrafficLights/TimedTrafficLightsTool.cs
+++ b/TLM/TLM/UI/SubTools/TimedTrafficLights/TimedTrafficLightsTool.cs
@@ -1263,23 +1263,23 @@ namespace TrafficManager.UI.SubTools.TimedTrafficLights {
         private void DrawStraightLightTexture(RoadBaseAI.TrafficLightState state, Rect rect) {
             switch (state) {
                 case RoadBaseAI.TrafficLightState.Green: {
-                    GUI.DrawTexture(rect, TrafficLightTextures.GreenLightStraight);
+                    GUI.DrawTexture(rect, TrafficLightTextures.Instance.GreenLightStraight);
                     break;
                 }
 
                 case RoadBaseAI.TrafficLightState.GreenToRed: {
-                    GUI.DrawTexture(rect, TrafficLightTextures.YellowLight);
+                    GUI.DrawTexture(rect, TrafficLightTextures.Instance.YellowLight);
                     break;
                 }
 
                 // also: case RoadBaseAI.TrafficLightState.Red:
                 default: {
-                    GUI.DrawTexture(rect, TrafficLightTextures.RedLightStraight);
+                    GUI.DrawTexture(rect, TrafficLightTextures.Instance.RedLightStraight);
                     break;
                 }
 
                 case RoadBaseAI.TrafficLightState.RedToGreen: {
-                    GUI.DrawTexture(rect, TrafficLightTextures.YellowLightStraight);
+                    GUI.DrawTexture(rect, TrafficLightTextures.Instance.YellowLightStraight);
                     break;
                 }
             }
@@ -1288,23 +1288,23 @@ namespace TrafficManager.UI.SubTools.TimedTrafficLights {
         private void DrawForwardLeftLightTexture(RoadBaseAI.TrafficLightState state, Rect rect) {
             switch (state) {
                 case RoadBaseAI.TrafficLightState.Green: {
-                    GUI.DrawTexture(rect, TrafficLightTextures.GreenLightForwardLeft);
+                    GUI.DrawTexture(rect, TrafficLightTextures.Instance.GreenLightForwardLeft);
                     break;
                 }
 
                 case RoadBaseAI.TrafficLightState.GreenToRed: {
-                    GUI.DrawTexture(rect, TrafficLightTextures.YellowLight);
+                    GUI.DrawTexture(rect, TrafficLightTextures.Instance.YellowLight);
                     break;
                 }
 
                 // also: case RoadBaseAI.TrafficLightState.Red:
                 default: {
-                    GUI.DrawTexture(rect, TrafficLightTextures.RedLightForwardLeft);
+                    GUI.DrawTexture(rect, TrafficLightTextures.Instance.RedLightForwardLeft);
                     break;
                 }
 
                 case RoadBaseAI.TrafficLightState.RedToGreen: {
-                    GUI.DrawTexture(rect, TrafficLightTextures.YellowLightForwardLeft);
+                    GUI.DrawTexture(rect, TrafficLightTextures.Instance.YellowLightForwardLeft);
                     break;
                 }
             }
@@ -1313,23 +1313,23 @@ namespace TrafficManager.UI.SubTools.TimedTrafficLights {
         private void DrawForwardRightLightTexture(RoadBaseAI.TrafficLightState state, Rect rect) {
             switch (state) {
                 case RoadBaseAI.TrafficLightState.Green: {
-                    GUI.DrawTexture(rect, TrafficLightTextures.GreenLightForwardRight);
+                    GUI.DrawTexture(rect, TrafficLightTextures.Instance.GreenLightForwardRight);
                     break;
                 }
 
                 case RoadBaseAI.TrafficLightState.GreenToRed: {
-                    GUI.DrawTexture(rect, TrafficLightTextures.YellowLight);
+                    GUI.DrawTexture(rect, TrafficLightTextures.Instance.YellowLight);
                     break;
                 }
 
                 // also: case RoadBaseAI.TrafficLightState.Red:
                 default: {
-                    GUI.DrawTexture(rect, TrafficLightTextures.RedLightForwardRight);
+                    GUI.DrawTexture(rect, TrafficLightTextures.Instance.RedLightForwardRight);
                     break;
                 }
 
                 case RoadBaseAI.TrafficLightState.RedToGreen: {
-                    GUI.DrawTexture(rect, TrafficLightTextures.YellowLightForwardRight);
+                    GUI.DrawTexture(rect, TrafficLightTextures.Instance.YellowLightForwardRight);
                     break;
                 }
             }
@@ -1338,23 +1338,23 @@ namespace TrafficManager.UI.SubTools.TimedTrafficLights {
         private void DrawLeftLightTexture(RoadBaseAI.TrafficLightState state, Rect rect) {
             switch (state) {
                 case RoadBaseAI.TrafficLightState.Green: {
-                    GUI.DrawTexture(rect, TrafficLightTextures.GreenLightLeft);
+                    GUI.DrawTexture(rect, TrafficLightTextures.Instance.GreenLightLeft);
                     break;
                 }
 
                 case RoadBaseAI.TrafficLightState.GreenToRed: {
-                    GUI.DrawTexture(rect, TrafficLightTextures.YellowLight);
+                    GUI.DrawTexture(rect, TrafficLightTextures.Instance.YellowLight);
                     break;
                 }
 
                 // also: case RoadBaseAI.TrafficLightState.Red:
                 default: {
-                    GUI.DrawTexture(rect, TrafficLightTextures.RedLightLeft);
+                    GUI.DrawTexture(rect, TrafficLightTextures.Instance.RedLightLeft);
                     break;
                 }
 
                 case RoadBaseAI.TrafficLightState.RedToGreen: {
-                    GUI.DrawTexture(rect, TrafficLightTextures.YellowLightLeft);
+                    GUI.DrawTexture(rect, TrafficLightTextures.Instance.YellowLightLeft);
                     break;
                 }
             }
@@ -1363,23 +1363,23 @@ namespace TrafficManager.UI.SubTools.TimedTrafficLights {
         private void DrawRightLightTexture(RoadBaseAI.TrafficLightState state, Rect rect) {
             switch (state) {
                 case RoadBaseAI.TrafficLightState.Green: {
-                    GUI.DrawTexture(rect, TrafficLightTextures.GreenLightRight);
+                    GUI.DrawTexture(rect, TrafficLightTextures.Instance.GreenLightRight);
                     break;
                 }
 
                 case RoadBaseAI.TrafficLightState.GreenToRed: {
-                    GUI.DrawTexture(rect, TrafficLightTextures.YellowLight);
+                    GUI.DrawTexture(rect, TrafficLightTextures.Instance.YellowLight);
                     break;
                 }
 
                 // also: case RoadBaseAI.TrafficLightState.Red:
                 default: {
-                    GUI.DrawTexture(rect, TrafficLightTextures.RedLightRight);
+                    GUI.DrawTexture(rect, TrafficLightTextures.Instance.RedLightRight);
                     break;
                 }
 
                 case RoadBaseAI.TrafficLightState.RedToGreen: {
-                    GUI.DrawTexture(rect, TrafficLightTextures.YellowLightRight);
+                    GUI.DrawTexture(rect, TrafficLightTextures.Instance.YellowLightRight);
                     break;
                 }
             }
@@ -1388,23 +1388,23 @@ namespace TrafficManager.UI.SubTools.TimedTrafficLights {
         private void DrawMainLightTexture(RoadBaseAI.TrafficLightState state, Rect rect) {
             switch (state) {
                 case RoadBaseAI.TrafficLightState.Green: {
-                    GUI.DrawTexture(rect, TrafficLightTextures.GreenLight);
+                    GUI.DrawTexture(rect, TrafficLightTextures.Instance.GreenLight);
                     break;
                 }
 
                 case RoadBaseAI.TrafficLightState.GreenToRed: {
-                    GUI.DrawTexture(rect, TrafficLightTextures.YellowLight);
+                    GUI.DrawTexture(rect, TrafficLightTextures.Instance.YellowLight);
                     break;
                 }
 
                 // also: case RoadBaseAI.TrafficLightState.Red:
                 default: {
-                    GUI.DrawTexture(rect, TrafficLightTextures.RedLight);
+                    GUI.DrawTexture(rect, TrafficLightTextures.Instance.RedLight);
                     break;
                 }
 
                 case RoadBaseAI.TrafficLightState.RedToGreen: {
-                    GUI.DrawTexture(rect, TrafficLightTextures.YellowRedLight);
+                    GUI.DrawTexture(rect, TrafficLightTextures.Instance.YellowRedLight);
                     break;
                 }
             }
@@ -1440,9 +1440,9 @@ namespace TrafficManager.UI.SubTools.TimedTrafficLights {
 
                     Texture2D tex = timedNode.IsStarted()
                                         ? (timedNode.IsInTestMode()
-                                               ? TrafficLightTextures.ClockTest
-                                               : TrafficLightTextures.ClockPlay)
-                                        : TrafficLightTextures.ClockPause;
+                                               ? TrafficLightTextures.Instance.ClockTest
+                                               : TrafficLightTextures.Instance.ClockPlay)
+                                        : TrafficLightTextures.Instance.ClockPause;
                     Highlight.DrawGenericSquareOverlayTexture(
                         texture: tex,
                         camPos: camPos,
@@ -1568,8 +1568,8 @@ namespace TrafficManager.UI.SubTools.TimedTrafficLights {
                             GUI.DrawTexture(
                                 myRect2,
                                 liveSegmentLights.ManualPedestrianMode
-                                    ? TrafficLightTextures.PedestrianModeManual
-                                    : TrafficLightTextures.PedestrianModeAutomatic);
+                                    ? TrafficLightTextures.Instance.PedestrianModeManual
+                                    : TrafficLightTextures.Instance.PedestrianModeAutomatic);
 
                             if (myRect2.Contains(Event.current.mousePosition) &&
                                 !IsCursorInPanel()) {
@@ -1601,13 +1601,13 @@ namespace TrafficManager.UI.SubTools.TimedTrafficLights {
 
                         switch (liveSegmentLights.PedestrianLightState) {
                             case RoadBaseAI.TrafficLightState.Green: {
-                                GUI.DrawTexture(myRect3, TrafficLightTextures.PedestrianGreenLight);
+                                GUI.DrawTexture(myRect3, TrafficLightTextures.Instance.PedestrianGreenLight);
                                 break;
                             }
 
                             // also: case RoadBaseAI.TrafficLightState.Red:
                             default: {
-                                GUI.DrawTexture(myRect3, TrafficLightTextures.PedestrianRedLight);
+                                GUI.DrawTexture(myRect3, TrafficLightTextures.Instance.PedestrianRedLight);
                                 break;
                             }
                         }
@@ -1662,7 +1662,7 @@ namespace TrafficManager.UI.SubTools.TimedTrafficLights {
                                 modeWidth,
                                 modeHeight);
 
-                            GUI.DrawTexture(myRect1, TrafficLightTextures.LightMode);
+                            GUI.DrawTexture(myRect1, TrafficLightTextures.Instance.LightMode);
 
                             if (myRect1.Contains(Event.current.mousePosition) &&
                                 !IsCursorInPanel()) {

--- a/TLM/TLM/UI/SubTools/TimedTrafficLights/TimedTrafficLightsTool.cs
+++ b/TLM/TLM/UI/SubTools/TimedTrafficLights/TimedTrafficLightsTool.cs
@@ -1459,7 +1459,7 @@ namespace TrafficManager.UI.SubTools.TimedTrafficLights {
             JunctionRestrictionsManager junctionRestrictionsManager = JunctionRestrictionsManager.Instance;
             ExtSegmentManager extSegmentManager = ExtSegmentManager.Instance;
             IExtSegmentEndManager segEndMan = Constants.ManagerFactory.ExtSegmentEndManager;
-
+            var vehicleInfoSignTextures = RoadUI.Instance.VehicleInfoSignTextures;
             var hoveredSegment = false;
 
             foreach (ushort nodeId in selectedNodeIds) {
@@ -1703,8 +1703,7 @@ namespace TrafficManager.UI.SubTools.TimedTrafficLights {
                                 guiColor.a = TrafficManagerTool.GetHandleAlpha(false);
                                 GUI.DrawTexture(
                                     infoRect,
-                                    RoadUI.VehicleInfoSignTextures[
-                                        TrafficManagerTool.InfoSignsToDisplay[k]]);
+                                    vehicleInfoSignTextures[TrafficManagerTool.InfoSignsToDisplay[k]]);
                                 ++numInfos;
                             }
                         }

--- a/TLM/TLM/UI/SubTools/ToggleTrafficLightsTool.cs
+++ b/TLM/TLM/UI/SubTools/ToggleTrafficLightsTool.cs
@@ -90,6 +90,7 @@ namespace TrafficManager.UI.SubTools {
 
         public override void OnToolGUI(Event e) {
             Vector3 camPos = Singleton<SimulationManager>.instance.m_simulationView.m_position;
+            var textures = TrafficLightTextures.Instance;
 
             //--------------------------------
             // Render all visible node states
@@ -101,16 +102,16 @@ namespace TrafficManager.UI.SubTools {
                 // Check whether there is a traffic light and CAN be any at all
                 Texture2D overlayTex;
                 if (TrafficLightSimulationManager.Instance.HasTimedSimulation(nodeId)) {
-                    overlayTex = TrafficLightTextures.TrafficLightEnabledTimed;
+                    overlayTex = textures.TrafficLightEnabledTimed;
                 } else
                 if (TrafficLightManager.Instance.HasTrafficLight(
                     nodeId,
                     ref netNode)) {
                     // Render traffic light icon
-                    overlayTex = TrafficLightTextures.TrafficLightEnabled;
+                    overlayTex = textures.TrafficLightEnabled;
                 } else {
                     // Render traffic light possible but disabled icon
-                    overlayTex = TrafficLightTextures.TrafficLightDisabled;
+                    overlayTex = textures.TrafficLightDisabled;
                 }
 
                 Highlight.DrawGenericOverlayTexture(

--- a/TLM/TLM/UI/SubTools/VehicleRestrictionsTool.cs
+++ b/TLM/TLM/UI/SubTools/VehicleRestrictionsTool.cs
@@ -451,6 +451,7 @@ namespace TrafficManager.UI.SubTools {
                                                    bool viewOnly,
                                                    out bool stateUpdated) {
             stateUpdated = false;
+            var vehicleRestrictionTextures = RoadUI.Instance.VehicleRestrictionTextures;
 
             if (viewOnly && !Options.vehicleRestrictionsOverlay &&
                 MainTool.GetToolMode() != ToolMode.VehicleRestrictions) {
@@ -586,9 +587,8 @@ namespace TrafficManager.UI.SubTools {
                         continue; // do not draw allowed vehicles in view-only mode
                     }
 
-
                     bool hoveredHandle = gridRenderer.DrawGenericOverlayGridTexture(
-                        texture: RoadUI.VehicleRestrictionTextures[vehicleType][allowed],
+                        texture: vehicleRestrictionTextures[vehicleType][allowed],
                         camPos: camPos,
                         x: x,
                         y: y,

--- a/TLM/TLM/UI/Textures/JunctionRestrictions.cs
+++ b/TLM/TLM/UI/Textures/JunctionRestrictions.cs
@@ -1,4 +1,5 @@
 namespace TrafficManager.UI.Textures {
+    using TrafficManager.Manager;
     using TrafficManager.Util;
     using UnityEngine;
     using static TextureResources;
@@ -6,26 +7,29 @@ namespace TrafficManager.UI.Textures {
     /// <summary>
     /// Textures for UI controlling crossings, junctions and nodes
     /// </summary>
-    public static class JunctionRestrictions {
-        public static readonly Texture2D LaneChangeForbidden;
-        public static readonly Texture2D LaneChangeAllowed;
+    public class JunctionRestrictions : AbstractCustomManager {
+        public static JunctionRestrictions Instance = new();
 
-        public static readonly Texture2D UturnAllowed;
-        public static readonly Texture2D UturnForbidden;
+        public Texture2D LaneChangeForbidden;
+        public Texture2D LaneChangeAllowed;
 
-        public static readonly Texture2D RightOnRedForbidden;
-        public static readonly Texture2D RightOnRedAllowed;
+        public Texture2D UturnAllowed;
+        public Texture2D UturnForbidden;
 
-        public static readonly Texture2D LeftOnRedForbidden;
-        public static readonly Texture2D LeftOnRedAllowed;
+        public Texture2D RightOnRedForbidden;
+        public Texture2D RightOnRedAllowed;
 
-        public static readonly Texture2D EnterBlockedJunctionAllowed;
-        public static readonly Texture2D EnterBlockedJunctionForbidden;
+        public Texture2D LeftOnRedForbidden;
+        public Texture2D LeftOnRedAllowed;
 
-        public static readonly Texture2D PedestrianCrossingAllowed;
-        public static readonly Texture2D PedestrianCrossingForbidden;
+        public Texture2D EnterBlockedJunctionAllowed;
+        public Texture2D EnterBlockedJunctionForbidden;
 
-        static JunctionRestrictions() {
+        public Texture2D PedestrianCrossingAllowed;
+        public Texture2D PedestrianCrossingForbidden;
+
+        /// <summary>Called by the lifecycle when textures are to be loaded.</summary>
+        public override void OnLevelLoading() {
             IntVector2 size = new IntVector2(200);
 
             LaneChangeAllowed = LoadDllResource("JunctionRestrictions.lanechange_allowed.png", size);
@@ -44,6 +48,30 @@ namespace TrafficManager.UI.Textures {
 
             PedestrianCrossingAllowed = LoadDllResource("JunctionRestrictions.crossing_allowed.png", size);
             PedestrianCrossingForbidden = LoadDllResource("JunctionRestrictions.crossing_forbidden.png", size);
+
+            base.OnLevelLoading();
+        }
+
+        /// <summary>Called by the lifecycle when textures are to be unloaded.</summary>
+        public override void OnLevelUnloading() {
+            UnityEngine.Object.Destroy(LaneChangeAllowed);
+            UnityEngine.Object.Destroy(LaneChangeForbidden);
+
+            UnityEngine.Object.Destroy(UturnAllowed);
+            UnityEngine.Object.Destroy(UturnForbidden);
+
+            UnityEngine.Object.Destroy(RightOnRedAllowed);
+            UnityEngine.Object.Destroy(RightOnRedForbidden);
+            UnityEngine.Object.Destroy(LeftOnRedAllowed);
+            UnityEngine.Object.Destroy(LeftOnRedForbidden);
+
+            UnityEngine.Object.Destroy(EnterBlockedJunctionAllowed);
+            UnityEngine.Object.Destroy(EnterBlockedJunctionForbidden);
+
+            UnityEngine.Object.Destroy(PedestrianCrossingAllowed);
+            UnityEngine.Object.Destroy(PedestrianCrossingForbidden);
+
+            base.OnLevelUnloading();
         }
     }
 }

--- a/TLM/TLM/UI/Textures/RoadSignThemes.cs
+++ b/TLM/TLM/UI/Textures/RoadSignThemes.cs
@@ -13,6 +13,10 @@ namespace TrafficManager.UI.Textures {
     using TrafficManager.Util;
     using UnityEngine;
 
+    /// <summary>
+    /// Singleton which manages road signs themes dynamically loaded and freed as the user .
+    /// The textures are loaded when OnLevelLoaded event is fired from the <see cref="Lifecycle.TMPELifecycle"/>.
+    /// </summary>
     public class RoadSignThemes : AbstractCustomManager {
         public static RoadSignThemes Instance = new();
 

--- a/TLM/TLM/UI/Textures/RoadSignThemes.cs
+++ b/TLM/TLM/UI/Textures/RoadSignThemes.cs
@@ -30,13 +30,13 @@ namespace TrafficManager.UI.Textures {
 
             public Texture2D Priority(PriorityType p) => this.priority_.ContainsKey(p)
                                                              ? this.priority_[p]
-                                                             : RoadUI.PrioritySignTextures[p];
+                                                             : RoadUI.Instance.PrioritySignTextures[p];
 
             private Dictionary<bool, Texture2D> parking_ = new();
 
             public Texture2D Parking(bool p) => this.parking_.ContainsKey(p)
                                                     ? this.parking_[p]
-                                                    : RoadUI.ParkingRestrictionTextures[p];
+                                                    : RoadUI.Instance.ParkingRestrictionTextures[p];
 
             /// <summary>This list of required speed signs is used for loading.</summary>
             private List<int> SignValues = new();

--- a/TLM/TLM/UI/Textures/RoadSignThemes.cs
+++ b/TLM/TLM/UI/Textures/RoadSignThemes.cs
@@ -296,7 +296,6 @@ namespace TrafficManager.UI.Textures {
             return Themes[defaultTheme].Load();
         }
 
-        // TODO: Split loading here into dynamic sections, static enforces everything to stay in this ctor
         private RoadSignThemes() {
             RoadDefaults = new RoadSignTheme(
                 name: "Defaults",

--- a/TLM/TLM/UI/Textures/TrafficLightTextures.cs
+++ b/TLM/TLM/UI/Textures/TrafficLightTextures.cs
@@ -1,4 +1,5 @@
 namespace TrafficManager.UI.Textures {
+    using TrafficManager.Manager;
     using TrafficManager.Util;
     using UnityEngine;
     using static TextureResources;
@@ -6,50 +7,52 @@ namespace TrafficManager.UI.Textures {
     /// <summary>
     /// Textures for UI controlling the traffic lights
     /// </summary>
-    public static class TrafficLightTextures {
-        public static readonly Texture2D RedLight;
-        public static readonly Texture2D RedLightForwardLeft;
-        public static readonly Texture2D RedLightForwardRight;
-        public static readonly Texture2D RedLightLeft;
-        public static readonly Texture2D RedLightRight;
-        public static readonly Texture2D RedLightStraight;
-        public static readonly Texture2D PedestrianRedLight;
+    public class TrafficLightTextures : AbstractCustomManager {
+        public static TrafficLightTextures Instance = new();
 
-        public static readonly Texture2D YellowLight;
-        public static readonly Texture2D YellowLightForwardLeft;
-        public static readonly Texture2D YellowLightForwardRight;
-        public static readonly Texture2D YellowLightLeft;
-        public static readonly Texture2D YellowLightRight;
-        public static readonly Texture2D YellowLightStraight;
-        public static readonly Texture2D YellowRedLight;
+        public Texture2D RedLight;
+        public Texture2D RedLightForwardLeft;
+        public Texture2D RedLightForwardRight;
+        public Texture2D RedLightLeft;
+        public Texture2D RedLightRight;
+        public Texture2D RedLightStraight;
+        public Texture2D PedestrianRedLight;
 
-        public static readonly Texture2D GreenLight;
-        public static readonly Texture2D GreenLightForwardLeft;
-        public static readonly Texture2D GreenLightForwardRight;
-        public static readonly Texture2D GreenLightLeft;
-        public static readonly Texture2D GreenLightRight;
-        public static readonly Texture2D GreenLightStraight;
-        public static readonly Texture2D PedestrianGreenLight;
+        public Texture2D YellowLight;
+        public Texture2D YellowLightForwardLeft;
+        public Texture2D YellowLightForwardRight;
+        public Texture2D YellowLightLeft;
+        public Texture2D YellowLightRight;
+        public Texture2D YellowLightStraight;
+        public Texture2D YellowRedLight;
+
+        public Texture2D GreenLight;
+        public Texture2D GreenLightForwardLeft;
+        public Texture2D GreenLightForwardRight;
+        public Texture2D GreenLightLeft;
+        public Texture2D GreenLightRight;
+        public Texture2D GreenLightStraight;
+        public Texture2D PedestrianGreenLight;
 
         //--------------------------
         // Timed TL Editor
         //--------------------------
-        public static Texture2D LightMode;
-        public static Texture2D LightCounter;
-        public static readonly Texture2D ClockPlay;
-        public static readonly Texture2D ClockPause;
-        public static readonly Texture2D ClockTest;
-        public static Texture2D PedestrianModeAutomatic;
-        public static Texture2D PedestrianModeManual;
+        public Texture2D LightMode;
+        public Texture2D LightCounter;
+        public Texture2D ClockPlay;
+        public Texture2D ClockPause;
+        public Texture2D ClockTest;
+        public Texture2D PedestrianModeAutomatic;
+        public Texture2D PedestrianModeManual;
 
         //--------------------------
         // Toggle TL Tool
         //--------------------------
-        public static readonly Texture2D TrafficLightEnabled;
-        public static readonly Texture2D TrafficLightEnabledTimed;
-        public static readonly Texture2D TrafficLightDisabled;
+        public Texture2D TrafficLightEnabled;
+        public Texture2D TrafficLightEnabledTimed;
+        public Texture2D TrafficLightDisabled;
 
-        static TrafficLightTextures() {
+        public override void OnLevelLoading() {
             IntVector2 tlSize = new IntVector2(103, 243);
 
             RedLight = LoadDllResource("TrafficLights.light_1_1.png", tlSize);
@@ -108,9 +111,51 @@ namespace TrafficManager.UI.Textures {
             TrafficLightEnabled = LoadDllResource("TrafficLights.IconJunctionTrafficLights.png", toggleSize);
             TrafficLightEnabledTimed = LoadDllResource("TrafficLights.IconJunctionTimedTL.png", toggleSize);
             TrafficLightDisabled = LoadDllResource("TrafficLights.IconJunctionNoTrafficLights.png", toggleSize);
+
+            base.OnLevelLoading();
         }
 
-        public static void ReloadTexturesWithTranslation() {
+        public override void OnLevelUnloading() {
+            UnityEngine.Object.Destroy(RedLight);
+            UnityEngine.Object.Destroy(RedLightForwardLeft);
+            UnityEngine.Object.Destroy(RedLightForwardRight);
+            UnityEngine.Object.Destroy(RedLightLeft);
+            UnityEngine.Object.Destroy(RedLightRight);
+            UnityEngine.Object.Destroy(RedLightStraight);
+            UnityEngine.Object.Destroy(PedestrianRedLight);
+
+            UnityEngine.Object.Destroy(YellowLight);
+            UnityEngine.Object.Destroy(YellowLightForwardLeft);
+            UnityEngine.Object.Destroy(YellowLightForwardRight);
+            UnityEngine.Object.Destroy(YellowLightLeft);
+            UnityEngine.Object.Destroy(YellowLightRight);
+            UnityEngine.Object.Destroy(YellowLightStraight);
+            UnityEngine.Object.Destroy(YellowRedLight);
+
+            UnityEngine.Object.Destroy(GreenLight);
+            UnityEngine.Object.Destroy(GreenLightForwardLeft);
+            UnityEngine.Object.Destroy(GreenLightForwardRight);
+            UnityEngine.Object.Destroy(GreenLightLeft);
+            UnityEngine.Object.Destroy(GreenLightRight);
+            UnityEngine.Object.Destroy(GreenLightStraight);
+            UnityEngine.Object.Destroy(PedestrianGreenLight);
+
+            UnityEngine.Object.Destroy(LightMode);
+            UnityEngine.Object.Destroy(LightCounter);
+            UnityEngine.Object.Destroy(ClockPlay);
+            UnityEngine.Object.Destroy(ClockPause);
+            UnityEngine.Object.Destroy(ClockTest);
+            UnityEngine.Object.Destroy(PedestrianModeAutomatic);
+            UnityEngine.Object.Destroy(PedestrianModeManual);
+
+            UnityEngine.Object.Destroy(TrafficLightEnabled);
+            UnityEngine.Object.Destroy(TrafficLightEnabledTimed);
+            UnityEngine.Object.Destroy(TrafficLightDisabled);
+
+            base.OnLevelUnloading();
+        }
+
+        public void ReloadTexturesWithTranslation() {
             if (LightMode) UnityEngine.GameObject.Destroy(LightMode);
             if (LightCounter) UnityEngine.GameObject.Destroy(LightCounter);
             if (PedestrianModeAutomatic) UnityEngine.GameObject.Destroy(PedestrianModeAutomatic);
@@ -118,7 +163,7 @@ namespace TrafficManager.UI.Textures {
             LoadTexturesWithTranslation();
         }
 
-        private static void LoadTexturesWithTranslation() {
+        private void LoadTexturesWithTranslation() {
             // light mode
             IntVector2 tlModeSize = new IntVector2(103, 95);
 

--- a/TLM/TLM/UI/TrafficManagerTool.cs
+++ b/TLM/TLM/UI/TrafficManagerTool.cs
@@ -296,6 +296,7 @@ namespace TrafficManager.UI {
             }
 
             SetToolMode_DeactivateTool();
+
             // Try figure out whether legacy subtool or a new subtool is selected
             if (!legacySubTools_.TryGetValue(newToolMode, out activeLegacySubTool_)
                 && !subTools_.TryGetValue(newToolMode, out activeSubTool_)) {


### PR DESCRIPTION
* Texture classes are not static anymore
* On level loaded, all textures are loaded too
* On level unloaded, textures are freed

In debug build this creates visible delay. Should we show a progress indicator or some short-time notification to let the player know that we're loading?