### PR TITLE
Speed limit overlay signs not visible on train tracks

### DIFF
--- a/TLM/TLM/Manager/Impl/SpeedLimitManager.cs
+++ b/TLM/TLM/Manager/Impl/SpeedLimitManager.cs
@@ -76,7 +76,7 @@ namespace TrafficManager.Manager.Impl {
 #endif
 
             // Must be road or track based:
-            if (netinfo.m_netAI is not RoadBaseAI or TrainTrackBaseAI or MetroTrackAI) {
+            if (!(netinfo.m_netAI is RoadBaseAI or TrainTrackBaseAI or MetroTrackAI)) {
 #if DEBUG
                 if (debugSpeedLimits)
                     Log._Debug($"Skipped NetInfo '{netinfo.name}' because m_netAI is not applicable: {netinfo.m_netAI}");


### PR DESCRIPTION
Speed limit overlay signs not visible on train tracks due to bug introduced in one of improvements 😕 

[Build zip](https://ci.appveyor.com/api/projects/krzychu124/tmpe/artifacts/TMPE.zip?branch=speed-limits-not-visible-on-train-tracks)