### PR TITLE
`VersionUtil.cs` housekeeping

### DIFF
--- a/TLM/TLM/Lifecycle/TrafficManagerMod.cs
+++ b/TLM/TLM/Lifecycle/TrafficManagerMod.cs
@@ -2,11 +2,12 @@ namespace TrafficManager.Lifecycle {
     using ColossalFramework.Globalization;
     using ICities;
     using JetBrains.Annotations;
-    using System;
+    using System.Diagnostics.CodeAnalysis;
     using TrafficManager.State;
     using TrafficManager.UI;
     using TrafficManager.Util;
 
+    [SuppressMessage("StyleCop.CSharp.LayoutRules", "SA1502:Element should not be on a single line", Justification = "Reviewed.")]
     public class TrafficManagerMod : ILoadingExtension, IUserMod {
         public static string ModName => $"TM:PE {VersionUtil.VersionString} {VersionUtil.BRANCH.ToUpper()}";
 

--- a/TLM/TLM/Lifecycle/TrafficManagerMod.cs
+++ b/TLM/TLM/Lifecycle/TrafficManagerMod.cs
@@ -8,7 +8,7 @@ namespace TrafficManager.Lifecycle {
     using TrafficManager.Util;
 
     public class TrafficManagerMod : ILoadingExtension, IUserMod {
-        public static string ModName => $"TM:PE {VersionUtil.VersionString} {VersionUtil.BRANCH}";
+        public static string ModName => $"TM:PE {VersionUtil.VersionString} {VersionUtil.BRANCH.ToUpper()}";
 
         public string Name => ModName;
 

--- a/TLM/TLM/State/VersionInfo.cs
+++ b/TLM/TLM/State/VersionInfo.cs
@@ -26,9 +26,5 @@ namespace TrafficManager.State {
 
     }
 
-    public enum ReleaseType {
-        Test,
-        Debug,
-        Stable,
     }
 }

--- a/TLM/TLM/State/VersionInfo.cs
+++ b/TLM/TLM/State/VersionInfo.cs
@@ -10,13 +10,7 @@ namespace TrafficManager.State {
 
         public VersionInfo(Version assemblyVersion) {
             this.assemblyVersion = assemblyVersion;
-#if DEBUG
-            releaseType = ReleaseType.Debug;
-#elif TEST
-            releaseType = ReleaseType.Test;
-#else
-            releaseType = ReleaseType.Stable;
-#endif
+            releaseType = VersionUtil.BRANCH;
         }
 
     }

--- a/TLM/TLM/State/VersionInfo.cs
+++ b/TLM/TLM/State/VersionInfo.cs
@@ -4,11 +4,6 @@ namespace TrafficManager.State {
     using Util;
 
     [Serializable]
-    public class VersionInfoConfiguration {
-        public VersionInfo VersionInfo = new VersionInfo(VersionUtil.ModVersion);
-    }
-
-    [Serializable]
     public class VersionInfo {
         public Version assemblyVersion;
         public ReleaseType releaseType;
@@ -26,5 +21,8 @@ namespace TrafficManager.State {
 
     }
 
+    [Serializable]
+    public class VersionInfoConfiguration {
+        public VersionInfo VersionInfo = new VersionInfo(VersionUtil.ModVersion);
     }
 }

--- a/TLM/TLM/Util/ModsCompatibilityChecker.cs
+++ b/TLM/TLM/Util/ModsCompatibilityChecker.cs
@@ -64,7 +64,7 @@ namespace TrafficManager.Util {
         /// <exception cref="PathTooLongException">Path is too long (longer than the system-defined
         ///     maximum length).</exception>
         private Dictionary<PluginInfo, string> ScanForIncompatibleMods() {
-            Guid selfGuid = Assembly.GetExecutingAssembly().ManifestModule.ModuleVersionId;
+            var selfGuid = VersionUtil.TmpeGuid;
 
             // check known incompatible mods? (incompatible_mods.txt)
             bool checkKnown = GlobalConfig.Instance.Main.ScanForKnownIncompatibleModsAtStartup;

--- a/TLM/TLM/Util/VersionUtil.cs
+++ b/TLM/TLM/Util/VersionUtil.cs
@@ -178,8 +178,6 @@ namespace TrafficManager.Util {
 
         /// <summary>
         /// Checks to see if game version is what TMPE expects, and if not warns users.
-        ///
-        /// This will be replaced as part of #699.
         /// </summary>
         public static void CheckGameVersion() {
             if (CurrentGameVersionU != EXPECTED_GAME_VERSION_U) {

--- a/TLM/TLM/Util/VersionUtil.cs
+++ b/TLM/TLM/Util/VersionUtil.cs
@@ -19,13 +19,14 @@ namespace TrafficManager.Util {
     [SuppressMessage("Performance", "HAA0601:Value type to reference type conversion causing boxing allocation", Justification = "Not performance critical")]
     [SuppressMessage("Performance", "HAA0302:Display class allocation to capture closure", Justification = "Not performance critical")]
     public static class VersionUtil {
-        public const string BRANCH =
+
+        public const ReleaseType BRANCH =
 #if TEST
-            "TEST";
+            ReleaseType.Test;
 #elif DEBUG
-            "DEBUG";
+            ReleaseType.Debug;
 #else
-            "STABLE";
+            ReleaseType.Stable;
 #endif
 
         /// <summary>
@@ -66,9 +67,9 @@ namespace TrafficManager.Util {
         public static string VersionString => ModVersion.ToString(3);
 
         /// <summary>
-        /// Returns <c>true</c> if this is a STABLE/RELEASE build, otherwise <c>false</c>.
+        /// Returns <c>true</c> if <see cref="BRANCH"/> is <see cref="ReleaseType.Stable"/>, otherwise <c>false</c>.
         /// </summary>
-        public static bool IsStableRelease => BRANCH == "STABLE";
+        public static bool IsStableRelease => BRANCH == ReleaseType.Stable;
 
         /// <summary>
         /// take first n components of the version.

--- a/TLM/TLM/Util/VersionUtil.cs
+++ b/TLM/TLM/Util/VersionUtil.cs
@@ -72,10 +72,7 @@ namespace TrafficManager.Util {
         public static bool IsStableRelease => BRANCH == ReleaseType.Stable;
 
         /// <summary>
-        /// take first n components of the version.
         /// </summary>
-        static Version Take(this Version version, int n) {
-            return new Version(version.ToString(n));
         }
 
         /// <summary>
@@ -159,6 +156,16 @@ namespace TrafficManager.Util {
                     Shortcuts.ShowErrorDialog("Your game should be updated", msg);
                 }
             }
+        }
+
+        /// <summary>
+        /// Take the first <paramref name="n"/> components of a <see cref="Version"/> and use that to construct a new <see cref="Version"/>.
+        /// </summary>
+        /// <param name="version">The source version.</param>
+        /// <param name="n">The number of components to take.</param>
+        /// <returns>A new version based on the first <paramref name="n"/> components of <paramref name="version"/>.</returns>
+        private static Version Take(this Version version, int n) {
+            return new Version(version.ToString(n));
         }
     }
 }

--- a/TLM/TLM/Util/VersionUtil.cs
+++ b/TLM/TLM/Util/VersionUtil.cs
@@ -5,10 +5,24 @@ namespace TrafficManager.Util {
     using TrafficManager.Lifecycle;
     using System.Diagnostics.CodeAnalysis;
 
-    // Use `VersionUtil.BRANCH` to get release type of current build.
+    /// <summary>
+    /// The three main types of TM:PE build.
+    /// </summary>
+    /// <remarks>Use `VersionUtil.BRANCH` to get release type of current build.</remarks>
     public enum ReleaseType {
+        /// <summary>
+        /// A TEST build for release to the TEST workshop page.
+        /// </summary>
         Test,
+
+        /// <summary>
+        /// A DEBUG build during development cycle.
+        /// </summary>
         Debug,
+
+        /// <summary>
+        /// A STABLE build for release to the STABLE workshop page.
+        /// </summary>
         Stable,
     }
 
@@ -18,8 +32,13 @@ namespace TrafficManager.Util {
     [SuppressMessage("Performance", "HAA0101:Array allocation for params parameter", Justification = "Not performance critical")]
     [SuppressMessage("Performance", "HAA0601:Value type to reference type conversion causing boxing allocation", Justification = "Not performance critical")]
     [SuppressMessage("Performance", "HAA0302:Display class allocation to capture closure", Justification = "Not performance critical")]
+    [SuppressMessage("StyleCop.CSharp.NamingRules", "SA1310:Field names should not contain underscore", Justification = "Reviewed.")]
     public static class VersionUtil {
 
+        /// <summary>
+        /// Specifies the <see cref="ReleaseType"/> of the build.
+        /// </summary>
+        /// <remarks>Use <see cref="ToUpper(ReleaseType)"/> extension if you want uppercase string.</remarks>
         public const ReleaseType BRANCH =
 #if TEST
             ReleaseType.Test;
@@ -29,46 +48,74 @@ namespace TrafficManager.Util {
             ReleaseType.Stable;
 #endif
 
-        // we could alternatively use BuildConfig.APPLICATION_VERSION because const values are evaluated at compile time.
-        // but I have decided not to do this because I don't want this to happen automatically with a rebuild if
-        // CS updates. these values should be changed manaually so as to force us to acknowledge that they have changed.
+        /// <summary>
+        /// Specifies the <see cref="BuildConfig.APPLICATION_VERSION"/> this TM:PE build is designed for.
+        /// </summary>
+        /// <remarks>
+        /// We manually specify value here to force us to consider the need for updates when game version changes.
+        /// </remarks>
         public const uint EXPECTED_GAME_VERSION_U = 189262096U;
 
         /// <summary>
-        /// VersionB of the game changes with mod breaking game updates.
+        /// <see cref="BuildConfig.APPLICATION_VERSION_B"/> changes when there are likely to be severe
+        /// breaking changes for mods.
         /// </summary>
         private const int VERSION_COMPONENTS_COUNT = 2;
 
-        // see comments for EXPECTED_GAME_VERSION_U.
+        /// <summary>
+        /// Gets the manually defined <see cref="BuildConfig.APPLICATION_VERSION"/> this TM:PE build is designed for.
+        /// </summary>
+        /// <remarks>
+        /// We manually specify value here to force us to consider the need for updates when game version changes.
+        /// </remarks>
         public static Version ExpectedGameVersion => new Version(1, 13, 3, 9);
 
+        /// <summary>
+        /// Gets <see cref="EXPECTED_GAME_VERSION_U"/> as a human-friendly string.
+        /// </summary>
         public static string ExpectedGameVersionString => BuildConfig.VersionToString(EXPECTED_GAME_VERSION_U, false);
 
-        // we cannot use BuildConfig.APPLICATION_VERSION directly (it would not make sense).
-        // because BuildConfig.APPLICATION_VERSION is const and constants are resolved at compile-time.
-        // this is important when game version changes but TMPE dll is old. at such circumstance
-        // if we use BuildConfig.APPLICATION_VERSION then we will not notice that game version has changed.
-        // using reflection is a WORKAROUND to force the compiler to get value dynamically at run-time.
+        /// <summary>
+        /// Gets the game version at runtime.
+        /// </summary>
+        /// <remarks>
+        /// The game version is a <c>const</c> which is resolved at compile-time and thus won't indicate
+        /// actual running version of the game should it subsequently be updated. To workaround this, we
+        /// use reflection to get the game version at runtime.
+        /// </remarks>
         public static uint CurrentGameVersionU =>
             (uint)typeof(BuildConfig).GetField(nameof(BuildConfig.APPLICATION_VERSION)).GetValue(null);
 
-        // see comments CurrentGameVersionU.
+        /// <summary>
+        /// Gets the game version at runtime.
+        /// </summary>
+        /// <remarks>
+        /// The game version is a <c>const</c> which is resolved at compile-time and thus won't indicate
+        /// actual running version of the game should it subsequently be updated. To workaround this, we
+        /// use reflection to get the game version at runtime.
+        /// </remarks>
         public static Version CurrentGameVersion => new Version(
             (int)(uint)typeof(BuildConfig).GetField(nameof(BuildConfig.APPLICATION_VERSION_A)).GetValue(null),
             (int)(uint)typeof(BuildConfig).GetField(nameof(BuildConfig.APPLICATION_VERSION_B)).GetValue(null),
             (int)(uint)typeof(BuildConfig).GetField(nameof(BuildConfig.APPLICATION_VERSION_C)).GetValue(null),
             (int)(uint)typeof(BuildConfig).GetField(nameof(BuildConfig.APPLICATION_BUILD_NUMBER)).GetValue(null));
 
-        // Use SharedAssemblyInfo.cs to modify TM:PE version
-        // External mods (eg. CSUR Toolbox) reference the versioning for compatibility purposes
+        /// <summary>
+        /// Gets the compile-time version of this TM:PE build from <c>SharedAssemblyInfo.cs</c>.
+        /// </summary>
+        /// <remarks>
+        /// External mods (eg. CSUR Toolbox) reference this value for compatibility purposes.
+        /// </remarks>
         public static Version ModVersion => typeof(TrafficManagerMod).Assembly.GetName().Version;
 
         /// <summary>
-        /// Get the Guid of this currently running instance of TM:PE.
+        /// Gets the Guid of the active instance of TM:PE.
         /// </summary>
         public static Guid TmpeGuid => Assembly.GetExecutingAssembly().ManifestModule.ModuleVersionId;
 
-        // used for in-game display
+        /// <summary>
+        /// Gets the <see cref="ModVersion"/> as a <c>string</c>; used for in-game display (mod options, toolbar, etc).
+        /// </summary>
         public static string VersionString => ModVersion.ToString(3);
 
         /// <summary>

--- a/TLM/TLM/Util/VersionUtil.cs
+++ b/TLM/TLM/Util/VersionUtil.cs
@@ -29,15 +29,15 @@ namespace TrafficManager.Util {
             ReleaseType.Stable;
 #endif
 
-        /// <summary>
-        /// VersionB of the game changes with mod breaking game updates .
-        /// </summary>
-        private const int VERSION_COMPONENTS_COUNT = 2;
-
         // we could alternatively use BuildConfig.APPLICATION_VERSION because const values are evaluated at compile time.
         // but I have decided not to do this because I don't want this to happen automatically with a rebuild if
         // CS updates. these values should be changed manaually so as to force us to acknowledge that they have changed.
         public const uint EXPECTED_GAME_VERSION_U = 189262096U;
+
+        /// <summary>
+        /// VersionB of the game changes with mod breaking game updates.
+        /// </summary>
+        private const int VERSION_COMPONENTS_COUNT = 2;
 
         // see comments for EXPECTED_GAME_VERSION_U.
         public static Version ExpectedGameVersion => new Version(1, 13, 3, 9);

--- a/TLM/TLM/Util/VersionUtil.cs
+++ b/TLM/TLM/Util/VersionUtil.cs
@@ -72,7 +72,12 @@ namespace TrafficManager.Util {
         public static bool IsStableRelease => BRANCH == ReleaseType.Stable;
 
         /// <summary>
+        /// Converts a <see cref="ReleaseType"/> to uppercase string.
         /// </summary>
+        /// <param name="value">The value to convert.</param>
+        /// <returns>Uppercase string representation of the <paramref name="value"/>.</returns>
+        public static string ToUpper(this ReleaseType value) {
+            return value.ToString().ToUpper();
         }
 
         /// <summary>

--- a/TLM/TLM/Util/VersionUtil.cs
+++ b/TLM/TLM/Util/VersionUtil.cs
@@ -63,6 +63,11 @@ namespace TrafficManager.Util {
         // External mods (eg. CSUR Toolbox) reference the versioning for compatibility purposes
         public static Version ModVersion => typeof(TrafficManagerMod).Assembly.GetName().Version;
 
+        /// <summary>
+        /// Get the Guid of this currently running instance of TM:PE.
+        /// </summary>
+        public static Guid TmpeGuid => Assembly.GetExecutingAssembly().ManifestModule.ModuleVersionId;
+
         // used for in-game display
         public static string VersionString => ModVersion.ToString(3);
 
@@ -105,9 +110,7 @@ namespace TrafficManager.Util {
         /// Log TMPE Guid.
         /// </summary>
         public static void LogTmpeGuid() {
-            Log.InfoFormat(
-                "Enabled TM:PE has GUID {0}",
-                Assembly.GetExecutingAssembly().ManifestModule.ModuleVersionId);
+            Log.InfoFormat("Enabled TM:PE has GUID {0}", TmpeGuid);
         }
 
         /// <summary>

--- a/TLM/TLM/Util/VersionUtil.cs
+++ b/TLM/TLM/Util/VersionUtil.cs
@@ -5,6 +5,13 @@ namespace TrafficManager.Util {
     using TrafficManager.Lifecycle;
     using System.Diagnostics.CodeAnalysis;
 
+    // Use `VersionUtil.BRANCH` to get release type of current build.
+    public enum ReleaseType {
+        Test,
+        Debug,
+        Stable,
+    }
+
     /// <summary>
     /// Much of this stuff will be replaced as part of PR #699.
     /// </summary>


### PR DESCRIPTION
- Move `ReleaseType` enum from `VersionInfo.cs` to `VersionUtil.cs`
- Update `BRANCH` from `string` to `ReleaseType`
- `VersionInfo.cs` can now reference `VersionUtil.BRANCH` to get current build release type
- Add `ToUpper()` extension for `ReleaseType` -> get uppercase string for in-game display
- Add `TmpeGuid` getter to de-bloat two places its used
- Deal with some (but not all) minor code analysis warnings
- Update xmldoc for `VersionUtil.cs`

Probably best to review per commit rather than entire PR.