### PR TITLE
Add 2 Traffic++ v2 mods to incompatible list

### DIFF
--- a/TLM/TLM/Resources/incompatible_mods.txt
+++ b/TLM/TLM/Resources/incompatible_mods.txt
@@ -51,3 +51,5 @@
 631930385;Realistic Vehicle Speeds
 1072157697;Cargo Info
 1558438291;Cities Multiplayer Mod (CSM) [Beta]
+2719881998;Traffic++ V2
+2719881745;Traffic++ V2


### PR DESCRIPTION
Looks like uploads of really old T++ mod; they probably crash the game as it doesn't look like they've been altered since the last version which was for CSL 1.6.