### PR TITLE
Revise warning that was confusing users

### DIFF
--- a/TLM/TLM/Custom/PathFinding/PathfinderUpdates.cs
+++ b/TLM/TLM/Custom/PathFinding/PathfinderUpdates.cs
@@ -48,10 +48,16 @@ namespace TrafficManager.Custom.PathFinding {
                 filter |= ExtVehicleType.Plane; // #1338
             }
 
-            // this will also log what gets despawned
-            Singleton<SimulationManager>.instance.AddAction(() => {
-                UtilityManager.Instance.DespawnVehicles(filter);
-            });
+            var countMatching = UtilityManager.Instance.CountVehiclesMatchingFilter(filter);
+
+            if (countMatching > 0) {
+                // this will also log what gets despawned
+                Singleton<SimulationManager>.instance.AddAction(() => {
+                    UtilityManager.Instance.DespawnVehicles(filter);
+                });
+            } else {
+                filter = ExtVehicleType.None;
+            }
 
             // this will be stored in savegame
             Options.SavegamePathfinderEdition = LatestPathfinderEdition;

--- a/TLM/TLM/Lifecycle/TMPELifecycle.cs
+++ b/TLM/TLM/Lifecycle/TMPELifecycle.cs
@@ -288,7 +288,7 @@ namespace TrafficManager.Lifecycle {
                     var despawned = PathfinderUpdates.DespawnVehiclesIfNecessary();
 
                     if (despawned != ExtVehicleType.None) {
-                        Prompt.Warning(
+                        Prompt.Info(
                             "TM:PE Pathfinder Updated",
                             $"Some vehicles ({despawned}) had broken paths due to a bug "
                             + "in an earlier version of the pathfinder. We've despawned "

--- a/TLM/TLM/Lifecycle/TMPELifecycle.cs
+++ b/TLM/TLM/Lifecycle/TMPELifecycle.cs
@@ -283,9 +283,7 @@ namespace TrafficManager.Lifecycle {
                 GeometryNotifierDisposable = GeometryManager.Instance.Subscribe(new GeometryNotifier());
                 Notifier.Instance.OnLevelLoaded();
 
-                if (PlayMode &&
-                    Mode != LoadMode.NewGame &&
-                    Mode != LoadMode.NewGameFromScenario) {
+                if (PlayMode && (Mode is not LoadMode.NewGame or LoadMode.NewGameFromScenario)) {
 
                     var despawned = PathfinderUpdates.DespawnVehiclesIfNecessary();
 

--- a/TLM/TLM/Lifecycle/TMPELifecycle.cs
+++ b/TLM/TLM/Lifecycle/TMPELifecycle.cs
@@ -292,7 +292,7 @@ namespace TrafficManager.Lifecycle {
                             "TM:PE Pathfinder Updated",
                             $"Some vehicles ({despawned}) had broken paths due to a bug "
                             + "in an earlier version of the pathfinder. We've despawned "
-                            + "then to prevent further issues. New vehicles will "
+                            + "them to prevent further issues. New vehicles will "
                             + "automatically spawn to replace them.");
                     }
                 }

--- a/TLM/TLM/Lifecycle/TMPELifecycle.cs
+++ b/TLM/TLM/Lifecycle/TMPELifecycle.cs
@@ -284,7 +284,17 @@ namespace TrafficManager.Lifecycle {
                 Notifier.Instance.OnLevelLoaded();
 
                 if (PlayMode) {
-                    PathfinderUpdates.DespawnVehiclesIfNecessary();
+                    var despawned = PathfinderUpdates.DespawnVehiclesIfNecessary();
+
+                    if (despawned != ExtVehicleType.None) {
+                        Prompt.Warning(
+                            "TM:PE Pathfinder Updated",
+                            $"Some vehicles ({despawned}) had broken paths due to a bug "
+                            + "in an earlier version of the pathfinder. We've despawned "
+                            + "then to prevent further issues. New vehicles will "
+                            + "automatically spawn to replace them.");
+                    }
+
                 }
 
                 Log.Info("OnLevelLoaded complete.");

--- a/TLM/TLM/Lifecycle/TMPELifecycle.cs
+++ b/TLM/TLM/Lifecycle/TMPELifecycle.cs
@@ -283,7 +283,10 @@ namespace TrafficManager.Lifecycle {
                 GeometryNotifierDisposable = GeometryManager.Instance.Subscribe(new GeometryNotifier());
                 Notifier.Instance.OnLevelLoaded();
 
-                if (PlayMode) {
+                if (PlayMode &&
+                    Mode != LoadMode.NewGame &&
+                    Mode != LoadMode.NewGameFromScenario) {
+
                     var despawned = PathfinderUpdates.DespawnVehiclesIfNecessary();
 
                     if (despawned != ExtVehicleType.None) {
@@ -294,7 +297,6 @@ namespace TrafficManager.Lifecycle {
                             + "then to prevent further issues. New vehicles will "
                             + "automatically spawn to replace them.");
                     }
-
                 }
 
                 Log.Info("OnLevelLoaded complete.");

--- a/TLM/TLM/Lifecycle/TMPELifecycle.cs
+++ b/TLM/TLM/Lifecycle/TMPELifecycle.cs
@@ -284,14 +284,7 @@ namespace TrafficManager.Lifecycle {
                 Notifier.Instance.OnLevelLoaded();
 
                 if (PlayMode) {
-                    var despawned = PathfinderUpdates.DespawnVehiclesIfNecessary();
-
-                    if (despawned != ExtVehicleType.None) {
-                        Prompt.Warning(
-                            "TM:PE Pathfinder Update",
-                            "Some vehicles were using outdated paths and have been despawned: "
-                            + despawned.ToString());
-                    }
+                    PathfinderUpdates.DespawnVehiclesIfNecessary();
                 }
 
                 Log.Info("OnLevelLoaded complete.");

--- a/TLM/TLM/Manager/Impl/UtilityManager.cs
+++ b/TLM/TLM/Manager/Impl/UtilityManager.cs
@@ -22,6 +22,26 @@ namespace TrafficManager.Manager.Impl {
 
         private readonly Queue<KeyValuePair<IRecordable, Dictionary<InstanceID, InstanceID>>> _transferRecordables = new();
 
+        public int CountVehiclesMatchingFilter(ExtVehicleType filter) {
+            int count = 0;
+            var manager = Singleton<VehicleManager>.instance;
+
+            for (uint vehicleId = 0; vehicleId < manager.m_vehicles.m_size; ++vehicleId) {
+                ref Vehicle vehicle = ref ((ushort)vehicleId).ToVehicle();
+
+                if (!vehicle.IsValid()) {
+                    continue;
+                }
+
+                if ((vehicle.ToExtVehicleType() & filter) == 0) {
+                    continue;
+                }
+
+                count++;
+            }
+            return count;
+        }
+
         public void DespawnVehicles(ExtVehicleType? filter = null) {
             lock (Singleton<VehicleManager>.instance) {
                 try {

--- a/TLM/TLM/UI/Helpers/Prompt.cs
+++ b/TLM/TLM/UI/Helpers/Prompt.cs
@@ -18,6 +18,16 @@ namespace TrafficManager.UI.Helpers {
     public class Prompt {
 
         /// <summary>
+        /// Display an info prompt in the centre of the screen.
+        /// </summary>
+        ///
+        /// <param name="title">Dialog title.</param>
+        /// <param name="message">Dialog body text.</param>
+        public static void Info(string title, string message) {
+            MessageBoxPanel(title, message);
+        }
+
+        /// <summary>
         /// Display a warning prompt in the centre of the screen.
         /// </summary>
         /// 
@@ -71,6 +81,37 @@ namespace TrafficManager.UI.Helpers {
                 UIView.library
                     .ShowModal<ExceptionPanel>("ExceptionPanel")
                     .SetMessage(title, message, isError);
+            };
+
+            try {
+                if (SceneManager.GetActiveScene().name == "Game") {
+                    Singleton<SimulationManager>.instance.m_ThreadingWrapper.QueueMainThread(prompt);
+                } else {
+                    prompt();
+                }
+            } catch (Exception e) {
+                Log.ErrorFormat(
+                    "Error displaying a Prompt:\n{0}",
+                    e.ToString());
+            }
+        }
+
+        /// <summary>
+        /// Display an info message dialog in the center of the screen
+        /// </summary>
+        ///
+        /// <param name="title">Dialog title.</param>
+        /// <param name="message">Dialog body text.</param>
+        private static void MessageBoxPanel(string title, string message) {
+            Action prompt = () => {
+                MessageBoxPanel messageBoxPanel = UIView.library
+                                                        .ShowModal<MessageBoxPanel>("MessageBoxPanel");
+                messageBoxPanel.Find<UILabel>("Message").text = message;
+                messageBoxPanel.Find<UILabel>("Caption").text = title;
+                UIButton uiButton = messageBoxPanel.Find<UIButton>("Close");
+                if (!uiButton)
+                    return;
+                uiButton.isVisible = false;
             };
 
             try {


### PR DESCRIPTION
This PR ~~removes~~ revises the warning dlg about vehicles being despawned due to pathfinder update. Many users thought it was an _error_ (it's using warning prompt UI as we don't have any alternative at present), so ~~just removed the warning dlg for now~~ updated how it works (see https://github.com/CitiesSkylinesMods/TMPE/pull/1347#issuecomment-1028180904 ).