### PR TITLE
Fix game version warning

### DIFF
--- a/TLM/TLM/Lifecycle/TMPELifecycle.cs
+++ b/TLM/TLM/Lifecycle/TMPELifecycle.cs
@@ -72,10 +72,25 @@ namespace TrafficManager.Lifecycle {
             }
         }
 
+        /// <summary>
+        /// Inhibits the "Resume" (auto-load last city on launch) feature of
+        /// the Paradox Launcher (and associated app launch option).
+        /// </summary>
+        public static void HaltLauncherAutoContinue() {
+            Log.Info("Halting game 'Resume' feature due to incompatibility issue.");
+            LauncherLoginData.instance.m_continue = false;
+        }
+
         private static void CompatibilityCheck() {
+            bool problems = false;
+
             ModsCompatibilityChecker mcc = new ModsCompatibilityChecker();
-            mcc.PerformModCheck();
-            VersionUtil.CheckGameVersion();
+            problems |= mcc.PerformModCheck();
+            problems |= VersionUtil.CheckGameVersion();
+
+            if (problems) {
+                HaltLauncherAutoContinue();
+            }
         }
 
         internal void Preload() {

--- a/TLM/TLM/Util/ModsCompatibilityChecker.cs
+++ b/TLM/TLM/Util/ModsCompatibilityChecker.cs
@@ -32,9 +32,11 @@ namespace TrafficManager.Util {
         }
 
         /// <summary>
-        /// Initiates scan for incompatible mods. If any found, and the user has enabled the mod checker, it creates and initialises the modal dialog panel.
+        /// Initiates scan for incompatible mods. If any found, and the user has enabled the mod checker,
+        /// it creates and initialises the modal dialog panel.
         /// </summary>
-        public void PerformModCheck() {
+        /// <returns>Returns <c>false</c> if incompatible mods found (ie. mcc dialog shown).</returns>
+        public bool PerformModCheck() {
             try {
                 Dictionary<PluginInfo, string> detected = ScanForIncompatibleMods();
 
@@ -46,6 +48,7 @@ namespace TrafficManager.Util {
                     panel.Initialize();
                     UIView.PushModal(panel);
                     UIView.SetFocus(panel);
+                    return false;
                 }
             }
             catch (Exception e) {
@@ -53,6 +56,7 @@ namespace TrafficManager.Util {
                     "Something went wrong while checking incompatible mods - see main game log for details.");
                 Debug.LogException(e);
             }
+            return true;
         }
 
         /// <summary>

--- a/TLM/TLM/Util/VersionUtil.cs
+++ b/TLM/TLM/Util/VersionUtil.cs
@@ -29,10 +29,10 @@ namespace TrafficManager.Util {
         // we could alternatively use BuildConfig.APPLICATION_VERSION because const values are evaluated at compile time.
         // but I have decided not to do this because I don't want this to happen automatically with a rebuild if
         // CS updates. these values should be changed manaually so as to force us to acknowledge that they have changed.
-        public const uint EXPECTED_GAME_VERSION_U = 189262096U;
+        public const uint EXPECTED_GAME_VERSION_U = 193061904u;
 
         // see comments for EXPECTED_GAME_VERSION_U.
-        public static Version ExpectedGameVersion => new Version(1, 13, 3, 9);
+        public static Version ExpectedGameVersion => new Version(1, 14, 0, 4);
 
         public static string ExpectedGameVersionString => BuildConfig.VersionToString(EXPECTED_GAME_VERSION_U, false);
 
@@ -128,27 +128,24 @@ namespace TrafficManager.Util {
                 Version current = CurrentGameVersion.Take(VERSION_COMPONENTS_COUNT);
                 Version expected = ExpectedGameVersion.Take(VERSION_COMPONENTS_COUNT);
 
-                if (current < expected) {
-                    // game too old
+                if (current != expected) {
                     string msg = string.Format(
-                        "Traffic Manager: President Edition detected that you are running " +
-                        "a newer game version ({0}) than TM:PE has been built for ({1}). " +
-                        "Please be aware that TM:PE has not been updated for the newest game " +
-                        "version yet and thus it is very likely it will not work as expected.",
-                        BuildConfig.applicationVersion,
-                        ExpectedGameVersionString);
-                    Log.Error(msg);
-                    Shortcuts.ShowErrorDialog("TM:PE has not been updated yet", msg);
-                } else if (current > expected) {
-                    // TMPE too old
-                    string msg = string.Format(
-                        "Traffic Manager: President Edition has been built for game version {0}. " +
-                        "You are running game version {1}. Some features of TM:PE will not " +
-                        "work with older game versions. Please let Steam update your game.",
+                        "{0} is designed for Cities: Skylines {1}. However you are using Cities: " +
+                        "Skylines {2} - this is likely to cause severe problems or crashes." +
+                        "\n\n" +
+                        "Please ensure you're using the right version of TM:PE for this version of " +
+                        "Cities: Skylines before proceeding, or disable TM:PE until the problem is " +
+                        "resolved. If you need help, contact us via Steam Workshop page or Discord chat.",
+                        TrafficManagerMod.ModName,
                         ExpectedGameVersionString,
                         BuildConfig.applicationVersion);
                     Log.Error(msg);
-                    Shortcuts.ShowErrorDialog("Your game should be updated", msg);
+
+                    Shortcuts.ShowErrorDialog(
+                        current > expected
+                            ? "TM:PE needs updating!"
+                            : "Cities: Skylines needs updating!",
+                        msg);
                 }
             }
         }

--- a/TLM/TLM/Util/VersionUtil.cs
+++ b/TLM/TLM/Util/VersionUtil.cs
@@ -116,12 +116,9 @@ namespace TrafficManager.Util {
             }
         }
 
-        /// <summary>
-        /// Checks to see if game version is what TMPE expects, and if not warns users.
-        ///
-        /// This will be replaced as part of #699.
-        /// </summary>
-        public static void CheckGameVersion() {
+        /// <summary>Checks to see if game version is what TMPE expects, and if not warns users.</summary>
+        /// <returns>Returns <c>false</c> if there is a game/mod version problem.</returns>
+        public static bool CheckGameVersion() {
             if (CurrentGameVersionU != EXPECTED_GAME_VERSION_U) {
                 Log.Info($"Detected game version v{BuildConfig.applicationVersion}. TMPE built for {ExpectedGameVersionString}");
                 Log._Debug($"CurrentGameVersion={CurrentGameVersion} ExpectedGameVersion={ExpectedGameVersion}");
@@ -146,8 +143,11 @@ namespace TrafficManager.Util {
                             ? "TM:PE needs updating!"
                             : "Cities: Skylines needs updating!",
                         msg);
+
+                    return false;
                 }
             }
+            return true;
         }
     }
 }


### PR DESCRIPTION
Fixes #1309
Fixes #697

Game version warning message was "inverted" (eg. if game too old it was saying TM:PE too old, and vice versa).

New message looks like this - title changes depending on what is too old, but message stays same.

![image](https://user-images.githubusercontent.com/1386719/150895108-773da89b-eaf8-4424-941c-c669d291062c.png)

Additionally the auto-resume feature added by Paradox Launcher will be cancelled if compatibility issues (either game version or mod compatibility checker) are found.
