### PR TITLE
Filtered despawn

### DIFF
--- a/TLM/TLM/Manager/Impl/ExtVehicleManager.cs
+++ b/TLM/TLM/Manager/Impl/ExtVehicleManager.cs
@@ -910,7 +910,7 @@ namespace TrafficManager.Manager.Impl {
 #endif
         }
 
-        public ExtVehicleType? DetermineVehicleTypeFromAIType(
+        internal ExtVehicleType? DetermineVehicleTypeFromAIType(
             ushort vehicleId,
             VehicleAI ai,
             bool emergencyOnDuty)

--- a/TLM/TLM/Manager/Impl/ExtVehicleManager.cs
+++ b/TLM/TLM/Manager/Impl/ExtVehicleManager.cs
@@ -910,7 +910,7 @@ namespace TrafficManager.Manager.Impl {
 #endif
         }
 
-        private ExtVehicleType? DetermineVehicleTypeFromAIType(
+        public ExtVehicleType? DetermineVehicleTypeFromAIType(
             ushort vehicleId,
             VehicleAI ai,
             bool emergencyOnDuty)

--- a/TLM/TLM/Manager/Impl/UtilityManager.cs
+++ b/TLM/TLM/Manager/Impl/UtilityManager.cs
@@ -29,7 +29,7 @@ namespace TrafficManager.Manager.Impl {
                         ? filter == 0
                             ? "Nothing (filter == 0)"
                             : filter.ToString()
-                        : "All vehicles and cims";
+                        : "All vehicles";
 
                     Log.Info($"Utility Manager: Despawning {logStr}");
 

--- a/TLM/TLM/Manager/Impl/UtilityManager.cs
+++ b/TLM/TLM/Manager/Impl/UtilityManager.cs
@@ -22,7 +22,7 @@ namespace TrafficManager.Manager.Impl {
 
         private readonly Queue<KeyValuePair<IRecordable, Dictionary<InstanceID, InstanceID>>> _transferRecordables = new();
 
-        public static void DespawnVehicles(ExtVehicleType? filter = null) {
+        public void DespawnVehicles(ExtVehicleType? filter = null) {
             lock (Singleton<VehicleManager>.instance) {
                 try {
                     var manager = Singleton<VehicleManager>.instance;
@@ -34,8 +34,7 @@ namespace TrafficManager.Manager.Impl {
                             continue;
                         }
 
-                        if (filter.HasValue &&
-                            (vehicle.ToExtVehicleType() & filter) == ExtVehicleType.None) {
+                        if (filter.HasValue && (vehicle.ToExtVehicleType() & filter) != 0) {
                             continue;
                         }
 

--- a/TLM/TLM/Manager/Impl/UtilityManager.cs
+++ b/TLM/TLM/Manager/Impl/UtilityManager.cs
@@ -34,12 +34,12 @@ namespace TrafficManager.Manager.Impl {
                             continue;
                         }
 
-                        if (filter != null &&
+                        if (filter.HasValue &&
                             (vehicle.ToExtVehicleType() & filter) == ExtVehicleType.None) {
                             continue;
                         }
 
-                        vehicle.Despawn();
+                        manager.ReleaseVehicle((ushort)vehicleId);
                     }
 
                     TrafficMeasurementManager.Instance.ResetTrafficStats();

--- a/TLM/TLM/Manager/Impl/UtilityManager.cs
+++ b/TLM/TLM/Manager/Impl/UtilityManager.cs
@@ -25,6 +25,14 @@ namespace TrafficManager.Manager.Impl {
         public void DespawnVehicles(ExtVehicleType? filter = null) {
             lock (Singleton<VehicleManager>.instance) {
                 try {
+                    var logStr = filter.HasValue
+                        ? filter == 0
+                            ? "Nothing (filter == 0)"
+                            : filter.ToString()
+                        : "All vehicles and cims";
+
+                    Log.Info($"Utility Manager: Despawning {logStr}");
+
                     var manager = Singleton<VehicleManager>.instance;
 
                     for (uint vehicleId = 0; vehicleId < manager.m_vehicles.m_size; ++vehicleId) {
@@ -44,7 +52,7 @@ namespace TrafficManager.Manager.Impl {
                     TrafficMeasurementManager.Instance.ResetTrafficStats();
                 }
                 catch (Exception ex) {
-                    Log.Error($"Error occured while trying to clear traffic: {ex}");
+                    Log.Error($"Error occured while trying to despawn vehicles: {ex}");
                 }
             }
         }
@@ -54,6 +62,8 @@ namespace TrafficManager.Manager.Impl {
         public void RemoveParkedVehicles() {
             lock (Singleton<VehicleManager>.instance) {
                 try {
+                    Log.Info("UtilityManager: Despawning parked vehicles");
+
                     VehicleManager vehicleManager = Singleton<VehicleManager>.instance;
 
                     for (uint i = 0; i < vehicleManager.m_parkedVehicles.m_size; ++i) {

--- a/TLM/TLM/Manager/Impl/UtilityManager.cs
+++ b/TLM/TLM/Manager/Impl/UtilityManager.cs
@@ -42,7 +42,7 @@ namespace TrafficManager.Manager.Impl {
                             continue;
                         }
 
-                        if (filter.HasValue && (vehicle.ToExtVehicleType() & filter) != 0) {
+                        if (filter.HasValue && (vehicle.ToExtVehicleType() & filter) == 0) {
                             continue;
                         }
 

--- a/TLM/TLM/State/Options.cs
+++ b/TLM/TLM/State/Options.cs
@@ -120,6 +120,20 @@ namespace TrafficManager.State {
         public static bool PriorityRoad_EnterBlockedYeild = false;
         public static bool PriorityRoad_StopAtEntry = false;
 
+        #region shims: do not perist
+
+        public static bool despawnerAll;
+        public static bool despawnerRoad;
+        public static bool despawnerParked;
+        public static bool despawnerServices;
+        public static bool despawnerTransport;
+        public static bool despawnerPassengerTrains;
+        public static bool despawnerCargoTrains;
+        public static bool despawnerAircraft;
+        public static bool despawnerShips;
+
+        #endregion shims: do not perist
+
         /// <summary>
         /// Invoked on options change to refresh the main menu and possibly update the labels for
         /// a new language. Takes a second, very slow.

--- a/TLM/TLM/State/OptionsTabs/OptionsMaintenanceTab.cs
+++ b/TLM/TLM/State/OptionsTabs/OptionsMaintenanceTab.cs
@@ -8,6 +8,7 @@ namespace TrafficManager.State {
     using TrafficManager.UI;
     using TrafficManager.Lifecycle;
     using ColossalFramework;
+    using System.Collections.Generic;
 
     public static class OptionsMaintenanceTab {
         [UsedImplicitly]
@@ -53,10 +54,6 @@ namespace TrafficManager.State {
             _resetStuckEntitiesBtn = maintenanceGroup.AddButton(
                                          T("Maintenance.Button:Reset stuck cims and vehicles"),
                                          onClickResetStuckEntities) as UIButton;
-
-            _removeParkedVehiclesBtn = maintenanceGroup.AddButton(
-                                           T("Maintenance.Button:Remove parked vehicles"),
-                                           OnClickRemoveParkedVehicles) as UIButton;
 
             _removeAllExistingTrafficLightsBtn = maintenanceGroup.AddButton(
                                            T("Maintenance.Button:Remove all existing traffic lights"),
@@ -120,6 +117,8 @@ namespace TrafficManager.State {
 
             Options.Indent(_turnOnRedEnabledToggle);
 
+            OptionsMaintenanceTab_DespawnGroup.AddUI(panelHelper);
+
             // TODO [issue ##959] remove when TTL is implemented in asset editor.
             bool inEditor = TMPELifecycle.InGameOrEditor()
                             && TMPELifecycle.AppMode != AppMode.Game;
@@ -138,16 +137,6 @@ namespace TrafficManager.State {
 
             Singleton<SimulationManager>.instance.AddAction(
                 () => { UtilityManager.Instance.ResetStuckEntities(); });
-        }
-
-        private static void OnClickRemoveParkedVehicles() {
-            if (!Options.IsGameLoaded()) {
-                return;
-            }
-
-            Singleton<SimulationManager>.instance.AddAction(() => {
-                UtilityManager.Instance.RemoveParkedVehicles();
-            });
         }
 
         private static void OnClickRemoveAllExistingTrafficLights() {

--- a/TLM/TLM/State/OptionsTabs/OptionsMaintenanceTab_DespawnGroup.cs
+++ b/TLM/TLM/State/OptionsTabs/OptionsMaintenanceTab_DespawnGroup.cs
@@ -12,7 +12,7 @@ namespace TrafficManager.State {
     public static class OptionsMaintenanceTab_DespawnGroup {
         public static CheckboxOption DespawnerAll =
             new(nameof(Options.despawnerAll)) {
-                Label = "Despawn.Checkbox:All vehicles and cims",
+                Label = "Despawn.Checkbox:All vehicles",
                 Handler = OnDespawnerAllChange,
             };
         public static CheckboxOption DespawnerRoad =

--- a/TLM/TLM/State/OptionsTabs/OptionsMaintenanceTab_DespawnGroup.cs
+++ b/TLM/TLM/State/OptionsTabs/OptionsMaintenanceTab_DespawnGroup.cs
@@ -1,0 +1,163 @@
+namespace TrafficManager.State {
+    using ColossalFramework;
+    using ICities;
+    using System.Collections.Generic;
+    using TrafficManager.API.Traffic.Enums;
+    using TrafficManager.Lifecycle;
+    using TrafficManager.Manager.Impl;
+    using TrafficManager.UI;
+    using TrafficManager.UI.Helpers;
+
+    public static class OptionsMaintenanceTab_DespawnGroup {
+        public static CheckboxOption DespawnerAll =
+            new(nameof(Options.despawnerAll)) {
+                Label = "Despawn.Checkbox:All vehicles and cims",
+                Handler = OnDespawnerAllChange,
+            };
+        public static CheckboxOption DespawnerRoad =
+            new(nameof(Options.despawnerRoad)) {
+                Label = "Despawn.Checkbox:Road vehicles",
+                Handler = OnDespawnerChange,
+            };
+        public static CheckboxOption DespawnerParked =
+            new(nameof(Options.despawnerParked)) {
+                Label = "Despawn.Checkbox:Parked vehicles",
+                Handler = OnDespawnerChange,
+            };
+        public static CheckboxOption DespawnerServices =
+            new(nameof(Options.despawnerServices)) {
+                Label = "Despawn.Checkbox:Service vehicles",
+                Handler = OnDespawnerChange,
+            };
+        public static CheckboxOption DespawnerTransport =
+            new(nameof(Options.despawnerTransport)) {
+                Label = "Despawn.Checkbox:Public Transport vehicles",
+                Handler = OnDespawnerChange,
+            };
+        public static CheckboxOption DespawnerPassengerTrains =
+            new(nameof(Options.despawnerPassengerTrains)) {
+                Label = "Despawn.Checkbox:Passenger Trains",
+                Handler = OnDespawnerChange,
+            };
+        public static CheckboxOption DespawnerCargoTrains =
+            new(nameof(Options.despawnerCargoTrains)) {
+                Label = "Despawn.Checkbox:Cargo Trains",
+                Handler = OnDespawnerChange,
+            };
+        public static CheckboxOption DespawnerAircraft =
+            new(nameof(Options.despawnerAircraft)) {
+                Label = "Despawn.Checkbox:Aircraft",
+                Handler = OnDespawnerChange,
+            };
+        public static CheckboxOption DespawnerShips =
+            new(nameof(Options.despawnerShips)) {
+                Label = "Despawn.Checkbox:Ships",
+                Handler = OnDespawnerChange,
+            };
+
+        private static readonly Dictionary<CheckboxOption, ExtVehicleType> Despawners = new()
+        {
+            { DespawnerRoad,
+                ExtVehicleType.RoadVehicle },
+            { DespawnerParked,
+                ExtVehicleType.None }, // special case
+            { DespawnerServices,
+                ExtVehicleType.Service |
+                ExtVehicleType.Emergency },
+            { DespawnerTransport,
+                ExtVehicleType.PublicTransport |
+                ExtVehicleType.PassengerFerry |
+                ExtVehicleType.PassengerBlimp |
+                ExtVehicleType.PassengerPlane |
+                ExtVehicleType.PassengerShip },
+            { DespawnerPassengerTrains,
+                ExtVehicleType.PassengerTrain },
+            { DespawnerCargoTrains,
+                ExtVehicleType.CargoTrain },
+            { DespawnerAircraft,
+                ExtVehicleType.Plane |
+                ExtVehicleType.Blimp |
+                ExtVehicleType.Helicopter },
+            { DespawnerShips,
+                ExtVehicleType.Ship |
+                ExtVehicleType.Ferry },
+        };
+
+        // When true, `On...Change` will do nothing
+        private static bool ignoreDespawnerChange = false;
+
+        // Stores the compiled list of selected despawner flags
+        private static ExtVehicleType despawnerFlags = ExtVehicleType.None;
+
+        public static void AddUI(UIHelperBase tab) {
+            if (!TMPELifecycle.PlayMode) return;
+
+            var group = tab.AddGroup(T("Maintenance.Group:Despawn"));
+
+            DespawnerAll.AddUI(group);
+
+            foreach (var despawner in Despawners) {
+                despawner.Key.Indent = true;
+                despawner.Key.AddUI(group);
+            }
+
+            group.AddButton(T("Maintenance.Despawn.Button:Despawn"), OnDespawnButtonClick);
+        }
+
+        private static string T(string text) {
+            return Translation.Options.Get(text);
+        }
+
+        private static void OnDespawnButtonClick() {
+            if (!TMPELifecycle.PlayMode) return;
+
+            if (DespawnerAll) {
+                Singleton<SimulationManager>.instance.AddAction(() => {
+                    UtilityManager.Instance.ClearTraffic();
+                });
+            } else if (despawnerFlags != 0) {
+                Singleton<SimulationManager>.instance.AddAction(() => {
+                    UtilityManager.Instance.DespawnVehicles(despawnerFlags);
+                });
+            }
+
+            if (DespawnerParked) {
+                Singleton<SimulationManager>.instance.AddAction(() => {
+                    UtilityManager.Instance.RemoveParkedVehicles();
+                });
+            }
+        }
+
+        private static void OnDespawnerAllChange(bool seleceted) {
+            if (ignoreDespawnerChange) return;
+            ignoreDespawnerChange = true;
+
+            foreach (var despawner in Despawners) {
+                despawner.Key.Value = seleceted;
+            }
+
+            despawnerFlags = seleceted ? (ExtVehicleType)int.MaxValue : ExtVehicleType.None;
+
+            ignoreDespawnerChange = false;
+        }
+
+        private static void OnDespawnerChange(bool _) {
+            if (ignoreDespawnerChange) return;
+            ignoreDespawnerChange = true;
+
+            int numSelected = 0;
+            despawnerFlags = ExtVehicleType.None;
+
+            foreach (var despawner in Despawners) {
+                if (despawner.Key) {
+                    despawnerFlags |= despawner.Value;
+                    numSelected++;
+                }
+            }
+
+            DespawnerAll.Value = numSelected >= (Despawners.Count - 1);
+
+            ignoreDespawnerChange = false;
+        }
+    }
+}

--- a/TLM/TLM/State/OptionsTabs/OptionsMaintenanceTab_DespawnGroup.cs
+++ b/TLM/TLM/State/OptionsTabs/OptionsMaintenanceTab_DespawnGroup.cs
@@ -147,18 +147,12 @@ namespace TrafficManager.State {
             if (ignoreDespawnerChange) return;
             ignoreDespawnerChange = true;
 
+            ExtVehicleType mask = ExtVehicleType.None;
             int numSelected = 0;
-
-            Log.Info($"Current despawnerMask = {despawnerMask}");
-
-            var mask = ExtVehicleType.None;
 
             foreach (var despawner in Despawners) {
                 if (despawner.Key) {
-                    Log.Info($"mask: {mask}");
-                    Log.Info($"- {despawner.Key.Label}: mask |= {despawner.Value}");
                     mask |= despawner.Value;
-                    Log.Info($"- mask now: {mask}");
                     numSelected++;
                 }
             }
@@ -166,8 +160,6 @@ namespace TrafficManager.State {
             DespawnerAll.Value = numSelected == Despawners.Count;
 
             despawnerMask = DespawnerAll ? null : mask;
-
-            Log.Info($"Despawner mask: {despawnerMask}{(DespawnerParked ? ", Parked" : string.Empty)}");
 
             ignoreDespawnerChange = false;
         }

--- a/TLM/TLM/State/OptionsTabs/OptionsMaintenanceTab_DespawnGroup.cs
+++ b/TLM/TLM/State/OptionsTabs/OptionsMaintenanceTab_DespawnGroup.cs
@@ -155,7 +155,7 @@ namespace TrafficManager.State {
                 }
             }
 
-            DespawnerAll.Value = numSelected >= (Despawners.Count - 1);
+            DespawnerAll.Value = numSelected == Despawners.Count;
 
             ignoreDespawnerChange = false;
         }

--- a/TLM/TLM/TLM.csproj
+++ b/TLM/TLM/TLM.csproj
@@ -146,6 +146,7 @@
     <Compile Include="Manager\Impl\ExtSegmentEndManager.cs" />
     <Compile Include="Manager\Impl\ExtSegmentManager.cs" />
     <Compile Include="Manager\Impl\GeometryNotifier.cs" />
+    <Compile Include="State\OptionsTabs\OptionsMaintenanceTab_DespawnGroup.cs" />
     <Compile Include="State\VersionInfo.cs" />
     <Compile Include="UI\WhatsNew\MarkupKeyword.cs" />
     <Compile Include="UI\WhatsNew\WhatsNewMarkup.cs" />

--- a/TLM/TLM/UI/Localization/LookupTable.cs
+++ b/TLM/TLM/UI/Localization/LookupTable.cs
@@ -9,6 +9,7 @@ namespace TrafficManager.UI.Localization {
     using System.Text;
     using CSUtil.Commons;
     using TrafficManager.U;
+    using TrafficManager.Util;
 
     public class LookupTable {
         public LookupTable(string lookupTableName) {
@@ -44,11 +45,16 @@ namespace TrafficManager.UI.Localization {
             }
 
             // If not found, try also get translation in the default English
-            // Untranslated keys are prefixed with ¶
+            // Untranslated keys are prefixed with ¶ in TEST & DEBUG builds;
+            // in STABLE builds prefix (upto and including `:`) is trimmed.
             return AllLanguages[Translation.DEFAULT_LANGUAGE_CODE]
                        .TryGetValue(key, out string ret2)
                        ? ret2
-                       : "¶" + key;
+                       : (VersionUtil.BRANCH != "STABLE")
+                            ? "¶" + key
+                            : key.IndexOf(":") > 0
+                                ? key.Substring(key.IndexOf(":") + 1)
+                                : key;
         }
 
         public bool HasString(string key) {

--- a/TLM/TLM/Util/Extensions/VehicleExtensions.cs
+++ b/TLM/TLM/Util/Extensions/VehicleExtensions.cs
@@ -1,5 +1,16 @@
+using ColossalFramework;
+using TrafficManager.API.Traffic.Enums;
+using TrafficManager.Manager.Impl;
+
 namespace TrafficManager.Util.Extensions {
     public static class VehicleExtensions {
+        private static Vehicle[] _vehBuffer = Singleton<VehicleManager>.instance.m_vehicles.m_buffer;
+
+        /// <summary>Returns a reference to the vehicle instance.</summary>
+        /// <param name="vehicleId">The ID of the vehicle instance to obtain.</param>
+        /// <returns>The vehicle instance.</returns>
+        public static ref Vehicle ToVehicle(this ushort vehicleId) => ref _vehBuffer[vehicleId];
+
         /// <summary>
         /// Checks if the vehicle is Created, but not Deleted.
         /// </summary>
@@ -9,5 +20,29 @@ namespace TrafficManager.Util.Extensions {
             vehicle.m_flags.CheckFlags(
                 required: Vehicle.Flags.Created,
                 forbidden: Vehicle.Flags.Deleted);
+
+        /// <summary>Queues the vehicle to be despawned.</summary>
+        /// <param name="vehicle">The vehicle instance to despawn.</param>
+        // TODO: Would vehicle.Unspawn() be viable/better approach?
+        public static void Despawn(this Vehicle vehicle) =>
+            Singleton<SimulationManager>.instance.AddAction(() =>
+                Singleton<VehicleManager>.instance.ReleaseVehicle(vehicle.Info.m_instanceID.Vehicle));
+
+        /// <summary>Determines the <see cref="ExtVehicleType"/> for a vehicle.</summary>
+        /// <param name="vehicle">The vehocle to inspect.</param>
+        /// <returns>The extended vehicle type.</returns>
+        public static ExtVehicleType ToExtVehicleType(this ref Vehicle vehicle) {
+            var vehicleId = vehicle.Info.m_instanceID.Vehicle;
+            var vehicleAI = vehicle.Info.m_vehicleAI;
+            var emergency = vehicle.m_flags.IsFlagSet(Vehicle.Flags.Emergency2);
+
+            var ret = ExtVehicleManager.Instance.DetermineVehicleTypeFromAIType(
+                vehicleId,
+                vehicleAI,
+                emergency);
+
+            return ret ?? ExtVehicleType.None;
+        }
+
     }
 }

--- a/TLM/TLM/Util/Extensions/VehicleExtensions.cs
+++ b/TLM/TLM/Util/Extensions/VehicleExtensions.cs
@@ -21,18 +21,6 @@ namespace TrafficManager.Util.Extensions {
                 required: Vehicle.Flags.Created,
                 forbidden: Vehicle.Flags.Deleted);
 
-        /// <summary>Queues the vehicle to be despawned.</summary>
-        /// <param name="vehicle">The vehicle instance to despawn.</param>
-        /// <remarks>
-        /// Don't use to despawn large numbers of vehicles as it will
-        /// spam SimulationManager with queued items; for many vehicles
-        /// use <see cref="UtilityManager.DespawnVehicles(ExtVehicleType?)"/> instead.
-        /// </remarks>
-        // TODO: Would vehicle.Unspawn() be viable/better approach?
-        public static void Despawn(this Vehicle vehicle) =>
-            Singleton<SimulationManager>.instance.AddAction(() =>
-                Singleton<VehicleManager>.instance.ReleaseVehicle(vehicle.Info.m_instanceID.Vehicle));
-
         /// <summary>Determines the <see cref="ExtVehicleType"/> for a vehicle.</summary>
         /// <param name="vehicle">The vehocle to inspect.</param>
         /// <returns>The extended vehicle type.</returns>

--- a/TLM/TLM/Util/Extensions/VehicleExtensions.cs
+++ b/TLM/TLM/Util/Extensions/VehicleExtensions.cs
@@ -23,6 +23,11 @@ namespace TrafficManager.Util.Extensions {
 
         /// <summary>Queues the vehicle to be despawned.</summary>
         /// <param name="vehicle">The vehicle instance to despawn.</param>
+        /// <remarks>
+        /// Don't use to despawn large numbers of vehicles as it will
+        /// spam SimulationManager with queued items; for many vehicles
+        /// use <see cref="UtilityManager.DespawnVehicles(ExtVehicleType?)"/> instead.
+        /// </remarks>
         // TODO: Would vehicle.Unspawn() be viable/better approach?
         public static void Despawn(this Vehicle vehicle) =>
             Singleton<SimulationManager>.instance.AddAction(() =>


### PR DESCRIPTION
Fixes: #270
Updates: #833

[TMPE.zip](https://ci.appveyor.com/api/buildjobs/amln5qhgh9ltk6qt/artifacts/TMPE.zip)

* Adds several vehicle-related extensions (see commits)
* Create a filterable (by `ExtVehicleType`) `DespawnVehicles()` method in `UtilityManager`.
* Add an in-game-only checkbox group to Maintenance tab allowing user to filter and despawn
* Beautify missing locale keys, but only in STABLE builds (all strings in image below are missing locale keys)

> Edit: Image below is outdated; the text `and cims` was removed from the `All...` option as cims are handled by entirely different AI.

![image](https://user-images.githubusercontent.com/1386719/151744086-0149bb96-ccc5-499a-8d6e-ce6d5efc5a08.png)

Toggling `All vehicles and cims` checkbox will apply the result to all indented checkbox below. Checking all indented checkbox will result in the `All...` checkbox being checked; and unchecking one or more indented checkbox will result in `All...` being unchecked.

Note that `Parked Vehicles` is handled as a speical case; when `Despawn` button is clicked, it checks that setting individually and queues relevant manager instance method (`RemoveParkedVehicles()`).

<details><summary>List of filters that can be used by `UtilityManager.Instance.DespawnVehicles()` for reference</summary>

```csharp
    [Flags]
    public enum ExtVehicleType {
        None = 0,
        PassengerCar = 1,
        Bus = 1 << 1,
        Taxi = 1 << 2,
        CargoTruck = 1 << 3,
        Service = 1 << 4,
        Emergency = 1 << 5,
        PassengerTrain = 1 << 6,
        CargoTrain = 1 << 7,
        Tram = 1 << 8,
        Bicycle = 1 << 9,
        Pedestrian = 1 << 10,
        PassengerShip = 1 << 11,
        CargoShip = 1 << 12,
        PassengerPlane = 1 << 13,
        Helicopter = 1 << 14,
        CableCar = 1 << 15,
        PassengerFerry = 1 << 16,
        PassengerBlimp = 1 << 17,
        CargoPlane = 1 << 18,
        Trolleybus = 1 << 19,
        Plane = PassengerPlane | CargoPlane,
        Ship = PassengerShip | CargoShip,
        CargoVehicle = CargoTruck | CargoTrain | CargoShip | CargoPlane,
        PublicTransport = Bus | Taxi | Tram | PassengerTrain | Trolleybus,
        RoadPublicTransport = Bus | Taxi | Trolleybus,
        RoadVehicle = PassengerCar | Bus | Taxi | CargoTruck | Service | Emergency, //may perform u-turn
        RailVehicle = PassengerTrain | CargoTrain,
        NonTransportRoadVehicle = RoadVehicle & ~PublicTransport,
        Ferry = PassengerFerry,
        Blimp = PassengerBlimp,
    }
```
</details>

Although this is a non-trivial change, I'd like to request it go in to 11.6.4.4 release as it will help users despawn their aircraft should they be stuck due to pathfinding issues tackled in PR #1338