### PR TITLE
Pathfinder update despawner

### DIFF
--- a/TLM/TLM/Custom/PathFinding/PathfinderUpdates.cs
+++ b/TLM/TLM/Custom/PathFinding/PathfinderUpdates.cs
@@ -1,0 +1,62 @@
+namespace TrafficManager.Custom.PathFinding {
+    using ColossalFramework;
+    using CSUtil.Commons;
+    using System.Diagnostics.CodeAnalysis;
+    using TrafficManager.API.Traffic.Enums;
+    using TrafficManager.Manager.Impl;
+    using TrafficManager.State;
+
+    /// <summary>
+    /// When a bug is fixed in pathfinder, update this class:
+    ///
+    /// 1. Increment LatestEdition number below
+    /// 2. Define all ExtVehicleType that need despawning for _that_ edition
+    /// </summary>
+    public static class PathfinderUpdates {
+
+        // Edition History:
+        // 0 - An old save, unknown pathfinder edition
+        // 1 - #1338 Aircraft pathfinding fix
+
+        /// <summary>
+        /// Update this each time a despawn-requiring change is
+        /// made to <see cref="TrafficManager.Custom.PathFinding"/>
+        /// or anything else path-related which merits targeted
+        /// vehicle despawning.
+        /// </summary>
+        [SuppressMessage("Usage", "RAS0002:Readonly field for a non-readonly struct", Justification = "Not performance critical.")]
+        private static readonly byte LatestPathfinderEdition = 1;
+
+        /// <summary>
+        /// Checks savegame pathfinder edition and, if necessary, despawns
+        /// any vehicles that might have invalid paths due to bugs in the
+        /// earlier pathfinder edition used when the save was created.
+        /// </summary>
+        /// <returns>
+        /// Returns the <see cref="ExtVehicleType"/> of vehicles that were despawned.
+        /// </returns>
+        public static ExtVehicleType DespawnVehiclesIfNecessary() {
+            var filter = ExtVehicleType.None;
+
+            if (Options.SavegamePathfinderEdition == LatestPathfinderEdition) {
+                return filter; // nothing to do, everything is fine
+            }
+
+            Log.Info($"Pathfinder update from {Options.SavegamePathfinderEdition} to {LatestPathfinderEdition}.");
+
+            if (Options.SavegamePathfinderEdition < 1) {
+                filter |= ExtVehicleType.Plane; // #1338
+            }
+
+            // this will also log what gets despawned
+            Singleton<SimulationManager>.instance.AddAction(() => {
+                UtilityManager.Instance.DespawnVehicles(filter);
+            });
+
+            // this will be stored in savegame
+            Options.SavegamePathfinderEdition = LatestPathfinderEdition;
+
+            return filter;
+        }
+    }
+}

--- a/TLM/TLM/Lifecycle/TMPELifecycle.cs
+++ b/TLM/TLM/Lifecycle/TMPELifecycle.cs
@@ -19,6 +19,8 @@ namespace TrafficManager.Lifecycle {
     using JetBrains.Annotations;
     using UI.WhatsNew;
     using System.Diagnostics.CodeAnalysis;
+    using TrafficManager.UI.Helpers;
+    using TrafficManager.API.Traffic.Enums;
 
     /// <summary>
     /// Do not use Singleton<TMPELifecycle>.instance to prevent memory leak.
@@ -280,6 +282,18 @@ namespace TrafficManager.Lifecycle {
                 // after all TMPE rules are applied.
                 GeometryNotifierDisposable = GeometryManager.Instance.Subscribe(new GeometryNotifier());
                 Notifier.Instance.OnLevelLoaded();
+
+                if (PlayMode) {
+                    var despawned = PathfinderUpdates.DespawnVehiclesIfNecessary();
+
+                    if (despawned != ExtVehicleType.None) {
+                        Prompt.Warning(
+                            "TM:PE Pathfinder Update",
+                            "Some vehicles were using outdated paths and have been despawned: "
+                            + despawned.ToString());
+                    }
+                }
+
                 Log.Info("OnLevelLoaded complete.");
             } catch (Exception ex) {
                 ex.LogException(true);

--- a/TLM/TLM/Manager/Impl/OptionsManager.cs
+++ b/TLM/TLM/Manager/Impl/OptionsManager.cs
@@ -142,11 +142,14 @@ namespace TrafficManager.Manager.Impl {
 
             ToCheckbox(data, idx: 56, OptionsVehicleRestrictionsTab.NoDoubleCrossings);
             ToCheckbox(data, idx: 57, OptionsVehicleRestrictionsTab.DedicatedTurningLanes);
+
+            Options.SavegamePathfinderEdition = LoadByte(data, idx: 58, defaultVal: 0);
+
             return true;
         }
 
         public byte[] SaveData(ref bool success) {
-            var save = new byte[57];
+            var save = new byte[59];
 
             save[0] = ConvertFromSimulationAccuracy(Options.simulationAccuracy);
             save[1] = 0; // Options.laneChangingRandomization
@@ -210,6 +213,8 @@ namespace TrafficManager.Manager.Impl {
 
             save[56] = OptionsVehicleRestrictionsTab.NoDoubleCrossings.Save();
             save[57] = OptionsVehicleRestrictionsTab.DedicatedTurningLanes.Save();
+
+            save[58] = (byte)Options.SavegamePathfinderEdition;
 
             return save;
         }

--- a/TLM/TLM/State/Options.cs
+++ b/TLM/TLM/State/Options.cs
@@ -120,6 +120,9 @@ namespace TrafficManager.State {
         public static bool PriorityRoad_EnterBlockedYeild = false;
         public static bool PriorityRoad_StopAtEntry = false;
 
+        // See PathfinderUpdates.cs
+        public static byte SavegamePathfinderEdition = 0;
+
         #region shims: do not perist
 
         public static bool despawnerAll;

--- a/TLM/TLM/TLM.csproj
+++ b/TLM/TLM/TLM.csproj
@@ -134,6 +134,7 @@
       <Link>Properties\SharedAssemblyInfo.cs</Link>
     </Compile>
     <Compile Include="Constants.cs" />
+    <Compile Include="Custom\PathFinding\PathfinderUpdates.cs" />
     <Compile Include="Geometry\Impl\SegmentEndId.cs" />
     <Compile Include="Lifecycle\Patcher.cs" />
     <Compile Include="Lifecycle\TMPELifecycle.cs" />


### PR DESCRIPTION
Fixes: #485

This adds ability to define and check pathfinder "edition" used for a savegame and, if necessary, despawn specific categories of vehicle that might have bad paths due to bugs in earlier versions of pathfinder.

The first use of this is TM:PE 11.6.4.4 which fixed a pathfinder bug affecting planes; so despawn planes when a save using older pathfinder is loaded.

- Add new `byte` option: `Options.SavegamePathfinderEdition`
     - Value defaults to `0` (unknown edition; ie. older savegame before this PR was added)
- Add `PathfinderUpdates` class to manage the version check
     - `LatestPathfinderEdition` needs updating when necessary
     - If save edition != latest edition:
          - Add relevant `ExtVehicleType` flags to `filter` as applicable
          - Despawn everything matching `filter` (see #1341 for how that works)
          - Update `Options.SavegamePathfinderEdition = LatestPathfinderEdition`
- In `TMPELifecycle.Load()` trigger the process (in `PlayMode` only)
    - If something despawned, show message to let user know