### PR TITLE
versioned atlas

### DIFF
--- a/TLM/TLM/Lifecycle/TMPELifecycle.cs
+++ b/TLM/TLM/Lifecycle/TMPELifecycle.cs
@@ -208,6 +208,7 @@ namespace TrafficManager.Lifecycle {
 
                 ModUI.OnLevelLoaded();
                 if (PlayMode) {
+                    Log._Debug("PlayMode");
                     UIView uiView = UIView.GetAView();
                     uiView.AddUIComponent(typeof(UITransportDemand));
                     uiView.gameObject.AddComponent<RemoveVehicleButtonExtender>();

--- a/TLM/TLM/TLM.csproj
+++ b/TLM/TLM/TLM.csproj
@@ -146,6 +146,7 @@
     <Compile Include="Manager\Impl\ExtSegmentEndManager.cs" />
     <Compile Include="Manager\Impl\ExtSegmentManager.cs" />
     <Compile Include="Manager\Impl\GeometryNotifier.cs" />
+    <Compile Include="Util\Extensions\VersionExtension.cs" />
     <Compile Include="Util\Iterators\GetNodeSegmentIdsEnumerable.cs" />
     <Compile Include="Util\Iterators\GetNodeSegmentIdsEnumerator.cs" />
     <Compile Include="Util\Iterators\GetSegmentLaneIdsEnumerable.cs" />

--- a/TLM/TLM/U/AtlasBuilder.cs
+++ b/TLM/TLM/U/AtlasBuilder.cs
@@ -1,8 +1,9 @@
-﻿namespace TrafficManager.U {
+namespace TrafficManager.U {
     using System.Collections.Generic;
     using System.Linq;
     using ColossalFramework.UI;
     using TrafficManager.Util;
+    using TrafficManager.Util.Extensions;
 
     /// <summary>
     /// Populates a set of spritedefs as your UI form is populated with controls. Allows to use
@@ -49,21 +50,9 @@
         /// Longer list of atlas keys can be loaded into one atlas.</summary>
         /// <returns>New UI atlas.</returns>
         public UITextureAtlas CreateAtlas() {
-            string fullName = $"TMPE_U_{this.atlasName_}";
-            UITextureAtlas foundAtlas = TextureUtil.FindAtlas(fullName);
-
-            // If is NOT the same as UI default, means the atlas is already loaded (return cached)
-            if (!System.Object.ReferenceEquals(foundAtlas, UIView.GetAView().defaultAtlas)) {
-#if DEBUG
-                // In debug build rebuild atlas, this will be slower but allows the developer to see
-                // the updated GUI textures.
-                UnityEngine.Object.Destroy(foundAtlas);
-#else
-                return foundAtlas;
-#endif
-            }
-
-            return TextureUtil.CreateAtlas(
+            string fullName = $"TMPE_U_rev{this.VersionOf().Revision}_{this.atlasName_}";
+            return TextureUtil.FindAtlasOrNull(fullName) ??
+                TextureUtil.CreateAtlas(
                 atlasName: fullName,
                 resourcePrefix: this.loadingPath_,
                 spriteDefs: spriteDefs_.ToArray(),

--- a/TLM/TLM/U/Button/UButton.cs
+++ b/TLM/TLM/U/Button/UButton.cs
@@ -15,7 +15,7 @@ namespace TrafficManager.U {
         }
 
         private void SetupDefaultSprites() {
-            this.atlas = U.TextureUtil.FindAtlas("Ingame");
+            this.atlas = U.TextureUtil.Ingame;
             this.normalBgSprite = "ButtonMenu";
             this.hoveredBgSprite = "ButtonMenuHovered";
             this.pressedBgSprite = "ButtonMenuPressed";

--- a/TLM/TLM/U/TextureUtil.cs
+++ b/TLM/TLM/U/TextureUtil.cs
@@ -10,7 +10,8 @@ namespace TrafficManager.U {
     using TrafficManager.Util;
 
     public static class TextureUtil {
-        public static UITextureAtlas Ingame => FindAtlas("Ingame");
+        public static UITextureAtlas Ingame =>
+            FindAtlasOrNull("Ingame") ?? UIView.GetAView().defaultAtlas;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="UITextureAtlas"/> class from resource names list.
@@ -131,10 +132,6 @@ namespace TrafficManager.U {
             ret.Apply();
 
             return ret;
-        }
-
-        public static UITextureAtlas FindAtlas(string name) {
-            return FindAtlasOrNull(name) ?? UIView.GetAView().defaultAtlas;
         }
 
         public static UITextureAtlas FindAtlasOrNull(string name) {

--- a/TLM/TLM/U/TextureUtil.cs
+++ b/TLM/TLM/U/TextureUtil.cs
@@ -10,6 +10,8 @@ namespace TrafficManager.U {
     using TrafficManager.Util;
 
     public static class TextureUtil {
+        public static UITextureAtlas Ingame => FindAtlas("Ingame");
+
         /// <summary>
         /// Initializes a new instance of the <see cref="UITextureAtlas"/> class from resource names list.
         /// NOTE: For UI sprites loading use <see cref="U.AtlasBuilder"/> instead, do not call this.
@@ -132,15 +134,18 @@ namespace TrafficManager.U {
         }
 
         public static UITextureAtlas FindAtlas(string name) {
-            UITextureAtlas[] atlases =
-                Resources.FindObjectsOfTypeAll(typeof(UITextureAtlas)) as UITextureAtlas[];
+            return FindAtlasOrNull(name) ?? UIView.GetAView().defaultAtlas;
+        }
+
+        public static UITextureAtlas FindAtlasOrNull(string name) {
+            UITextureAtlas[] atlases = Resources.FindObjectsOfTypeAll<UITextureAtlas>();
             for (int i = 0; i < atlases.Length; i++) {
                 if (atlases[i].name == name) {
                     return atlases[i];
                 }
             }
 
-            return UIView.GetAView().defaultAtlas;
+            return null;
         }
     } // end class
 }

--- a/TLM/TLM/UI/MainMenu/MainMenuWindow.OsdPanel.cs
+++ b/TLM/TLM/UI/MainMenu/MainMenuWindow.OsdPanel.cs
@@ -1,4 +1,4 @@
-﻿namespace TrafficManager.UI.MainMenu {
+namespace TrafficManager.UI.MainMenu {
     using TrafficManager.State;
     using TrafficManager.U;
     using TrafficManager.U.Autosize;
@@ -10,7 +10,7 @@
                 this.name = "TMPE_MainMenu_KeybindsPanel";
 
                 // the GenericPanel sprite is Light Silver, make it dark
-                this.atlas = TextureUtil.FindAtlas("Ingame");
+                this.atlas = TextureUtil.Ingame;
                 this.backgroundSprite = "GenericPanel";
                 this.color = new Color32(64, 64, 64, 240);
                 this.opacity = GlobalConfig.Instance.Main.KeybindsPanelVisible

--- a/TLM/TLM/UI/MainMenu/MainMenuWindow.ToolPanel.cs
+++ b/TLM/TLM/UI/MainMenu/MainMenuWindow.ToolPanel.cs
@@ -1,4 +1,4 @@
-﻿namespace TrafficManager.UI.MainMenu {
+namespace TrafficManager.UI.MainMenu {
     using System.Collections.Generic;
     using System.Linq;
     using ColossalFramework.UI;
@@ -101,7 +101,7 @@
                 this.name = "TMPE_MainMenu_ExtraPanel";
 
                 // Silver background panel
-                this.atlas = TextureUtil.FindAtlas("Ingame");
+                this.atlas = TextureUtil.Ingame;
                 this.backgroundSprite = "GenericPanel";
 
                 // The panel will be Dark Silver at 50% dark 100% alpha

--- a/TLM/TLM/UI/RemoveCitizenInstanceButtonExtender.cs
+++ b/TLM/TLM/UI/RemoveCitizenInstanceButtonExtender.cs
@@ -46,6 +46,7 @@ namespace TrafficManager.UI {
 
             button.AlignTo(panel.component, UIAlignAnchor.TopRight);
             button.relativePosition += new Vector3(-button.width - 80f, 50f);
+            Log._Debug($"Added {button} to {panel}");
             return button;
         }
 

--- a/TLM/TLM/UI/RemoveVehicleButtonExtender.cs
+++ b/TLM/TLM/UI/RemoveVehicleButtonExtender.cs
@@ -108,11 +108,6 @@ namespace TrafficManager.UI {
             public override bool CanActivate() {
                 return false;
             }
-
-            protected override void OnVisibilityChanged() {
-                base.OnVisibilityChanged();
-                BringToFront();
-            }
         }
     }
 }

--- a/TLM/TLM/UI/RemoveVehicleButtonExtender.cs
+++ b/TLM/TLM/UI/RemoveVehicleButtonExtender.cs
@@ -11,6 +11,7 @@ namespace TrafficManager.UI {
         private IList<UIButton> buttons;
 
         public void Start() {
+            Log._Debug($"{GetType().Name} started.");
             buttons = new List<UIButton>();
 
             var citizenVehicleInfoPanel
@@ -55,6 +56,7 @@ namespace TrafficManager.UI {
             button.AlignTo(panel.component, UIAlignAnchor.TopRight);
             button.relativePosition += new Vector3(-button.width - 55f, 50f);
 
+            Log._Debug($"Added {button} to {panel}");
             return button;
         }
 
@@ -105,6 +107,11 @@ namespace TrafficManager.UI {
 
             public override bool CanActivate() {
                 return false;
+            }
+
+            protected override void OnVisibilityChanged() {
+                base.OnVisibilityChanged();
+                BringToFront();
             }
         }
     }

--- a/TLM/TLM/UI/SubTools/LaneArrows/LaneArrowToolWindow.cs
+++ b/TLM/TLM/UI/SubTools/LaneArrows/LaneArrowToolWindow.cs
@@ -106,7 +106,7 @@ namespace TrafficManager.UI.SubTools.LaneArrows {
                     parent: buttonRowPanel,
                     stack: i == 0 ? UStackMode.Below : UStackMode.ToTheRight);
                 buttonGroupPanel.name = buttonName;
-                buttonGroupPanel.atlas = TextureUtil.FindAtlas("Ingame");
+                buttonGroupPanel.atlas = TextureUtil.Ingame;
                 buttonGroupPanel.backgroundSprite = "GenericPanel";
 
                 int i1 = i; // copy of the loop variable, for the resizeFunction below

--- a/TLM/TLM/Util/Extensions/VersionExtension.cs
+++ b/TLM/TLM/Util/Extensions/VersionExtension.cs
@@ -1,0 +1,12 @@
+namespace TrafficManager.Util.Extensions {
+    using System;
+    using System.Reflection;
+
+    public static class VersionExtension {
+        internal static Version VersionOf(this Assembly asm) => asm.GetName().Version;
+
+        internal static Version VersionOf(this Type t) => t.Assembly.GetName().Version;
+
+        internal static Version VersionOf(this object obj) => VersionOf(obj.GetType());
+    }
+}


### PR DESCRIPTION
old code was trying to destroy old atlases to enable hot-reload.  but it had 2 problems:
- the logic of the code was such that if two buttons need the same atlas, the new button destroyed the atlas of the prev button (in debug builds only). as a result the remove vehicle button was not rendered.
- Also its not clear to me if destroying the atlas was enough because the textures are still in memory ... right? so there should still be memory leak.

changes:
- The new code adds version to atlas name and deals with the hot-reload issue that way.
- I also introduced `Ingame` property in TextureUtil to avoid type mistake when getting `Ingame` atlas.
- I didn't try to solve the memory leak issue because it could get complicated and should be topic of another PR.

[TMPE.zip](https://ci.appveyor.com/api/projects/krzychu124/tmpe/artifacts/TMPE.zip?branch=remove-car-button)