### PR TITLE
Fix metro track detection - Speed Limits overlays

### DIFF
--- a/TLM/TLM/Manager/Impl/SpeedLimitManager.cs
+++ b/TLM/TLM/Manager/Impl/SpeedLimitManager.cs
@@ -76,7 +76,7 @@ namespace TrafficManager.Manager.Impl {
 #endif
 
             // Must be road or track based:
-            if (!(netinfo.m_netAI is RoadBaseAI or TrainTrackBaseAI or MetroTrackAI)) {
+            if (!(netinfo.m_netAI is RoadBaseAI or TrainTrackBaseAI or MetroTrackBaseAI)) {
 #if DEBUG
                 if (debugSpeedLimits)
                     Log._Debug($"Skipped NetInfo '{netinfo.name}' because m_netAI is not applicable: {netinfo.m_netAI}");


### PR DESCRIPTION
- actually `Sunset Harbor` fix (they've added new base type and default one has been moved `MetroTrackAI` one level higher, the same as new `MetroTrackBridgeAI` and `MetroTrackTunnelAI` as shown below

![image](https://user-images.githubusercontent.com/19638970/151438773-09b86bd4-8607-4f99-94d2-9b03a02abd55.png)


With regards to other tracks, Monorails work, no need to change anything but I think we should improve visibility of underground signs as they currently invisible in normal mode and users are confused that something does not work. Put that tiny arrow pointing down where overlay sign is normally rendered in underground mode? Good improvement for [11.6.5](https://github.com/CitiesSkylinesMods/TMPE/milestone/54)

Closes #1322 