### PR TITLE
Themed default speed signs

### DIFF
--- a/TLM/TLM/Manager/Impl/LanePos.cs
+++ b/TLM/TLM/Manager/Impl/LanePos.cs
@@ -5,17 +5,20 @@ namespace TrafficManager.Manager.Impl {
         public float position;
         public VehicleInfo.VehicleType vehicleType;
         public NetInfo.LaneType laneType;
+        public NetInfo.Direction finalDirection;
 
         public LanePos(uint laneId,
                        byte laneIndex,
                        float position,
                        VehicleInfo.VehicleType vehicleType,
-                       NetInfo.LaneType laneType) {
+                       NetInfo.LaneType laneType,
+                       NetInfo.Direction finalDirection) {
             this.laneId = laneId;
             this.laneIndex = laneIndex;
             this.position = position;
             this.vehicleType = vehicleType;
             this.laneType = laneType;
+            this.finalDirection = finalDirection;
         }
     }
 }

--- a/TLM/TLM/Manager/Impl/OptionsManager.cs
+++ b/TLM/TLM/Manager/Impl/OptionsManager.cs
@@ -214,7 +214,7 @@ namespace TrafficManager.Manager.Impl {
 
             save[56] = OptionsVehicleRestrictionsTab.NoDoubleCrossings.Save();
             save[57] = OptionsVehicleRestrictionsTab.DedicatedTurningLanes.Save();
-            save[58] = OptionsGeneralTab.DifferentiateDefaultSpeedsInNormalView.Save(),
+            save[58] = OptionsGeneralTab.DifferentiateDefaultSpeedsInNormalView.Save();
 
             return save;
         }

--- a/TLM/TLM/Manager/Impl/OptionsManager.cs
+++ b/TLM/TLM/Manager/Impl/OptionsManager.cs
@@ -143,7 +143,7 @@ namespace TrafficManager.Manager.Impl {
             ToCheckbox(data, idx: 56, OptionsVehicleRestrictionsTab.NoDoubleCrossings);
             ToCheckbox(data, idx: 57, OptionsVehicleRestrictionsTab.DedicatedTurningLanes);
           
-            ToCheckbox(data, idx: 58, OptionsGeneralTab.DifferentiateDefaultSpeedsInNormalView);
+            ToCheckbox(data, idx: 58, OptionsGeneralTab.UseThemedIconsForDefaultSpeedsInNormalView);
 
             return true;
         }
@@ -214,7 +214,8 @@ namespace TrafficManager.Manager.Impl {
 
             save[56] = OptionsVehicleRestrictionsTab.NoDoubleCrossings.Save();
             save[57] = OptionsVehicleRestrictionsTab.DedicatedTurningLanes.Save();
-            save[58] = OptionsGeneralTab.DifferentiateDefaultSpeedsInNormalView.Save();
+
+            save[58] = OptionsGeneralTab.UseThemedIconsForDefaultSpeedsInNormalView.Save();
 
             return save;
         }

--- a/TLM/TLM/Manager/Impl/OptionsManager.cs
+++ b/TLM/TLM/Manager/Impl/OptionsManager.cs
@@ -244,6 +244,8 @@ namespace TrafficManager.Manager.Impl {
 
             index = LoadBool(index, OptionsVehicleRestrictionsTab.NoDoubleCrossings);
             index = LoadBool(index, OptionsVehicleRestrictionsTab.DedicatedTurningLanes);
+
+            index = LoadBool(index, OptionsGeneralTab.DifferentiateDefaultSpeedsInNormalView);
             return true;
         }
 
@@ -311,6 +313,8 @@ namespace TrafficManager.Manager.Impl {
 
                 OptionsVehicleRestrictionsTab.NoDoubleCrossings.Save(),
                 OptionsVehicleRestrictionsTab.DedicatedTurningLanes.Save(),
+
+                OptionsGeneralTab.DifferentiateDefaultSpeedsInNormalView.Save(),
             };
         }
     }

