### PR TITLE
Incorrect minimal number of path-find threads

### DIFF
--- a/TLM/TLM/Custom/PathFinding/CustomPathManager.cs
+++ b/TLM/TLM/Custom/PathFinding/CustomPathManager.cs
@@ -113,7 +113,7 @@ namespace TrafficManager.Custom.PathFinding {
             int numOfStockPathFinds = stockPathFinds.Length;
             // utilize more threads if possible (systems with 8+) otherwise use vanilla calculation
             int numCustomPathFinds = SystemInfo.processorCount < 8
-                                         ? SystemInfo.processorCount / 2
+                                         ? Mathf.Max(SystemInfo.processorCount / 2, 1)
                                          : SystemInfo.processorCount - 4;
             simSleepMultiplier_ = CalculateBestSimSleepMultiplier(numCustomPathFinds);
 


### PR DESCRIPTION
User reported that on the map with TM:PE enabled there was no traffic at all and game didn't spawn new vehicles.

It's super weird case but somehow game reported 1 core CPU which does not make sense, but... TM:PE created 0 path-find threads 😂 

Specs from `output_log.txt` (`i7-1165G7` is 4 core/8 threads CPU)
```
Model: HP Laptop 17t-by400 (HP)
OS: Windows 10  (10.0.0) 64bit
Language: English
CPU: 11th Gen Intel(R) Core(TM) i7-1165G7 @ 2.80GHz (1 core(s))
System Memory: 29594
Gfx Device: Intel(R) Iris(R) Xe Graphics
Gfx Version: Direct3D 11.0 [level 11.1]
Gfx Memory: 7526
Gfx Shader Model: 50
Game Version: 1.14.0-f4-steam-win
```
