### PR TITLE
Catch + log any load/save errors in `OptionsManager`

### DIFF
--- a/TLM/TLM/Manager/Impl/OptionsManager.cs
+++ b/TLM/TLM/Manager/Impl/OptionsManager.cs
@@ -7,6 +7,7 @@ namespace TrafficManager.Manager.Impl {
     using TrafficManager.UI.Helpers;
     using TrafficManager.Lifecycle;
     using JetBrains.Annotations;
+    using TrafficManager.Util;
 
     public class OptionsManager
         : AbstractCustomManager,
@@ -86,7 +87,7 @@ namespace TrafficManager.Manager.Impl {
                 OptionsVehicleRestrictionsTab.SetAllowUTurns(LoadBool(data, idx: 13));
                 OptionsVehicleRestrictionsTab.SetAllowLaneChangesWhileGoingStraight(LoadBool(data, idx: 14));
                 OptionsGameplayTab.SetDisableDespawning(!LoadBool(data, idx: 15)); // inverted
-                                                                                   // skip Options.setDynamicPathRecalculation(data[16] == (byte)1);
+                // skip Options.setDynamicPathRecalculation(data[16] == (byte)1);
                 OptionsOverlaysTab.SetConnectedLanesOverlay(LoadBool(data, idx: 17));
                 OptionsVehicleRestrictionsTab.SetPrioritySignsEnabled(LoadBool(data, idx: 18));
                 OptionsVehicleRestrictionsTab.SetTimedLightsEnabled(LoadBool(data, idx: 19));
@@ -148,7 +149,7 @@ namespace TrafficManager.Manager.Impl {
                 return true;
             }
             catch (Exception ex) {
-                Log.Error(ex.ToString());
+                ex.LogException();
                 return false;
             }
         }
@@ -227,7 +228,7 @@ namespace TrafficManager.Manager.Impl {
                 return save;
             }
             catch (Exception ex) {
-                Log.Error(ex.ToString());
+                ex.LogException();
                 return save; // try and salvage some of the settings
             }
         }

