### PR TITLE
` ReplaceMaxPosTranspiler`: `Log.Warning()` -> `Log.Info()`

### DIFF
--- a/TLM/TLM/Patch/_VehicleAI/StartPathFindCommons.cs
+++ b/TLM/TLM/Patch/_VehicleAI/StartPathFindCommons.cs
@@ -49,7 +49,7 @@ namespace TrafficManager.Patch._VehicleAI {
 
             if (counter == 0) {
                 // if another mod has already made such replacement then we would know :)
-                Log.Warning("Warning: redundant transpiler (counter == 0) - Another mod must have changed these values already (probably 81-tiles).");
+                Log.Info("ReplaceMaxPosTranspiler: Another mod has already changed the values (probably 81-tiles).");
             }
             Log._Debug($"StartPathFindCommons.ReplaceMaxPosTranspiler() successfully " +
                 $"replaced {counter} instances of ldc.r4 {vanilaMaxPos} with {newMaxPos}");


### PR DESCRIPTION
There's no need to treat this as a warning as it's expected behaviour; it's just there to ensure we log the fact the values already changed.

```diff
+ Warning 221.5853098: Warning: redundant transpiler (counter == 0) - Another mod must have changed these values already (probably 81-tiles).
   at CSUtil.Commons.Log.LogToFile(System.String log, LogLevel level)
   at CSUtil.Commons.Log.Warning(System.String s)
   at TrafficManager.Patch._VehicleAI.StartPathFindCommons+<ReplaceMaxPosTranspiler>d__6.MoveNext()
   at System.Collections.Generic.List`1[[HarmonyLib.CodeInstruction, CitiesHarmony.Harmony, Version=2.0.4.0, Culture=neutral, PublicKeyToken=null]].AddEnumerable(IEnumerable`1 enumerable)
   at System.Collections.Generic.List`1[[HarmonyLib.CodeInstruction, CitiesHarmony.Harmony, Version=2.0.4.0, Culture=neutral, PublicKeyToken=null]]..ctor(IEnumerable`1 collection)
   at System.Linq.Enumerable.ToList(IEnumerable`1 source)
   at HarmonyLib.CodeTranspiler.GetResult(System.Reflection.Emit.ILGenerator generator, System.Reflection.MethodBase method)
   at HarmonyLib.MethodBodyReader.FinalizeILCodes(HarmonyLib.Emitter emitter, System.Collections.Generic.List`1 transpilers, System.Collections.Generic.List`1 endLabels, Boolean ByRef hasReturnCode)
   at HarmonyLib.MethodCopier.Finalize(HarmonyLib.Emitter emitter, System.Collections.Generic.List`1 endLabels, Boolean ByRef hasReturnCode)
   at HarmonyLib.MethodPatcher.CreateReplacement(System.Collections.Generic.Dictionary`2 ByRef finalInstructions)
   at HarmonyLib.PatchFunctions.UpdateWrapper(System.Reflection.MethodBase original, HarmonyLib.PatchInfo patchInfo)
   at HarmonyLib.PatchClassProcessor.ProcessPatchJob(HarmonyLib.Job job)
   at HarmonyLib.PatchClassProcessor.BulkPatch(System.Collections.Generic.List`1 originals, System.Reflection.MethodBase ByRef lastOriginal)
   at HarmonyLib.PatchClassProcessor.Patch()
   at TrafficManager.Lifecycle.Patcher.PatchAll(System.String harmonyId, System.Type required, System.Type forbidden)
   at TrafficManager.Lifecycle.Patcher.Install()
   at TrafficManager.Lifecycle.TMPELifecycle.Load()
   at TrafficManager.Lifecycle.TrafficManagerMod.OnLevelLoaded(LoadMode mode)
   at LoadingWrapper.LoadingWrapper.OnLevelLoaded_Patch4(.LoadingWrapper , UpdateMode )
   at LoadingManager+<LoadLevelComplete>c__Iterator9.MoveNext()
   at LoadingManager.FpsBoosterUpdate()
   at BehaviourUpdater.Updater.Update()
```

This and #1348 should result in no `Warning` stack traces in log file under normal conditions/operation.