### PR TITLE
Show full `What's New` version in UI

### DIFF
--- a/TLM/TLM/Lifecycle/TrafficManagerMod.cs
+++ b/TLM/TLM/Lifecycle/TrafficManagerMod.cs
@@ -5,10 +5,11 @@ namespace TrafficManager.Lifecycle {
     using System;
     using TrafficManager.State;
     using TrafficManager.UI;
+    using TrafficManager.UI.WhatsNew;
     using TrafficManager.Util;
 
     public class TrafficManagerMod : ILoadingExtension, IUserMod {
-        public static string ModName => $"TM:PE {VersionUtil.VersionString} {VersionUtil.BRANCH}";
+        public static string ModName => $"TM:PE {WhatsNew.CurrentVersion} {VersionUtil.BRANCH}";
 
         public string Name => ModName;
 

--- a/TLM/TLM/UI/WhatsNew/WhatsNew.cs
+++ b/TLM/TLM/UI/WhatsNew/WhatsNew.cs
@@ -11,7 +11,7 @@ namespace TrafficManager.UI.WhatsNew {
 
     public class WhatsNew {
         // bump and update what's new changelogs when new features added
-        internal static readonly Version CurrentVersion = new Version(11,6,4,2);
+        public static readonly Version CurrentVersion = new Version(11,6,4,2);
 
         private const string WHATS_NEW_FILE = "whats_new.txt";
         private const string RESOURCES_PREFIX = "TrafficManager.Resources.";

--- a/TLM/TLM/Util/VersionUtil.cs
+++ b/TLM/TLM/Util/VersionUtil.cs
@@ -80,12 +80,13 @@ namespace TrafficManager.Util {
         }
 
         /// <summary>
-        /// TMPE build info and what game ver it expects.
+        /// TMPE build info and the version of the game which the mod was built using
+        /// (BuildConfig.applicationVersion is resolved at compile time!)
         /// </summary>
         public static void LogBuildDetails() {
             Log.InfoFormat(
-                "TM:PE enabled. Version {0}, Build {1} {2} for game version {3}",
-                VersionString,
+                "{0} - Build {1} {2} compiled under C:SL {3}",
+                TrafficManagerMod.ModName,
                 ModVersion,
                 BRANCH,
                 BuildConfig.applicationVersion);


### PR DESCRIPTION
This PR changes the version that's shown in-game; instead of the assembly version, it uses the version from `WhatsNew.cs` which has a manually specified build number.

In mod options:

![image](https://user-images.githubusercontent.com/1386719/151673273-d097ab85-1c77-4ca9-a0cf-5ea94ae3051b.png)

In game toolbar:

![image](https://user-images.githubusercontent.com/1386719/151673480-9aada09d-b4d7-4a37-8a90-72d6776bb961.png)

Log file:

```
Info 0.0539720: TM:PE 11.6.4.2 STABLE - Build 11.6.4.33864 STABLE compiled under C:SL 1.14.0-f4
```