--- a/TLM/TLM/Manager/Impl/OptionsManager.cs
+++ b/TLM/TLM/Manager/Impl/OptionsManager.cs
@@ -69,154 +69,167 @@ namespace TrafficManager.Manager.Impl {
         }
 
         public bool LoadData(byte[] data) {
-            OptionsGeneralTab.SetSimulationAccuracy(ConvertToSimulationAccuracy(LoadByte(data, idx: 0)));
-            // skip Options.setLaneChangingRandomization(options[1]);
-            OptionsGameplayTab.SetRecklessDrivers(LoadByte(data, idx: 2));
-            OptionsVehicleRestrictionsTab.SetRelaxedBusses(LoadBool(data, idx: 3));
-            OptionsOverlaysTab.SetNodesOverlay(LoadBool(data, idx: 4));
-            OptionsVehicleRestrictionsTab.SetMayEnterBlockedJunctions(LoadBool(data, idx: 5));
-            OptionsGameplayTab.SetAdvancedAi(LoadBool(data, idx: 6));
-            OptionsVehicleRestrictionsTab.SetHighwayRules(LoadBool(data, idx: 7));
-            OptionsOverlaysTab.SetPrioritySignsOverlay(LoadBool(data, idx: 8));
-            OptionsOverlaysTab.SetTimedLightsOverlay(LoadBool(data, idx: 9));
-            OptionsOverlaysTab.SetSpeedLimitsOverlay(LoadBool(data, idx: 10));
-            OptionsOverlaysTab.SetVehicleRestrictionsOverlay(LoadBool(data, idx: 11));
-            OptionsGameplayTab.SetStrongerRoadConditionEffects(LoadBool(data, idx: 12));
-            OptionsVehicleRestrictionsTab.SetAllowUTurns(LoadBool(data, idx: 13));
-            OptionsVehicleRestrictionsTab.SetAllowLaneChangesWhileGoingStraight(LoadBool(data, idx: 14));
-            OptionsGameplayTab.SetDisableDespawning(!LoadBool(data, idx: 15)); // inverted
-            // skip Options.setDynamicPathRecalculation(data[16] == (byte)1);
-            OptionsOverlaysTab.SetConnectedLanesOverlay(LoadBool(data, idx: 17));
-            OptionsVehicleRestrictionsTab.SetPrioritySignsEnabled(LoadBool(data, idx: 18));
-            OptionsVehicleRestrictionsTab.SetTimedLightsEnabled(LoadBool(data, idx: 19));
-            OptionsMaintenanceTab.SetCustomSpeedLimitsEnabled(LoadBool(data, idx: 20));
-            OptionsMaintenanceTab.SetVehicleRestrictionsEnabled(LoadBool(data, idx: 21));
-            OptionsMaintenanceTab.SetLaneConnectorEnabled(LoadBool(data, idx: 22));
-            OptionsOverlaysTab.SetJunctionRestrictionsOverlay(LoadBool(data, idx: 23));
-            OptionsMaintenanceTab.SetJunctionRestrictionsEnabled(LoadBool(data, idx: 24));
-            OptionsGameplayTab.SetProhibitPocketCars(LoadBool(data, idx: 25));
-            OptionsVehicleRestrictionsTab.SetPreferOuterLane(LoadBool(data, idx: 26));
-            OptionsGameplayTab.SetIndividualDrivingStyle(LoadBool(data, idx: 27));
-            OptionsVehicleRestrictionsTab.SetEvacBussesMayIgnoreRules(LoadBool(data, idx: 28));
-            OptionsGeneralTab.SetInstantEffects(LoadBool(data, idx: 29));
-            OptionsMaintenanceTab.SetParkingRestrictionsEnabled(LoadBool(data, idx: 30));
-            OptionsOverlaysTab.SetParkingRestrictionsOverlay(LoadBool(data, idx: 31));
-            OptionsVehicleRestrictionsTab.SetBanRegularTrafficOnBusLanes(LoadBool(data, idx: 32));
-            OptionsMaintenanceTab.SetShowPathFindStats(LoadBool(data, idx: 33));
-            OptionsGameplayTab.SetDLSPercentage(LoadByte(data, idx: 34));
+            try {
+                OptionsGeneralTab.SetSimulationAccuracy(ConvertToSimulationAccuracy(LoadByte(data, idx: 0)));
+                // skip Options.setLaneChangingRandomization(options[1]);
+                OptionsGameplayTab.SetRecklessDrivers(LoadByte(data, idx: 2));
+                OptionsVehicleRestrictionsTab.SetRelaxedBusses(LoadBool(data, idx: 3));
+                OptionsOverlaysTab.SetNodesOverlay(LoadBool(data, idx: 4));
+                OptionsVehicleRestrictionsTab.SetMayEnterBlockedJunctions(LoadBool(data, idx: 5));
+                OptionsGameplayTab.SetAdvancedAi(LoadBool(data, idx: 6));
+                OptionsVehicleRestrictionsTab.SetHighwayRules(LoadBool(data, idx: 7));
+                OptionsOverlaysTab.SetPrioritySignsOverlay(LoadBool(data, idx: 8));
+                OptionsOverlaysTab.SetTimedLightsOverlay(LoadBool(data, idx: 9));
+                OptionsOverlaysTab.SetSpeedLimitsOverlay(LoadBool(data, idx: 10));
+                OptionsOverlaysTab.SetVehicleRestrictionsOverlay(LoadBool(data, idx: 11));
+                OptionsGameplayTab.SetStrongerRoadConditionEffects(LoadBool(data, idx: 12));
+                OptionsVehicleRestrictionsTab.SetAllowUTurns(LoadBool(data, idx: 13));
+                OptionsVehicleRestrictionsTab.SetAllowLaneChangesWhileGoingStraight(LoadBool(data, idx: 14));
+                OptionsGameplayTab.SetDisableDespawning(!LoadBool(data, idx: 15)); // inverted
+                                                                                   // skip Options.setDynamicPathRecalculation(data[16] == (byte)1);
+                OptionsOverlaysTab.SetConnectedLanesOverlay(LoadBool(data, idx: 17));
+                OptionsVehicleRestrictionsTab.SetPrioritySignsEnabled(LoadBool(data, idx: 18));
+                OptionsVehicleRestrictionsTab.SetTimedLightsEnabled(LoadBool(data, idx: 19));
+                OptionsMaintenanceTab.SetCustomSpeedLimitsEnabled(LoadBool(data, idx: 20));
+                OptionsMaintenanceTab.SetVehicleRestrictionsEnabled(LoadBool(data, idx: 21));
+                OptionsMaintenanceTab.SetLaneConnectorEnabled(LoadBool(data, idx: 22));
+                OptionsOverlaysTab.SetJunctionRestrictionsOverlay(LoadBool(data, idx: 23));
+                OptionsMaintenanceTab.SetJunctionRestrictionsEnabled(LoadBool(data, idx: 24));
+                OptionsGameplayTab.SetProhibitPocketCars(LoadBool(data, idx: 25));
+                OptionsVehicleRestrictionsTab.SetPreferOuterLane(LoadBool(data, idx: 26));
+                OptionsGameplayTab.SetIndividualDrivingStyle(LoadBool(data, idx: 27));
+                OptionsVehicleRestrictionsTab.SetEvacBussesMayIgnoreRules(LoadBool(data, idx: 28));
+                OptionsGeneralTab.SetInstantEffects(LoadBool(data, idx: 29));
+                OptionsMaintenanceTab.SetParkingRestrictionsEnabled(LoadBool(data, idx: 30));
+                OptionsOverlaysTab.SetParkingRestrictionsOverlay(LoadBool(data, idx: 31));
+                OptionsVehicleRestrictionsTab.SetBanRegularTrafficOnBusLanes(LoadBool(data, idx: 32));
+                OptionsMaintenanceTab.SetShowPathFindStats(LoadBool(data, idx: 33));
+                OptionsGameplayTab.SetDLSPercentage(LoadByte(data, idx: 34));
 
-            if (data.Length > 35) {
-                try {
-                    OptionsVehicleRestrictionsTab.SetVehicleRestrictionsAggression(
-                        (VehicleRestrictionsAggression)data[35]);
+                if (data.Length > 35) {
+                    try {
+                        OptionsVehicleRestrictionsTab.SetVehicleRestrictionsAggression(
+                            (VehicleRestrictionsAggression)data[35]);
+                    }
+                    catch (Exception e) {
+                        Log.Warning(
+                            $"Skipping invalid value {data[35]} for vehicle restrictions aggression");
+                    }
                 }
-                catch (Exception e) {
-                    Log.Warning(
-                        $"Skipping invalid value {data[35]} for vehicle restrictions aggression");
-                }
+
+                OptionsVehicleRestrictionsTab.SetTrafficLightPriorityRules(LoadBool(data, idx: 36));
+                OptionsGameplayTab.SetRealisticPublicTransport(LoadBool(data, idx: 37));
+                OptionsMaintenanceTab.SetTurnOnRedEnabled(LoadBool(data, idx: 38));
+                OptionsVehicleRestrictionsTab.SetAllowNearTurnOnRed(LoadBool(data, idx: 39));
+                OptionsVehicleRestrictionsTab.SetAllowFarTurnOnRed(LoadBool(data, idx: 40));
+                OptionsVehicleRestrictionsTab.SetAddTrafficLightsIfApplicable(LoadBool(data, idx: 41));
+
+                ToCheckbox(data, idx: 42, OptionsMassEditTab.RoundAboutQuickFix_StayInLaneMainR);
+                ToCheckbox(data, idx: 43, OptionsMassEditTab.RoundAboutQuickFix_StayInLaneNearRabout);
+                ToCheckbox(data, idx: 44, OptionsMassEditTab.RoundAboutQuickFix_DedicatedExitLanes);
+                ToCheckbox(data, idx: 45, OptionsMassEditTab.RoundAboutQuickFix_NoCrossMainR);
+                ToCheckbox(data, idx: 46, OptionsMassEditTab.RoundAboutQuickFix_NoCrossYieldR);
+                ToCheckbox(data, idx: 47, OptionsMassEditTab.RoundAboutQuickFix_PrioritySigns);
+
+                ToCheckbox(data, idx: 48, OptionsMassEditTab.PriorityRoad_CrossMainR);
+                ToCheckbox(data, idx: 49, OptionsMassEditTab.PriorityRoad_AllowLeftTurns);
+                ToCheckbox(data, idx: 50, OptionsMassEditTab.PriorityRoad_EnterBlockedYeild);
+                ToCheckbox(data, idx: 51, OptionsMassEditTab.PriorityRoad_StopAtEntry);
+
+                ToCheckbox(data, idx: 52, OptionsMassEditTab.RoundAboutQuickFix_KeepClearYieldR);
+                ToCheckbox(data, idx: 53, OptionsMassEditTab.RoundAboutQuickFix_RealisticSpeedLimits);
+                ToCheckbox(data, idx: 54, OptionsMassEditTab.RoundAboutQuickFix_ParkingBanMainR);
+                ToCheckbox(data, idx: 55, OptionsMassEditTab.RoundAboutQuickFix_ParkingBanYieldR);
+
+                ToCheckbox(data, idx: 56, OptionsVehicleRestrictionsTab.NoDoubleCrossings);
+                ToCheckbox(data, idx: 57, OptionsVehicleRestrictionsTab.DedicatedTurningLanes);
+
+                Options.SavegamePathfinderEdition = LoadByte(data, idx: 58, defaultVal: 0);
+                return true;
             }
-
-            OptionsVehicleRestrictionsTab.SetTrafficLightPriorityRules(LoadBool(data, idx: 36));
-            OptionsGameplayTab.SetRealisticPublicTransport(LoadBool(data, idx: 37));
-            OptionsMaintenanceTab.SetTurnOnRedEnabled(LoadBool(data, idx: 38));
-            OptionsVehicleRestrictionsTab.SetAllowNearTurnOnRed(LoadBool(data, idx: 39));
-            OptionsVehicleRestrictionsTab.SetAllowFarTurnOnRed(LoadBool(data, idx: 40));
-            OptionsVehicleRestrictionsTab.SetAddTrafficLightsIfApplicable(LoadBool(data, idx: 41));
-
-            ToCheckbox(data, idx: 42, OptionsMassEditTab.RoundAboutQuickFix_StayInLaneMainR);
-            ToCheckbox(data, idx: 43, OptionsMassEditTab.RoundAboutQuickFix_StayInLaneNearRabout);
-            ToCheckbox(data, idx: 44, OptionsMassEditTab.RoundAboutQuickFix_DedicatedExitLanes);
-            ToCheckbox(data, idx: 45, OptionsMassEditTab.RoundAboutQuickFix_NoCrossMainR);
-            ToCheckbox(data, idx: 46, OptionsMassEditTab.RoundAboutQuickFix_NoCrossYieldR);
-            ToCheckbox(data, idx: 47, OptionsMassEditTab.RoundAboutQuickFix_PrioritySigns);
-
-            ToCheckbox(data, idx: 48, OptionsMassEditTab.PriorityRoad_CrossMainR);
-            ToCheckbox(data, idx: 49, OptionsMassEditTab.PriorityRoad_AllowLeftTurns);
-            ToCheckbox(data, idx: 50, OptionsMassEditTab.PriorityRoad_EnterBlockedYeild);
-            ToCheckbox(data, idx: 51, OptionsMassEditTab.PriorityRoad_StopAtEntry);
-
-            ToCheckbox(data, idx: 52, OptionsMassEditTab.RoundAboutQuickFix_KeepClearYieldR);
-            ToCheckbox(data, idx: 53, OptionsMassEditTab.RoundAboutQuickFix_RealisticSpeedLimits);
-            ToCheckbox(data, idx: 54, OptionsMassEditTab.RoundAboutQuickFix_ParkingBanMainR);
-            ToCheckbox(data, idx: 55, OptionsMassEditTab.RoundAboutQuickFix_ParkingBanYieldR);
-
-            ToCheckbox(data, idx: 56, OptionsVehicleRestrictionsTab.NoDoubleCrossings);
-            ToCheckbox(data, idx: 57, OptionsVehicleRestrictionsTab.DedicatedTurningLanes);
-
-            Options.SavegamePathfinderEdition = LoadByte(data, idx: 58, defaultVal: 0);
-
-            return true;
+            catch (Exception ex) {
+                Log.Error(ex.ToString());
+                return false;
+            }
         }
 
         public byte[] SaveData(ref bool success) {
+
+            // Remember to update this when adding new options (lastIdx + 1)
             var save = new byte[59];
 
-            save[0] = ConvertFromSimulationAccuracy(Options.simulationAccuracy);
-            save[1] = 0; // Options.laneChangingRandomization
-            save[2] = (byte)Options.recklessDrivers;
-            save[3] = (byte)(Options.relaxedBusses ? 1 : 0);
-            save[4] = (byte)(Options.nodesOverlay ? 1 : 0);
-            save[5] = (byte)(Options.allowEnterBlockedJunctions ? 1 : 0);
-            save[6] = (byte)(Options.advancedAI ? 1 : 0);
-            save[7] = (byte)(Options.highwayRules ? 1 : 0);
-            save[8] = (byte)(Options.prioritySignsOverlay ? 1 : 0);
-            save[9] = (byte)(Options.timedLightsOverlay ? 1 : 0);
-            save[10] = (byte)(Options.speedLimitsOverlay ? 1 : 0);
-            save[11] = (byte)(Options.vehicleRestrictionsOverlay ? 1 : 0);
-            save[12] = (byte)(Options.strongerRoadConditionEffects ? 1 : 0);
-            save[13] = (byte)(Options.allowUTurns ? 1 : 0);
-            save[14] = (byte)(Options.allowLaneChangesWhileGoingStraight ? 1 : 0);
-            save[15] = (byte)(Options.disableDespawning ? 0 : 1);
-            save[16] = 0; // Options.IsDynamicPathRecalculationActive
-            save[17] = (byte)(Options.connectedLanesOverlay ? 1 : 0);
-            save[18] = (byte)(Options.prioritySignsEnabled ? 1 : 0);
-            save[19] = (byte)(Options.timedLightsEnabled ? 1 : 0);
-            save[20] = (byte)(Options.customSpeedLimitsEnabled ? 1 : 0);
-            save[21] = (byte)(Options.vehicleRestrictionsEnabled ? 1 : 0);
-            save[22] = (byte)(Options.laneConnectorEnabled ? 1 : 0);
-            save[23] = (byte)(Options.junctionRestrictionsOverlay ? 1 : 0);
-            save[24] = (byte)(Options.junctionRestrictionsEnabled ? 1 : 0);
-            save[25] = (byte)(Options.parkingAI ? 1 : 0);
-            save[26] = (byte)(Options.preferOuterLane ? 1 : 0);
-            save[27] = (byte)(Options.individualDrivingStyle ? 1 : 0);
-            save[28] = (byte)(Options.evacBussesMayIgnoreRules ? 1 : 0);
-            save[29] = (byte)(Options.instantEffects ? 1 : 0);
-            save[30] = (byte)(Options.parkingRestrictionsEnabled ? 1 : 0);
-            save[31] = (byte)(Options.parkingRestrictionsOverlay ? 1 : 0);
-            save[32] = (byte)(Options.banRegularTrafficOnBusLanes ? 1 : 0);
-            save[33] = (byte)(Options.showPathFindStats ? 1 : 0);
-            save[34] = Options.altLaneSelectionRatio;
-            save[35] = (byte)Options.vehicleRestrictionsAggression;
-            save[36] = (byte)(Options.trafficLightPriorityRules ? 1 : 0);
-            save[37] = (byte)(Options.realisticPublicTransport ? 1 : 0);
-            save[38] = (byte)(Options.turnOnRedEnabled ? 1 : 0);
-            save[39] = (byte)(Options.allowNearTurnOnRed ? 1 : 0);
-            save[40] = (byte)(Options.allowFarTurnOnRed ? 1 : 0);
-            save[41] = (byte)(Options.automaticallyAddTrafficLightsIfApplicable ? 1 : 0);
+            try {
+                save[0] = ConvertFromSimulationAccuracy(Options.simulationAccuracy);
+                save[1] = 0; // Options.laneChangingRandomization
+                save[2] = (byte)Options.recklessDrivers;
+                save[3] = (byte)(Options.relaxedBusses ? 1 : 0);
+                save[4] = (byte)(Options.nodesOverlay ? 1 : 0);
+                save[5] = (byte)(Options.allowEnterBlockedJunctions ? 1 : 0);
+                save[6] = (byte)(Options.advancedAI ? 1 : 0);
+                save[7] = (byte)(Options.highwayRules ? 1 : 0);
+                save[8] = (byte)(Options.prioritySignsOverlay ? 1 : 0);
+                save[9] = (byte)(Options.timedLightsOverlay ? 1 : 0);
+                save[10] = (byte)(Options.speedLimitsOverlay ? 1 : 0);
+                save[11] = (byte)(Options.vehicleRestrictionsOverlay ? 1 : 0);
+                save[12] = (byte)(Options.strongerRoadConditionEffects ? 1 : 0);
+                save[13] = (byte)(Options.allowUTurns ? 1 : 0);
+                save[14] = (byte)(Options.allowLaneChangesWhileGoingStraight ? 1 : 0);
+                save[15] = (byte)(Options.disableDespawning ? 0 : 1);
+                save[16] = 0; // Options.IsDynamicPathRecalculationActive
+                save[17] = (byte)(Options.connectedLanesOverlay ? 1 : 0);
+                save[18] = (byte)(Options.prioritySignsEnabled ? 1 : 0);
+                save[19] = (byte)(Options.timedLightsEnabled ? 1 : 0);
+                save[20] = (byte)(Options.customSpeedLimitsEnabled ? 1 : 0);
+                save[21] = (byte)(Options.vehicleRestrictionsEnabled ? 1 : 0);
+                save[22] = (byte)(Options.laneConnectorEnabled ? 1 : 0);
+                save[23] = (byte)(Options.junctionRestrictionsOverlay ? 1 : 0);
+                save[24] = (byte)(Options.junctionRestrictionsEnabled ? 1 : 0);
+                save[25] = (byte)(Options.parkingAI ? 1 : 0);
+                save[26] = (byte)(Options.preferOuterLane ? 1 : 0);
+                save[27] = (byte)(Options.individualDrivingStyle ? 1 : 0);
+                save[28] = (byte)(Options.evacBussesMayIgnoreRules ? 1 : 0);
+                save[29] = (byte)(Options.instantEffects ? 1 : 0);
+                save[30] = (byte)(Options.parkingRestrictionsEnabled ? 1 : 0);
+                save[31] = (byte)(Options.parkingRestrictionsOverlay ? 1 : 0);
+                save[32] = (byte)(Options.banRegularTrafficOnBusLanes ? 1 : 0);
+                save[33] = (byte)(Options.showPathFindStats ? 1 : 0);
+                save[34] = Options.altLaneSelectionRatio;
+                save[35] = (byte)Options.vehicleRestrictionsAggression;
+                save[36] = (byte)(Options.trafficLightPriorityRules ? 1 : 0);
+                save[37] = (byte)(Options.realisticPublicTransport ? 1 : 0);
+                save[38] = (byte)(Options.turnOnRedEnabled ? 1 : 0);
+                save[39] = (byte)(Options.allowNearTurnOnRed ? 1 : 0);
+                save[40] = (byte)(Options.allowFarTurnOnRed ? 1 : 0);
+                save[41] = (byte)(Options.automaticallyAddTrafficLightsIfApplicable ? 1 : 0);
 
-            save[42] = OptionsMassEditTab.RoundAboutQuickFix_StayInLaneMainR.Save();
-            save[43] = OptionsMassEditTab.RoundAboutQuickFix_StayInLaneNearRabout.Save();
-            save[44] = OptionsMassEditTab.RoundAboutQuickFix_DedicatedExitLanes.Save();
-            save[45] = OptionsMassEditTab.RoundAboutQuickFix_NoCrossMainR.Save();
-            save[46] = OptionsMassEditTab.RoundAboutQuickFix_NoCrossYieldR.Save();
-            save[47] = OptionsMassEditTab.RoundAboutQuickFix_PrioritySigns.Save();
+                save[42] = OptionsMassEditTab.RoundAboutQuickFix_StayInLaneMainR.Save();
+                save[43] = OptionsMassEditTab.RoundAboutQuickFix_StayInLaneNearRabout.Save();
+                save[44] = OptionsMassEditTab.RoundAboutQuickFix_DedicatedExitLanes.Save();
+                save[45] = OptionsMassEditTab.RoundAboutQuickFix_NoCrossMainR.Save();
+                save[46] = OptionsMassEditTab.RoundAboutQuickFix_NoCrossYieldR.Save();
+                save[47] = OptionsMassEditTab.RoundAboutQuickFix_PrioritySigns.Save();
 
-            save[48] = OptionsMassEditTab.PriorityRoad_CrossMainR.Save();
-            save[49] = OptionsMassEditTab.PriorityRoad_AllowLeftTurns.Save();
-            save[50] = OptionsMassEditTab.PriorityRoad_EnterBlockedYeild.Save();
-            save[51] = OptionsMassEditTab.PriorityRoad_StopAtEntry.Save();
+                save[48] = OptionsMassEditTab.PriorityRoad_CrossMainR.Save();
+                save[49] = OptionsMassEditTab.PriorityRoad_AllowLeftTurns.Save();
+                save[50] = OptionsMassEditTab.PriorityRoad_EnterBlockedYeild.Save();
+                save[51] = OptionsMassEditTab.PriorityRoad_StopAtEntry.Save();
 
-            save[52] = OptionsMassEditTab.RoundAboutQuickFix_KeepClearYieldR.Save();
-            save[53] = OptionsMassEditTab.RoundAboutQuickFix_RealisticSpeedLimits.Save();
-            save[54] = OptionsMassEditTab.RoundAboutQuickFix_ParkingBanMainR.Save();
-            save[55] = OptionsMassEditTab.RoundAboutQuickFix_ParkingBanYieldR.Save();
+                save[52] = OptionsMassEditTab.RoundAboutQuickFix_KeepClearYieldR.Save();
+                save[53] = OptionsMassEditTab.RoundAboutQuickFix_RealisticSpeedLimits.Save();
+                save[54] = OptionsMassEditTab.RoundAboutQuickFix_ParkingBanMainR.Save();
+                save[55] = OptionsMassEditTab.RoundAboutQuickFix_ParkingBanYieldR.Save();
 
-            save[56] = OptionsVehicleRestrictionsTab.NoDoubleCrossings.Save();
-            save[57] = OptionsVehicleRestrictionsTab.DedicatedTurningLanes.Save();
+                save[56] = OptionsVehicleRestrictionsTab.NoDoubleCrossings.Save();
+                save[57] = OptionsVehicleRestrictionsTab.DedicatedTurningLanes.Save();
 
-            save[58] = (byte)Options.SavegamePathfinderEdition;
+                save[58] = (byte)Options.SavegamePathfinderEdition;
 
-            return save;
+                return save;
+            }
+            catch (Exception ex) {
+                Log.Error(ex.ToString());
+                return save; // try and salvage some of the settings
+            }
         }
     }
 }

--- a/TLM/TLM/State/Options.cs
+++ b/TLM/TLM/State/Options.cs
@@ -121,7 +121,7 @@ namespace TrafficManager.State {
         public static bool PriorityRoad_StopAtEntry = false;
 
         // See PathfinderUpdates.cs
-        public static byte SavegamePathfinderEdition = 0;
+        public static byte SavegamePathfinderEdition;
 
         #region shims: do not perist
 
@@ -161,6 +161,7 @@ namespace TrafficManager.State {
         }
 
         public static void MakeSettings(UIHelper helper) {
+            Log.Info("Adding UI to mod options tabs");
             try {
                 ExtUITabstrip tabStrip = ExtUITabstrip.Create(helper);
                 OptionsGeneralTab.MakeSettings_General(tabStrip);


### PR DESCRIPTION
Wrap contents of the load/save data methods in `try...catch` blocks, logging any errors that may occur so at least we can find out where it went wrong.

When saving, I've set it to return the `save` byte arrray as that way we should be able to salvage most of the options (assuming the most common issue will be forgetting to update the size of the array when new options are added). Not sure if this is good or bad idea, lmk in comments.