### PR TITLE
Reduce loading log spam from AssetDataExtension

### DIFF
--- a/TLM/TLM/Lifecycle/AssetDataExtension.cs
+++ b/TLM/TLM/Lifecycle/AssetDataExtension.cs
@@ -21,7 +21,7 @@ namespace TrafficManager.Lifecycle {
             OnAssetSavedImpl(name, asset, out userData);
 
         public static void OnAssetLoadedImpl(string name, object asset, Dictionary<string, byte[]> userData) {
-            Log.Info($"AssetDataExtension.OnAssetLoadedImpl({name}, {asset}, userData) called");
+            Log._Debug($"AssetDataExtension.OnAssetLoadedImpl({name}, {asset}, userData) called");
             if (asset is BuildingInfo prefab) {
                 Log._Debug("AssetDataExtension.OnAssetLoadedImpl():  prefab is " + prefab);
                 if (userData.TryGetValue(TMPE_RECORD_ID, out byte[] data)) {


### PR DESCRIPTION
Fixes: #1295

- `Log.Info()` -> `Log._Debug()`