### PR TITLE
`Log.Note()` - midway beween `Log.Info()` and `Log.Warning()`

### DIFF
--- a/TLM/CSUtil.Commons/Log.cs
+++ b/TLM/CSUtil.Commons/Log.cs
@@ -126,8 +126,17 @@ namespace CSUtil.Commons {
             LogToFile(string.Format(format, args), LogLevel.Info);
         }
 
+        /// <summary>
+        /// Get's a minified stack trace, optionally prepended by a string.
+        /// </summary>
+        /// <param name="prepend">Prepend the result with this string (skipped if <c>null</c> or empty)</param>
+        /// <param name="trunc">Truncate the stack trace to this many lines.</param>
+        /// <param name="chop">Chop this many lines from start of stack trace.</param>
+        /// <remarks>
+        /// For full stack trace, use <see cref="Log.Warning(string)"/>
+        /// or <see cref="Log.Error(string)"/> instead.
         [MethodImpl(MethodImplOptions.NoInlining)]
-        public static List<string> MiniStackTrace(string prependStr, int maxLen = 3) {
+        public static List<string> MiniStackTrace(string prepend, int trunc = 3, int chop = 2) {
             var stack = new StackTrace(true);
             var list = new List<string>(
                 stack.ToString().Split(new string[] { "\r\n" },
@@ -136,12 +145,12 @@ namespace CSUtil.Commons {
             list.RemoveRange(0, 2); // trim this method & caller
 
             int len = list.Count;
-            if (len > maxLen) {
-                list.RemoveRange(maxLen, len - maxLen);
+            if (len > trunc) {
+                list.RemoveRange(trunc, len - trunc);
             }
 
-            if (!string.IsNullOrEmpty(prependStr)) {
-                list.Insert(0, prependStr);
+            if (!string.IsNullOrEmpty(prepend)) {
+                list.Insert(0, prepend);
             }
 
             return list;
@@ -151,13 +160,15 @@ namespace CSUtil.Commons {
         /// Log a string and include a minified stack trace (3 methods).
         /// </summary>
         /// <param name="s">The text</param>
+        /// <param name="trunc">Truncate the stack trace to this many lines.</param>
+        /// <param name="chop">Chop this many lines from start of stack trace.</param>
         /// <remarks>
         /// For full stack trace, use <see cref="Log.Warning(string)"/>
         /// or <see cref="Log.Error(string)"/> instead.
         /// </remarks>
         [MethodImpl(MethodImplOptions.NoInlining)]
-        public static void Note(string s) {
-            string str = MiniStackTrace(s).ToString();
+        public static void Note(string s, int trunc = 3, int chop = 2) {
+            string str = MiniStackTrace(s, trunc, chop).ToString();
             LogToFile(str, LogLevel.Note);
         }
 

--- a/TLM/CSUtil.Commons/Log.cs
+++ b/TLM/CSUtil.Commons/Log.cs
@@ -130,19 +130,22 @@ namespace CSUtil.Commons {
         /// Get's a minified stack trace, optionally prepended by a string.
         /// </summary>
         /// <param name="prepend">Prepend the result with this string (skipped if <c>null</c> or empty)</param>
-        /// <param name="trunc">Truncate the stack trace to this many lines.</param>
-        /// <param name="chop">Chop this many lines from start of stack trace.</param>
+        /// <param name="skip">Skip this many lines from start of stack trace.</param>
+        /// <param name="trunc">Truncate remaining stack trace to this many lines.</param>
         /// <remarks>
-        /// For full stack trace, use <see cref="Log.Warning(string)"/>
-        /// or <see cref="Log.Error(string)"/> instead.
+        /// Skips first <paramref name="skip"/> stack items,
+        /// then truncates to <paramref name="trunc"/> total stack items,
+        /// then, if applicable, prepends <paramref name="s"/>.
+        /// </remarks>
         [MethodImpl(MethodImplOptions.NoInlining)]
-        public static List<string> MiniStackTrace(string prepend, int trunc = 3, int chop = 2) {
+        public static List<string> MiniStackTrace(string prepend, int skip = 2, int trunc = 3) {
             var stack = new StackTrace(true);
+
             var list = new List<string>(
                 stack.ToString().Split(new string[] { "\r\n" },
                 StringSplitOptions.RemoveEmptyEntries));
 
-            list.RemoveRange(0, 2); // trim this method & caller
+            list.RemoveRange(0, skip);
 
             int len = list.Count;
             if (len > trunc) {
@@ -160,22 +163,20 @@ namespace CSUtil.Commons {
         /// Log a string and include a minified stack trace (3 methods).
         /// </summary>
         /// <param name="s">The text</param>
-        /// <param name="trunc">Truncate the stack trace to this many lines.</param>
-        /// <param name="chop">Chop this many lines from start of stack trace.</param>
-        /// <remarks>
-        /// For full stack trace, use <see cref="Log.Warning(string)"/>
-        /// or <see cref="Log.Error(string)"/> instead.
-        /// </remarks>
+        /// <param name="skip">Skip this many lines from start of stack trace.</param>
+        /// <param name="trunc">Truncate remaining stack trace to this many lines.</param>
         [MethodImpl(MethodImplOptions.NoInlining)]
-        public static void Note(string s, int trunc = 3, int chop = 2) {
-            string str = MiniStackTrace(s, trunc, chop).ToString();
-            LogToFile(str, LogLevel.Note);
+        public static void Note(string s, int skip = 2, int trunc = 3) {
+            LogToFile(
+                $"{string.Join("\n", MiniStackTrace(s, skip, trunc).ToArray())}",
+                LogLevel.Note);
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
         public static void NoteFormat(string format, params object[] args) {
-            string str = MiniStackTrace(string.Format(format, args)).ToString();
-            LogToFile(str, LogLevel.Note);
+            LogToFile(
+                $"{string.Join("\n", MiniStackTrace(string.Format(format, args)).ToArray())}",
+                LogLevel.Note);
         }
 
         /// <summary>

--- a/TLM/TLM/UI/Localization/Translation.cs
+++ b/TLM/TLM/UI/Localization/Translation.cs
@@ -190,7 +190,7 @@ namespace TrafficManager.UI {
             }
 
             if (!DEFAULT_LANGUAGE_CODE.Equals(language)) {
-                Log.Note($"Translated file {translatedFilename} not found!");
+                Log.Note($"Translated file {translatedFilename} not found!", 4, 1);
             }
 
             return filename;

--- a/TLM/TLM/UI/Localization/Translation.cs
+++ b/TLM/TLM/UI/Localization/Translation.cs
@@ -190,7 +190,7 @@ namespace TrafficManager.UI {
             }
 
             if (!DEFAULT_LANGUAGE_CODE.Equals(language)) {
-                Log.Warning($"Translated file {translatedFilename} not found!");
+                Log.Note($"Translated file {translatedFilename} not found!");
             }
 
             return filename;


### PR DESCRIPTION
- Add new `LogLevel.Note` enum (sits between `Info` and `Warning`)
- Add `Log.Note()` and `Log.NoteFormat()`
- Add `Log.MiniStackTrace()` helper method to do stacktrace chopping
   - Trims `trim` lines from start (default `2`)
   - Truncates remining list to `trunc` lines (default `3`)
   - Prepends a `prepend` string, unless it's `null` or `""`

It's useful when you want a bit of stack trace but don't want users complaining something is broken.

Example: Go from this `Log.Warning(str)`:

```diff
Warning 720.3672530: Translated file RoadUI.sign_stop_en-gb.png not found!
   at CSUtil.Commons.Log.LogToFile(System.String log, LogLevel level)
   at CSUtil.Commons.Log.Warning(System.String s)
   at TrafficManager.UI.Translation.GetTranslatedFileName(System.String filename, System.String language)
   at TrafficManager.UI.Translation.GetTranslatedFileName(System.String filename)
   at TrafficManager.UI.Textures.RoadUI.OnLevelLoading()
   at TrafficManager.Lifecycle.TMPELifecycle.Load()
   at TrafficManager.Lifecycle.TrafficManagerMod.OnLevelLoaded(LoadMode mode)
   at LoadingWrapper.LoadingWrapper.OnLevelLoaded_Patch4(.LoadingWrapper , UpdateMode )
   at LoadingManager+<LoadLevelComplete>c__Iterator9.MoveNext()
   at LoadingManager.FpsBoosterUpdate()
   at BehaviourUpdater.Updater.Update()
```

To this `Log.Note(str)`:

```diff
Note 720.3672530: Translated file RoadUI.sign_stop_en-gb.png not found!
-   at CSUtil.Commons.Log.LogToFile(System.String log, LogLevel level)
-   at CSUtil.Commons.Log.Warning(System.String s)
   at TrafficManager.UI.Translation.GetTranslatedFileName(System.String filename, System.String language)
   at TrafficManager.UI.Translation.GetTranslatedFileName(System.String filename)
   at TrafficManager.UI.Textures.RoadUI.OnLevelLoading()
-   at TrafficManager.Lifecycle.TMPELifecycle.Load()
-   at TrafficManager.Lifecycle.TrafficManagerMod.OnLevelLoaded(LoadMode mode)
-   at LoadingWrapper.LoadingWrapper.OnLevelLoaded_Patch4(.LoadingWrapper , UpdateMode )
-   at LoadingManager+<LoadLevelComplete>c__Iterator9.MoveNext()
-   at LoadingManager.FpsBoosterUpdate()
-   at BehaviourUpdater.Updater.Update()
```

Or this `Log.Note(str, 4)`:

```diff
Note 720.3672530: Translated file RoadUI.sign_stop_en-gb.png not found!
-   at TrafficManager.UI.Translation.GetTranslatedFileName(System.String filename, System.String language)
-   at TrafficManager.UI.Translation.GetTranslatedFileName(System.String filename)
   at TrafficManager.UI.Textures.RoadUI.OnLevelLoading()
+   at TrafficManager.Lifecycle.TMPELifecycle.Load()
+   at TrafficManager.Lifecycle.TrafficManagerMod.OnLevelLoaded(LoadMode mode)
```

Or this `Log.Note(str, 4, 1):

```diff
Note 720.3672530: Translated file RoadUI.sign_stop_en-gb.png not found!
   at TrafficManager.UI.Textures.RoadUI.OnLevelLoading()
-   at TrafficManager.Lifecycle.TMPELifecycle.Load()
-   at TrafficManager.Lifecycle.TrafficManagerMod.OnLevelLoaded(LoadMode mode)
```