--- a/TLM/TLM/Manager/Impl/OptionsManager.cs
+++ b/TLM/TLM/Manager/Impl/OptionsManager.cs
@@ -150,7 +150,7 @@ namespace TrafficManager.Manager.Impl {
 
         public byte[] SaveData(ref bool success) {
 
-            var save = new byte[58];
+            var save = new byte[59];
 
             save[0] = ConvertFromSimulationAccuracy(Options.simulationAccuracy);
             save[1] = 0; // Options.laneChangingRandomization

--- a/TLM/TLM/Manager/Impl/SpeedLimitManagerExt.cs
+++ b/TLM/TLM/Manager/Impl/SpeedLimitManagerExt.cs
@@ -1,6 +1,12 @@
-﻿namespace TrafficManager.Manager.Impl {
+using TrafficManager.Util.Extensions;
+
+namespace TrafficManager.Manager.Impl {
     /// <summary>Adds extra helper functions to NetSegment and NetInfo.Lane, etc.</summary>
     public static class SpeedLimitManagerExt {
+
+        private const NetSegment.Flags RequiredFlags = NetSegment.Flags.Created;
+        private const NetSegment.Flags RejectionFlags = NetSegment.Flags.Collapsed | NetSegment.Flags.Deleted;
+
         /// <summary>
         /// Extension method. Call via 'segment.MayHaveCustomSpeedLimits()`.
         /// Check whether custom speed limits may be assigned to the given segment.
@@ -8,12 +14,10 @@
         /// <param name="segment">Reference to affected segment.</param>
         /// <returns>True if this segment type can have custom speed limits set.</returns>
         public static bool MayHaveCustomSpeedLimits(this ref NetSegment segment) {
-            if ((segment.m_flags & NetSegment.Flags.Created) == NetSegment.Flags.None) {
-                return false;
-            }
 
-            // Collapsed roads cannot have speed limit, but will be restored if you upgrade in place
-            if ((segment.m_flags & NetSegment.Flags.Collapsed) != NetSegment.Flags.None) {
+            // if (!segment.IsValid())
+            if ((segment.m_flags & RequiredFlags) == NetSegment.Flags.None ||
+                (segment.m_flags & RejectionFlags) != NetSegment.Flags.None) {
                 return false;
             }
 

--- a/TLM/TLM/State/Options.cs
+++ b/TLM/TLM/State/Options.cs
@@ -120,6 +120,9 @@ namespace TrafficManager.State {
         public static bool PriorityRoad_EnterBlockedYeild = false;
         public static bool PriorityRoad_StopAtEntry = false;
 
+        /// <summary>When <c>true</c>, default speeds will be depicted with green signs in normal speed limit override view.</summary>
+        public static bool differentiateDefaultSpeedsInNormalView = false;
+
         /// <summary>
         /// Invoked on options change to refresh the main menu and possibly update the labels for
         /// a new language. Takes a second, very slow.

--- a/TLM/TLM/State/Options.cs
+++ b/TLM/TLM/State/Options.cs
@@ -120,8 +120,11 @@ namespace TrafficManager.State {
         public static bool PriorityRoad_EnterBlockedYeild = false;
         public static bool PriorityRoad_StopAtEntry = false;
 
-        /// <summary>When <c>true</c>, default speeds will be depicted with green signs in normal speed limit override view.</summary>
-        public static bool differentiateDefaultSpeedsInNormalView = false;
+        /// <summary>
+        /// When <c>true</c>, default speeds use themed icons in normal view.
+        /// When <c>false</c>, they'll use unthemed green icons.
+        /// </summary>
+        public static bool useThemedIconsForDefaultSpeedsInNormalView = true;
 
         /// <summary>
         /// Invoked on options change to refresh the main menu and possibly update the labels for

--- a/TLM/TLM/State/OptionsTabs/OptionsGeneralTab.cs
+++ b/TLM/TLM/State/OptionsTabs/OptionsGeneralTab.cs
@@ -18,6 +18,12 @@ namespace TrafficManager.State {
     using UI.WhatsNew;
 
     public static class OptionsGeneralTab {
+        public static CheckboxOption DifferentiateDefaultSpeedsInNormalView =
+            new (nameof(Options.differentiateDefaultSpeedsInNormalView)) {
+                Label = "General.Checkbox:DifferentiateDefaultSpeedsInNormalView",
+                Handler = OnDifferentiateDefaultSpeedsInNormalViewChanged,
+            };
+
         private static UICheckBox _instantEffectsToggle;
 
         [UsedImplicitly]
@@ -201,6 +207,8 @@ namespace TrafficManager.State {
                       eventCallback: OnRoadSignsThemeChanged) as UIDropDown;
 
             _roadSignsThemeDropdown.width *= 2.0f;
+
+            DifferentiateDefaultSpeedsInNormalView.AddUI(generalGroup);
         }
 
         private static void OnLanguageChanged(int newLanguageIndex) {
@@ -422,6 +430,10 @@ namespace TrafficManager.State {
 
             mainConfig.RoadSignTheme = newTheme;
             GlobalConfig.WriteConfig();
+        }
+
+        private static void OnDifferentiateDefaultSpeedsInNormalViewChanged(bool newVal) {
+            // ?
         }
 
         private static void OnSimulationAccuracyChanged(int newAccuracy) {

--- a/TLM/TLM/State/OptionsTabs/OptionsGeneralTab.cs
+++ b/TLM/TLM/State/OptionsTabs/OptionsGeneralTab.cs
@@ -18,10 +18,9 @@ namespace TrafficManager.State {
     using UI.WhatsNew;
 
     public static class OptionsGeneralTab {
-        public static CheckboxOption DifferentiateDefaultSpeedsInNormalView =
-            new (nameof(Options.differentiateDefaultSpeedsInNormalView)) {
-                Label = "General.Checkbox:DifferentiateDefaultSpeedsInNormalView",
-                Handler = OnDifferentiateDefaultSpeedsInNormalViewChanged,
+        public static CheckboxOption UseThemedIconsForDefaultSpeedsInNormalView =
+            new (nameof(Options.useThemedIconsForDefaultSpeedsInNormalView)) {
+                Label = "General.Checkbox:Use themed icons for Default speeds in normal view",
             };
 
         private static UICheckBox _instantEffectsToggle;
@@ -208,7 +207,7 @@ namespace TrafficManager.State {
 
             _roadSignsThemeDropdown.width *= 2.0f;
 
-            DifferentiateDefaultSpeedsInNormalView.AddUI(generalGroup);
+            UseThemedIconsForDefaultSpeedsInNormalView.AddUI(generalGroup);
         }
 
         private static void OnLanguageChanged(int newLanguageIndex) {
@@ -430,10 +429,6 @@ namespace TrafficManager.State {
 
             mainConfig.RoadSignTheme = newTheme;
             GlobalConfig.WriteConfig();
-        }
-
-        private static void OnDifferentiateDefaultSpeedsInNormalViewChanged(bool newVal) {
-            // ?
         }
 
         private static void OnSimulationAccuracyChanged(int newAccuracy) {

--- a/TLM/TLM/UI/SubTools/SpeedLimits/Overlay/SpeedLimitsOverlay.cs
+++ b/TLM/TLM/UI/SubTools/SpeedLimits/Overlay/SpeedLimitsOverlay.cs
@@ -492,6 +492,19 @@ namespace TrafficManager.UI.SubTools.SpeedLimits.Overlay {
             return ret;
         }
 
+        /// <summary>
+        /// Determines whether to show green default speed icon or themed icon for normal speed override view.
+        /// </summary>
+        /// <param name="drawSpeed">The speed to show.</param>
+        /// <param name="defaultSpeed">The default speed limit.</param>
+        /// <returns>Returns <c>true</c> = use default signs, or <c>false</c> = use themed signs.</returns>
+        private bool UseUnthemedIcons(SpeedValue? drawSpeed, SpeedValue? defaultSpeed) {
+            return
+                !drawSpeed.HasValue
+                || (Options.differentiateDefaultSpeedsInNormalView
+                    && drawSpeed.Value.Equals(defaultSpeed));
+        }
+
         private bool DrawSpeedLimitHandles_SegmentCenter(
             ushort segmentId,
             Vector3 segCenter,
@@ -554,7 +567,7 @@ namespace TrafficManager.UI.SubTools.SpeedLimits.Overlay {
                     forward: overrideSpeedlimitForward,
                     back: overrideSpeedlimitBack);
 
-                if (!drawSpeedlimit.HasValue || drawSpeedlimit.Value.Equals(defaultSpeedLimit)) {
+                if (UseUnthemedIcons(drawSpeedlimit, defaultSpeedLimit)) {
                     // No value, no override
                     squareSignRenderer.Reset(
                         screenPos,
@@ -722,11 +735,7 @@ namespace TrafficManager.UI.SubTools.SpeedLimits.Overlay {
                 GetSpeedLimitResult overrideSpeedlimit =
                     SpeedLimitManager.Instance.CalculateCustomSpeedLimit(laneId);
 
-                if (!overrideSpeedlimit.OverrideValue.HasValue
-                    || (overrideSpeedlimit.DefaultValue.HasValue &&
-                        overrideSpeedlimit.OverrideValue.Value.Equals(
-                            overrideSpeedlimit.DefaultValue.Value)))
-                {
+                if (UseUnthemedIcons(overrideSpeedlimit.OverrideValue, overrideSpeedlimit.DefaultValue)) {
                     //-------------------------------------
                     // Draw default blue speed limit
                     //-------------------------------------

--- a/TLM/TLM/UI/SubTools/SpeedLimits/Overlay/SpeedLimitsOverlay.cs
+++ b/TLM/TLM/UI/SubTools/SpeedLimits/Overlay/SpeedLimitsOverlay.cs
@@ -634,9 +634,17 @@ namespace TrafficManager.UI.SubTools.SpeedLimits.Overlay {
 
             bool onlyMonorailLanes = true;
 
+            int sortedLaneIndex = -1;
+            int directionChangeIndex = int.MaxValue;
+
             foreach (var lane in sortedLanes) {
+                ++sortedLaneIndex;
+
                 if (directions.Count < 2 && !directions.Contains(lane.finalDirection)) {
                     directions.Add(lane.finalDirection);
+                    if (directions.Count == 2) {
+                        directionChangeIndex = sortedLaneIndex;
+                    }
                 }
 
                 if (onlyMonorailLanes &&
@@ -659,10 +667,6 @@ namespace TrafficManager.UI.SubTools.SpeedLimits.Overlay {
             Vector3 drawOriginPos = segmentCenterPos -
                                     (0.5f * (((sortedLanes.Count - 1) + directions.Count) - 1) * signSize * xu);
 
-            directions.Clear();
-
-            int sortedLaneIndex = -1;
-
             // Main grid for large icons
             var grid = new Highlight.Grid(
                 gridOrigin: drawOriginPos,
@@ -676,18 +680,15 @@ namespace TrafficManager.UI.SubTools.SpeedLimits.Overlay {
             var colorController = new OverlayHandleColorController(args.IsInteractive);
 
             bool ret = false;
+            sortedLaneIndex = -1;
 
             foreach (var lane in sortedLanes) {
 
                 ++sortedLaneIndex;
                 uint laneId = lane.laneId;
 
-                if (directions.Count < 2 && !directions.Contains(lane.finalDirection)) {
-                    if (directions.Count > 0) {
-                        signColumn += 1f; // full space between opposite directions
-                    }
-
-                    directions.Add(lane.finalDirection);
+                if (sortedLaneIndex == directionChangeIndex) {
+                    signColumn += 1f; // add space between directions
                 }
 
                 Vector3 worldPos = grid.GetPositionForRowCol(signColumn, 0);

--- a/TLM/TLM/Util/Extensions/NetSegmentExtensions.cs
+++ b/TLM/TLM/Util/Extensions/NetSegmentExtensions.cs
@@ -123,14 +123,15 @@ namespace TrafficManager.Util.Extensions {
                     (vehicleTypeFilter == null || (laneInfo.m_vehicleType & vehicleTypeFilter) !=
                      VehicleInfo.VehicleType.None) &&
                     (filterDir == null ||
-                     segmentInfo.m_lanes[laneIndex].m_finalDirection == filterDir)) {
+                     laneInfo.m_finalDirection == filterDir)) {
                     laneList.Add(
                         new LanePos(
                             curLaneId,
                             laneIndex,
-                            segmentInfo.m_lanes[laneIndex].m_position,
+                            laneInfo.m_position,
                             laneInfo.m_vehicleType,
-                            laneInfo.m_laneType));
+                            laneInfo.m_laneType,
+                            laneInfo.m_finalDirection));
                 }
 
                 curLaneId = netManager.m_lanes.m_buffer[curLaneId].m_nextLane;


### PR DESCRIPTION
[TMPE.zip](https://ci.appveyor.com/api/buildjobs/3u2awmwa401hjmfc/artifacts/TMPE.zip)

This is based on user-feedback resulting from 11.6.4.0 STABLE release https://github.com/CitiesSkylinesMods/TMPE/issues/1221#issuecomment-1022557573

![image](https://user-images.githubusercontent.com/19638970/151237909-1c6769d9-4fbe-4e76-a23e-8049d3af062b.png)

This PR adds a new mod option, `Options.differentiateDefaultSpeedsInNormalView`, which is `false` by default. It is modified via a `CheckboxOption` on the General options tab:

> ![image](https://user-images.githubusercontent.com/1386719/151259479-d77bb663-d45d-4d0d-b7b8-28af45354bf8.png)

In normal view / persistent overlays:

- `false`: _themed_ icons depict default speeds
- `true`: _unthemed_ icons depict default speeds

In defaults view:

- Unthemed icons always used (existing functionality)

Also fixes the issue with overly large lane icons https://github.com/CitiesSkylinesMods/TMPE/issues/1221#issue-1072850489

<details><summary>Screenshots...</summary>

Normal mode, option is `false` (default state):

![image](https://user-images.githubusercontent.com/1386719/151260147-4ed535da-3f7d-44a7-9411-be62e348aad1.png)

Normal mode, option is `true`:

![image](https://user-images.githubusercontent.com/1386719/151260096-1125773c-93a2-4595-adfc-487ff3e5e2e6.png)

Defaults mode, regardless of option state:

![image](https://user-images.githubusercontent.com/1386719/151260301-c022fee7-ffae-41aa-9c05-0dd791e24f0f.png)

Persistent overlay, option is `false`:

![image](https://user-images.githubusercontent.com/1386719/151260431-1c61273a-985c-4334-b5d1-a081e39fe13f.png)

Persistent overlay, option is `true`:

![image](https://user-images.githubusercontent.com/1386719/151260480-6545a8ba-3b9b-4783-8bc6-8b84fc320906.png)

</details>

Todo:

- [ ] Localisations

Possible future enhancements:

* Overlay a small green circle (filled) at bottom of sign to indicate it's default speed limit?