### PR TITLE
What's New in TM:PE 11.6.4.3?

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ This changelog includes all versions and major variants of the mod going all the
 * [Meta] This fixes rare issue on some PCs that are limited to single CPU core
 * [Fixed] Incorrect minimal number of path-find threads #1331 (krzychu124)
 * [Updated] Code clean-up: Refactor `OptionsManager.cs` #1321 (kvakvs, aubergine18)
+* [Updated] Show full version in UI and log file #1335 (aubergine18)
 - [Steam] [TM:PE v11 STABLE](https://steamcommunity.com/sharedfiles/filedetails/?id=1637663252)
 
 #### TM:PE V11.6.4.3 TEST, 29/01/2022
@@ -43,6 +44,7 @@ This changelog includes all versions and major variants of the mod going all the
 * [Meta] This fixes rare issue on some PCs that are limited to single CPU core
 * [Fixed] Incorrect minimal number of path-find threads #1331 (krzychu124)
 * [Updated] Code clean-up: Refactor `OptionsManager.cs` #1321 (kvakvs, aubergine18)
+* [Updated] Show full version in UI and log file #1335 (aubergine18)
 - [Steam] [TM:PE v11 TEST](https://steamcommunity.com/sharedfiles/filedetails/?id=2489276785)
 
 #### TM:PE V11.6.4.2 STABLE, 27/01/2022

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ This changelog includes all versions and major variants of the mod going all the
 * [Fixed] Incorrect minimal number of path-find threads #1331 (krzychu124)
 * [Updated] Code clean-up: Refactor `OptionsManager.cs` #1321 (kvakvs, aubergine18)
 * [Updated] Show full version in UI and log file #1335 (aubergine18)
+* [Removed] Temporary: Don't auto-show What's New on TM:PE menu button click #1336 #1314 (krzychu124, aubergine18)
 - [Steam] [TM:PE v11 STABLE](https://steamcommunity.com/sharedfiles/filedetails/?id=1637663252)
 
 #### TM:PE V11.6.4.3 TEST, 29/01/2022
@@ -45,6 +46,7 @@ This changelog includes all versions and major variants of the mod going all the
 * [Fixed] Incorrect minimal number of path-find threads #1331 (krzychu124)
 * [Updated] Code clean-up: Refactor `OptionsManager.cs` #1321 (kvakvs, aubergine18)
 * [Updated] Show full version in UI and log file #1335 (aubergine18)
+* [Removed] Temporary: Don't auto-show What's New on TM:PE menu button click #1336 #1314 (krzychu124, aubergine18)
 - [Steam] [TM:PE v11 TEST](https://steamcommunity.com/sharedfiles/filedetails/?id=2489276785)
 
 #### TM:PE V11.6.4.2 STABLE, 27/01/2022

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,15 +32,17 @@ This changelog includes all versions and major variants of the mod going all the
 #### TM:PE V11.6.4.3 STABLE, 29/01/2022
 
 * [Meta] TM:PE 11.6.4-hotfix-3
-* [Meta] This fixes rare issue on some HP Laptops that report only 1 CPU core.
+* [Meta] This fixes rare issue on some PCs that are limited to single CPU core
 * [Fixed] Incorrect minimal number of path-find threads #1331 (krzychu124)
+* [Updated] Code clean-up: Refactor `OptionsManager.cs` #1321 (kvakvs, aubergine18)
 - [Steam] [TM:PE v11 STABLE](https://steamcommunity.com/sharedfiles/filedetails/?id=1637663252)
 
 #### TM:PE V11.6.4.3 TEST, 29/01/2022
 
 * [Meta] TM:PE 11.6.4-hotfix-3
-* [Meta] This fixes rare issue on some HP Laptops that report only 1 CPU core.
+* [Meta] This fixes rare issue on some PCs that are limited to single CPU core
 * [Fixed] Incorrect minimal number of path-find threads #1331 (krzychu124)
+* [Updated] Code clean-up: Refactor `OptionsManager.cs` #1321 (kvakvs, aubergine18)
 - [Steam] [TM:PE v11 TEST](https://steamcommunity.com/sharedfiles/filedetails/?id=2489276785)
 
 #### TM:PE V11.6.4.2 STABLE, 27/01/2022

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,20 @@ This changelog includes all versions and major variants of the mod going all the
 
 </details>
 
+#### TM:PE V11.6.4.3 STABLE, 29/01/2022
+
+* [Meta] TM:PE 11.6.4-hotfix-3
+* [Meta] This fixes rare issue on some HP Laptops that report only 1 CPU core.
+* [Fixed] Incorrect minimal number of path-find threads #1331 (krzychu124)
+- [Steam] [TM:PE v11 STABLE](https://steamcommunity.com/sharedfiles/filedetails/?id=1637663252)
+
+#### TM:PE V11.6.4.3 TEST, 29/01/2022
+
+* [Meta] TM:PE 11.6.4-hotfix-3
+* [Meta] This fixes rare issue on some HP Laptops that report only 1 CPU core.
+* [Fixed] Incorrect minimal number of path-find threads #1331 (krzychu124)
+- [Steam] [TM:PE v11 TEST](https://steamcommunity.com/sharedfiles/filedetails/?id=2489276785)
+
 #### TM:PE V11.6.4.2 STABLE, 27/01/2022
 
 * [Meta] TM:PE 11.6.4-hotfix-2

--- a/README.md
+++ b/README.md
@@ -44,8 +44,9 @@ Official releases:
 #### TM:PE V11.6.4.3 STABLE, 29/01/2022
 
 * [Meta] TM:PE 11.6.4-hotfix-3
-* [Meta] This fixes rare issue on some HP Laptops that report only 1 CPU core.
+* [Meta] This fixes rare issue on some PCs that are limited to single CPU core
 * [Fixed] Incorrect minimal number of path-find threads #1331 (krzychu124)
+* [Updated] Code clean-up: Refactor `OptionsManager.cs` #1321 (kvakvs, aubergine18)
 - [Steam] [TM:PE v11 STABLE](https://steamcommunity.com/sharedfiles/filedetails/?id=1637663252)
 
 #### TM:PE V11.6.4.2 STABLE, 27/01/2022
@@ -64,8 +65,9 @@ Official releases:
 #### TM:PE V11.6.4.3 TEST, 29/01/2022
 
 * [Meta] TM:PE 11.6.4-hotfix-3
-* [Meta] This fixes rare issue on some HP Laptops that report only 1 CPU core.
+* [Meta] This fixes rare issue on some PCs that are limited to single CPU core
 * [Fixed] Incorrect minimal number of path-find threads #1331 (krzychu124)
+* [Updated] Code clean-up: Refactor `OptionsManager.cs` #1321 (kvakvs, aubergine18)
 - [Steam] [TM:PE v11 TEST](https://steamcommunity.com/sharedfiles/filedetails/?id=2489276785)
 
 #### TM:PE V11.6.4.2 TEST, 27/01/2022

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Official releases:
 * [Fixed] Incorrect minimal number of path-find threads #1331 (krzychu124)
 * [Updated] Code clean-up: Refactor `OptionsManager.cs` #1321 (kvakvs, aubergine18)
 * [Updated] Show full version in UI and log file #1335 (aubergine18)
+* [Removed] Temporary: Don't auto-show What's New on TM:PE menu button click #1336 #1314 (krzychu124, aubergine18)
 - [Steam] [TM:PE v11 STABLE](https://steamcommunity.com/sharedfiles/filedetails/?id=1637663252)
 
 #### TM:PE V11.6.4.2 STABLE, 27/01/2022
@@ -70,6 +71,7 @@ Official releases:
 * [Fixed] Incorrect minimal number of path-find threads #1331 (krzychu124)
 * [Updated] Code clean-up: Refactor `OptionsManager.cs` #1321 (kvakvs, aubergine18)
 * [Updated] Show full version in UI and log file #1335 (aubergine18)
+* [Removed] Temporary: Don't auto-show What's New on TM:PE menu button click #1336 #1314 (krzychu124, aubergine18)
 - [Steam] [TM:PE v11 TEST](https://steamcommunity.com/sharedfiles/filedetails/?id=2489276785)
 
 #### TM:PE V11.6.4.2 TEST, 27/01/2022

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Official releases:
 * [Meta] This fixes rare issue on some PCs that are limited to single CPU core
 * [Fixed] Incorrect minimal number of path-find threads #1331 (krzychu124)
 * [Updated] Code clean-up: Refactor `OptionsManager.cs` #1321 (kvakvs, aubergine18)
+* [Updated] Show full version in UI and log file #1335 (aubergine18)
 - [Steam] [TM:PE v11 STABLE](https://steamcommunity.com/sharedfiles/filedetails/?id=1637663252)
 
 #### TM:PE V11.6.4.2 STABLE, 27/01/2022
@@ -68,6 +69,7 @@ Official releases:
 * [Meta] This fixes rare issue on some PCs that are limited to single CPU core
 * [Fixed] Incorrect minimal number of path-find threads #1331 (krzychu124)
 * [Updated] Code clean-up: Refactor `OptionsManager.cs` #1321 (kvakvs, aubergine18)
+* [Updated] Show full version in UI and log file #1335 (aubergine18)
 - [Steam] [TM:PE v11 TEST](https://steamcommunity.com/sharedfiles/filedetails/?id=2489276785)
 
 #### TM:PE V11.6.4.2 TEST, 27/01/2022

--- a/README.md
+++ b/README.md
@@ -41,6 +41,13 @@ Official releases:
 
 > Date format: dd/mm/yyyy
 
+#### TM:PE V11.6.4.3 STABLE, 29/01/2022
+
+* [Meta] TM:PE 11.6.4-hotfix-3
+* [Meta] This fixes rare issue on some HP Laptops that report only 1 CPU core.
+* [Fixed] Incorrect minimal number of path-find threads #1331 (krzychu124)
+- [Steam] [TM:PE v11 STABLE](https://steamcommunity.com/sharedfiles/filedetails/?id=1637663252)
+
 #### TM:PE V11.6.4.2 STABLE, 27/01/2022
 
 * [Meta] TM:PE 11.6.4-hotfix-2
@@ -53,6 +60,13 @@ Official releases:
 * [Fixed] Speed limit icons not appearing on rail tracks #1318 (krzychu124)
 
 ### Recent TEST releases (dd/mm/yyyy)
+
+#### TM:PE V11.6.4.3 TEST, 29/01/2022
+
+* [Meta] TM:PE 11.6.4-hotfix-3
+* [Meta] This fixes rare issue on some HP Laptops that report only 1 CPU core.
+* [Fixed] Incorrect minimal number of path-find threads #1331 (krzychu124)
+- [Steam] [TM:PE v11 TEST](https://steamcommunity.com/sharedfiles/filedetails/?id=2489276785)
 
 #### TM:PE V11.6.4.2 TEST, 27/01/2022
 

--- a/TLM/TLM/Resources/whats_new.txt
+++ b/TLM/TLM/Resources/whats_new.txt
@@ -7,6 +7,7 @@
 [Fixed] Incorrect minimal number of path-find threads #1331 (krzychu124)
 [Updated] Code maintenance: Refactor OptionsManager.cs #1321 (kvakvs, aubergine18)
 [Updated] Show full version in UI and log file #1335 (aubergine18)
+[Removed] Temporary: Don't auto-show What's New on TM:PE menu button click #1336 #1314 (krzychu124, aubergine18)
 [/Version]
 
 [Version] 11.6.4.2

--- a/TLM/TLM/Resources/whats_new.txt
+++ b/TLM/TLM/Resources/whats_new.txt
@@ -6,6 +6,7 @@
 [Meta] This fixes rare issue on some PCs that are limited to single CPU core
 [Fixed] Incorrect minimal number of path-find threads #1331 (krzychu124)
 [Updated] Code maintenance: Refactor OptionsManager.cs #1321 (kvakvs, aubergine18)
+[Updated] Show full version in UI and log file #1335 (aubergine18)
 [/Version]
 
 [Version] 11.6.4.2

--- a/TLM/TLM/Resources/whats_new.txt
+++ b/TLM/TLM/Resources/whats_new.txt
@@ -3,8 +3,9 @@
 [Released] January 29 2022
 [Link] tmpe-v11643-stable-29012022
 [Meta] TM:PE 11.6.4-hotfix-3
-[Meta] This fixes rare issue on some HP Laptops that report only 1 CPU core.
+[Meta] This fixes rare issue on some PCs that are limited to single CPU core
 [Fixed] Incorrect minimal number of path-find threads #1331 (krzychu124)
+[Updated] Code maintenance: Refactor OptionsManager.cs #1321 (kvakvs, aubergine18)
 [/Version]
 
 [Version] 11.6.4.2

--- a/TLM/TLM/Resources/whats_new.txt
+++ b/TLM/TLM/Resources/whats_new.txt
@@ -1,3 +1,12 @@
+[Version] 11.6.4.3
+[Stable]
+[Released] January 29 2022
+[Link] tmpe-v11643-stable-29012022
+[Meta] TM:PE 11.6.4-hotfix-3
+[Meta] This fixes rare issue on some HP Laptops that report only 1 CPU core.
+[Fixed] Incorrect minimal number of path-find threads #1331 (krzychu124)
+[/Version]
+
 [Version] 11.6.4.2
 [Stable]
 [Released] January 27 2022

--- a/TLM/TLM/UI/WhatsNew/WhatsNew.cs
+++ b/TLM/TLM/UI/WhatsNew/WhatsNew.cs
@@ -11,7 +11,7 @@ namespace TrafficManager.UI.WhatsNew {
 
     public class WhatsNew {
         // bump and update what's new changelogs when new features added
-        internal static readonly Version CurrentVersion = new Version(11,6,4,2);
+        internal static readonly Version CurrentVersion = new Version(11,6,4,3);
 
         private const string WHATS_NEW_FILE = "whats_new.txt";
         private const string RESOURCES_PREFIX = "TrafficManager.Resources.";


### PR DESCRIPTION
This is bug fix release:

* [Meta] TM:PE 11.6.4-hotfix-3
* [Meta] This fixes rare issue on some PCs that are limited to single CPU core
* [Fixed] Incorrect minimal number of path-find threads #1331 (krzychu124)
* [Updated] Code clean-up: Refactor `OptionsManager.cs` #1321 (kvakvs, aubergine18)
* [Updated] Show full version in UI and log file #1335 (aubergine18)
* [Removed] Temporary: Don't auto-show What's New on TM:PE menu button click #1336 #1314 (krzychu124, aubergine18)