### PR TITLE
Slm data rework hotfix

### DIFF
--- a/TLM/TLM/Manager/Impl/SpeedLimitManager.cs
+++ b/TLM/TLM/Manager/Impl/SpeedLimitManager.cs
@@ -128,10 +128,6 @@ namespace TrafficManager.Manager.Impl {
             }
 
             NetInfo netinfo = netSegment.Info;
-            if(customNetinfoSpeedLimits_.TryGetValue(netinfo, out float customNetinfoSpeedLimit)) {
-                return new SpeedValue(customNetinfoSpeedLimit);
-            }
-
             uint curLaneId = netSegment.m_lanes;
             var laneIndex = 0;
             uint validLanes = 0;
@@ -155,7 +151,7 @@ namespace TrafficManager.Manager.Impl {
                     // custom speed limit
                     meanSpeedLimit += setSpeedLimit.Value;
                 } else {
-                    meanSpeedLimit += new SpeedValue(laneInfo.m_speedLimit);
+                    meanSpeedLimit += GetDefaultSpeedLimit(netinfo, laneInfo);
                 }
 
                 ++validLanes;

--- a/TLM/TLM/UI/SubTools/SpeedLimits/SpeedLimitsTool.cs
+++ b/TLM/TLM/UI/SubTools/SpeedLimits/SpeedLimitsTool.cs
@@ -259,22 +259,26 @@ namespace TrafficManager.UI.SubTools.SpeedLimits {
             this.overlayDrawArgs_.IsInteractive = interactive;
             this.overlayDrawArgs_.MultiSegmentMode = this.GetMultiSegmentMode();
 
-            var modeWithModifiers = this.speedlimitsToolMode_ switch {
-                SpeedlimitsToolMode.Segments => Shortcuts.AltIsPressed
-                                                    ? SpeedlimitsToolMode.Defaults
-                                                    : (Shortcuts.ControlIsPressed
-                                                           ? SpeedlimitsToolMode.Lanes
-                                                           : SpeedlimitsToolMode.Segments),
-                SpeedlimitsToolMode.Lanes => Shortcuts.AltIsPressed
-                                                 ? SpeedlimitsToolMode.Defaults
-                                                 : (Shortcuts.ControlIsPressed
-                                                        ? SpeedlimitsToolMode.Segments
-                                                        : SpeedlimitsToolMode.Lanes),
-                SpeedlimitsToolMode.Defaults => Shortcuts.AltIsPressed
-                                                    ? SpeedlimitsToolMode.Segments
-                                                    : SpeedlimitsToolMode.Defaults,
-                _ => throw new ArgumentOutOfRangeException()
-            };
+            var modeWithModifiers =
+                (interactive
+                     ? this.speedlimitsToolMode_
+                     : SpeedlimitsToolMode.Segments
+                    ) switch {
+                        SpeedlimitsToolMode.Segments => Shortcuts.AltIsPressed
+                                                            ? SpeedlimitsToolMode.Defaults
+                                                            : (Shortcuts.ControlIsPressed
+                                                                   ? SpeedlimitsToolMode.Lanes
+                                                                   : SpeedlimitsToolMode.Segments),
+                        SpeedlimitsToolMode.Lanes => Shortcuts.AltIsPressed
+                                                         ? SpeedlimitsToolMode.Defaults
+                                                         : (Shortcuts.ControlIsPressed
+                                                                ? SpeedlimitsToolMode.Segments
+                                                                : SpeedlimitsToolMode.Lanes),
+                        SpeedlimitsToolMode.Defaults => Shortcuts.AltIsPressed
+                                                            ? SpeedlimitsToolMode.Segments
+                                                            : SpeedlimitsToolMode.Defaults,
+                        _ => throw new ArgumentOutOfRangeException()
+                    };
             this.overlayDrawArgs_.ToolMode = modeWithModifiers;
         }
 


### PR DESCRIPTION
_Note it's a hotfix for #1277_ 

- fixed issue with incorrectly calculated averaged speed limit in `Segments` mode by reverting changes and adopting to renamed methods - issue affected only calculations for displaying overlay signs in `Segments` mode,
- improvement: forced `Segments` mode for non-interactive Speed Limits overlay (overlays tab), shortcut still works