### PR TITLE
Disable `What's New` on TM:PE button

### DIFF
--- a/TLM/TLM/UI/ModUI.cs
+++ b/TLM/TLM/UI/ModUI.cs
@@ -127,9 +127,10 @@ namespace TrafficManager.UI {
                 ShowMainMenu();
                 GetTrafficManagerTool()?.RequestOnscreenDisplayUpdate();
 
-                if (!TMPELifecycle.Instance.WhatsNew.Shown) {
-                    WhatsNew.WhatsNew.OpenModal();
-                }
+                // Temporarily disable - see: https://github.com/CitiesSkylinesMods/TMPE/issues/1314#issuecomment-1024989575
+                // if (!TMPELifecycle.Instance.WhatsNew.Shown) {
+                //     WhatsNew.WhatsNew.OpenModal();
+                // }
             }
         }
 


### PR DESCRIPTION
Disable `WhatsNew.WhatsNew.OpenModal()` on TM:PE button click due to ongoing issues with stack overflow described in #1314

https://github.com/CitiesSkylinesMods/TMPE/issues/1314#issuecomment-1024989575