### PR TITLE
`Log.Warning()` -> `Log.Info()` for missing localised image resources

### DIFF
--- a/TLM/TLM/UI/Localization/Translation.cs
+++ b/TLM/TLM/UI/Localization/Translation.cs
@@ -190,7 +190,7 @@ namespace TrafficManager.UI {
             }
 
             if (!DEFAULT_LANGUAGE_CODE.Equals(language)) {
-                Log.Warning($"Translated file {translatedFilename} not found!");
+                Log.Info($"Translated file {translatedFilename} not found; using base language");
             }
 
             return filename;


### PR DESCRIPTION
This doesn't merit a stack trace in the log (there's a whole bunch of them depending on which language is selected):

```diff
+ Warning 222.3841204: Translated file RoadUI.sign_stop_en-gb.png not found!
   at CSUtil.Commons.Log.LogToFile(System.String log, LogLevel level)
   at CSUtil.Commons.Log.Warning(System.String s)
   at TrafficManager.UI.Translation.GetTranslatedFileName(System.String filename, System.String language)
   at TrafficManager.UI.Translation.GetTranslatedFileName(System.String filename)
   at TrafficManager.UI.Textures.RoadUI.OnLevelLoading()
   at TrafficManager.Lifecycle.TMPELifecycle.Load()
   at TrafficManager.Lifecycle.TrafficManagerMod.OnLevelLoaded(LoadMode mode)
   at LoadingWrapper.LoadingWrapper.OnLevelLoaded_Patch4(.LoadingWrapper , UpdateMode )
   at LoadingManager+<LoadLevelComplete>c__Iterator9.MoveNext()
   at LoadingManager.FpsBoosterUpdate()
   at BehaviourUpdater.Updater.Update()
```

This PR downgrades that `Log.Warning()` to a `Log.Info()` thus removing stack trace. If some trace is required (lmk if that is the case!), we could do something like PR #1315.