### PR TITLE
Aircraft pathfinding fix

### DIFF
--- a/TLM/TLM/Custom/PathFinding/CustomPathManager.cs
+++ b/TLM/TLM/Custom/PathFinding/CustomPathManager.cs
@@ -374,7 +374,7 @@ namespace TrafficManager.Custom.PathFinding {
 
             PathCreationArgs args = new PathCreationArgs {
                 extPathType = ExtPathType.None,
-                extVehicleType = ConvertToExtVehicleType(vehicleType),
+                extVehicleType = ExtVehicleManager.ConvertToExtVehicleType(vehicleType),
                 vehicleId = 0,
                 spawned = true,
                 buildIndex = Singleton<SimulationManager>.instance.m_currentBuildIndex,
@@ -403,54 +403,6 @@ namespace TrafficManager.Custom.PathFinding {
             }
 
             return CustomCreatePath(out path, ref SimulationManager.instance.m_randomizer, args);
-        }
-
-        /// <summary>
-        /// Converts game VehicleInfo.VehicleType to closest TMPE.API.Traffic.Enums.ExtVehicleType
-        /// </summary>
-        /// <param name="vehicleType"></param>
-        /// <returns></returns>
-        private static ExtVehicleType ConvertToExtVehicleType(VehicleInfo.VehicleType vehicleType) {
-            ExtVehicleType extVehicleType = ExtVehicleType.None;
-            if ((vehicleType & VehicleInfo.VehicleType.Car) != VehicleInfo.VehicleType.None) {
-                extVehicleType = ExtVehicleType.Bus;
-            }
-
-            if ((vehicleType & (VehicleInfo.VehicleType.Train | VehicleInfo.VehicleType.Metro |
-                                VehicleInfo.VehicleType.Monorail)) !=
-                VehicleInfo.VehicleType.None) {
-                extVehicleType = ExtVehicleType.PassengerTrain;
-            }
-
-            if ((vehicleType & VehicleInfo.VehicleType.Tram) != VehicleInfo.VehicleType.None) {
-                extVehicleType = ExtVehicleType.Tram;
-            }
-
-            if ((vehicleType & VehicleInfo.VehicleType.Ship) != VehicleInfo.VehicleType.None) {
-                extVehicleType = ExtVehicleType.PassengerShip;
-            }
-
-            if ((vehicleType & VehicleInfo.VehicleType.Plane) != VehicleInfo.VehicleType.None) {
-                extVehicleType = ExtVehicleType.PassengerPlane;
-            }
-
-            if ((vehicleType & VehicleInfo.VehicleType.Ferry) != VehicleInfo.VehicleType.None) {
-                extVehicleType = ExtVehicleType.Ferry;
-            }
-
-            if ((vehicleType & VehicleInfo.VehicleType.Blimp) != VehicleInfo.VehicleType.None) {
-                extVehicleType = ExtVehicleType.Blimp;
-            }
-
-            if ((vehicleType & VehicleInfo.VehicleType.CableCar) != VehicleInfo.VehicleType.None) {
-                extVehicleType = ExtVehicleType.CableCar;
-            }
-
-            if ((vehicleType & VehicleInfo.VehicleType.Trolleybus) != VehicleInfo.VehicleType.None) {
-                extVehicleType = ExtVehicleType.Trolleybus;
-            }
-
-            return extVehicleType;
         }
 
         /// <summary>

--- a/TLM/TLM/Manager/Impl/ExtVehicleManager.cs
+++ b/TLM/TLM/Manager/Impl/ExtVehicleManager.cs
@@ -1050,39 +1050,23 @@ namespace TrafficManager.Manager.Impl {
             ExtVehicleType extVehicleType = ExtVehicleType.None;
             if ((vehicleType & VehicleInfo.VehicleType.Car) != VehicleInfo.VehicleType.None) {
                 extVehicleType = ExtVehicleType.Bus;
-            }
-
-            if ((vehicleType & (VehicleInfo.VehicleType.Train | VehicleInfo.VehicleType.Metro |
+            } else if ((vehicleType & (VehicleInfo.VehicleType.Train | VehicleInfo.VehicleType.Metro |
                                 VehicleInfo.VehicleType.Monorail)) !=
                 VehicleInfo.VehicleType.None) {
                 extVehicleType = ExtVehicleType.PassengerTrain;
-            }
-
-            if ((vehicleType & VehicleInfo.VehicleType.Tram) != VehicleInfo.VehicleType.None) {
+            } else if ((vehicleType & VehicleInfo.VehicleType.Tram) != VehicleInfo.VehicleType.None) {
                 extVehicleType = ExtVehicleType.Tram;
-            }
-
-            if ((vehicleType & VehicleInfo.VehicleType.Ship) != VehicleInfo.VehicleType.None) {
+            } else if ((vehicleType & VehicleInfo.VehicleType.Ship) != VehicleInfo.VehicleType.None) {
                 extVehicleType = ExtVehicleType.PassengerShip;
-            }
-
-            if ((vehicleType & VehicleInfo.VehicleType.Plane) != VehicleInfo.VehicleType.None) {
+            } else if ((vehicleType & VehicleInfo.VehicleType.Plane) != VehicleInfo.VehicleType.None) {
                 extVehicleType = ExtVehicleType.PassengerPlane;
-            }
-
-            if ((vehicleType & VehicleInfo.VehicleType.Ferry) != VehicleInfo.VehicleType.None) {
+            } else if ((vehicleType & VehicleInfo.VehicleType.Ferry) != VehicleInfo.VehicleType.None) {
                 extVehicleType = ExtVehicleType.Ferry;
-            }
-
-            if ((vehicleType & VehicleInfo.VehicleType.Blimp) != VehicleInfo.VehicleType.None) {
+            } else if ((vehicleType & VehicleInfo.VehicleType.Blimp) != VehicleInfo.VehicleType.None) {
                 extVehicleType = ExtVehicleType.Blimp;
-            }
-
-            if ((vehicleType & VehicleInfo.VehicleType.CableCar) != VehicleInfo.VehicleType.None) {
+            } else if ((vehicleType & VehicleInfo.VehicleType.CableCar) != VehicleInfo.VehicleType.None) {
                 extVehicleType = ExtVehicleType.CableCar;
-            }
-
-            if ((vehicleType & VehicleInfo.VehicleType.Trolleybus) != VehicleInfo.VehicleType.None) {
+            } else if ((vehicleType & VehicleInfo.VehicleType.Trolleybus) != VehicleInfo.VehicleType.None) {
                 extVehicleType = ExtVehicleType.Trolleybus;
             }
 

--- a/TLM/TLM/Manager/Impl/ExtVehicleManager.cs
+++ b/TLM/TLM/Manager/Impl/ExtVehicleManager.cs
@@ -1041,6 +1041,54 @@ namespace TrafficManager.Manager.Impl {
             }
         }
 
+        /// <summary>
+        /// Converts game VehicleInfo.VehicleType to closest TMPE.API.Traffic.Enums.ExtVehicleType
+        /// </summary>
+        /// <param name="vehicleType"></param>
+        /// <returns></returns>
+        public static ExtVehicleType ConvertToExtVehicleType(VehicleInfo.VehicleType vehicleType) {
+            ExtVehicleType extVehicleType = ExtVehicleType.None;
+            if ((vehicleType & VehicleInfo.VehicleType.Car) != VehicleInfo.VehicleType.None) {
+                extVehicleType = ExtVehicleType.Bus;
+            }
+
+            if ((vehicleType & (VehicleInfo.VehicleType.Train | VehicleInfo.VehicleType.Metro |
+                                VehicleInfo.VehicleType.Monorail)) !=
+                VehicleInfo.VehicleType.None) {
+                extVehicleType = ExtVehicleType.PassengerTrain;
+            }
+
+            if ((vehicleType & VehicleInfo.VehicleType.Tram) != VehicleInfo.VehicleType.None) {
+                extVehicleType = ExtVehicleType.Tram;
+            }
+
+            if ((vehicleType & VehicleInfo.VehicleType.Ship) != VehicleInfo.VehicleType.None) {
+                extVehicleType = ExtVehicleType.PassengerShip;
+            }
+
+            if ((vehicleType & VehicleInfo.VehicleType.Plane) != VehicleInfo.VehicleType.None) {
+                extVehicleType = ExtVehicleType.PassengerPlane;
+            }
+
+            if ((vehicleType & VehicleInfo.VehicleType.Ferry) != VehicleInfo.VehicleType.None) {
+                extVehicleType = ExtVehicleType.Ferry;
+            }
+
+            if ((vehicleType & VehicleInfo.VehicleType.Blimp) != VehicleInfo.VehicleType.None) {
+                extVehicleType = ExtVehicleType.Blimp;
+            }
+
+            if ((vehicleType & VehicleInfo.VehicleType.CableCar) != VehicleInfo.VehicleType.None) {
+                extVehicleType = ExtVehicleType.CableCar;
+            }
+
+            if ((vehicleType & VehicleInfo.VehicleType.Trolleybus) != VehicleInfo.VehicleType.None) {
+                extVehicleType = ExtVehicleType.Trolleybus;
+            }
+
+            return extVehicleType;
+        }
+
         [UsedImplicitly]
         public ushort GetFrontVehicleId(ushort vehicleId, ref Vehicle vehicleData) {
             bool reversed = (vehicleData.m_flags & Vehicle.Flags.Reversed) != 0;

--- a/TLM/TLM/Patch/_PathManager/CreatePathPatch.cs
+++ b/TLM/TLM/Patch/_PathManager/CreatePathPatch.cs
@@ -7,6 +7,7 @@ namespace TrafficManager.Patch._PathManager {
     using JetBrains.Annotations;
     using System;
     using System.Reflection;
+    using Manager.Impl;
     using State.ConfigData;
     using TrafficManager.API.Traffic.Data;
     using TrafficManager.Custom.PathFinding;
@@ -59,6 +60,8 @@ namespace TrafficManager.Patch._PathManager {
 
             } else {
                 // CreatePath called for vanilla AI
+                // determine vehicle type
+                args.extVehicleType = ExtVehicleManager.ConvertToExtVehicleType(vehicleTypes);
                 args.skipQueue = skipQueue;
             }
 


### PR DESCRIPTION
TM:PE is searching for path for all AI's in game, so added `vehicleType` converter to handle all explicitly used vehicles by pathfinding. Previously they set vehicle type None which caused issues in path-finding code testing lanes with allowed vehicle types. This change may fix other rare issues that happened in the past for AIs not explicitly managed by TM:PE

closes #1327 
closes #1329 

[Build zip](https://ci.appveyor.com/api/projects/krzychu124/tmpe/artifacts/TMPE.zip?branch=bugfix/1326-aircraft-pathfinding)