### PR TITLE
What's New in TM:PE 11.6.4.5 ?

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ This changelog includes all versions and major variants of the mod going all the
 - [Updated] Catch and log errors in savegame options save/load #1345 (aubergine18)
 - [Updated] Pathfinder edition check refinements #1347 (aubergine18)
 - [Updated] Reduce severity of some normal log messages #1348 #1350 (aubergine18)
+- [Updated] Add new `.Info()` panel to `Prompt` class #1347 (krzychu124)
 - [Steam] [TM:PE v11 STABLE](https://steamcommunity.com/sharedfiles/filedetails/?id=1637663252)
 
 #### TM:PE V11.6.4.5 TEST, 02/02/2022
@@ -45,6 +46,7 @@ This changelog includes all versions and major variants of the mod going all the
 - [Updated] Catch and log errors in savegame options save/load #1345 (aubergine18)
 - [Updated] Pathfinder edition check refinements #1347 (aubergine18)
 - [Updated] Reduce severity of some normal log messages #1348 #1350 (aubergine18)
+- [Updated] Add new `.Info()` panel to `Prompt` class #1347 (krzychu124)
 - [Steam] [TM:PE v11 TEST](https://steamcommunity.com/sharedfiles/filedetails/?id=2489276785)
 
 #### TM:PE V11.6.4.4 STABLE, 01/02/2022

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,24 @@ This changelog includes all versions and major variants of the mod going all the
 
 </details>
 
+#### TM:PE V11.6.4.5 STABLE, 02/02/2022
+
+- [Meta] TM:PE 11.6.4-hotfix-5
+- [Meta] Updates to error checking/logging, and refine pathfinder edition checks
+- [Updated] Catch and log errors in savegame options save/load #1345 (aubergine18)
+- [Updated] Pathfinder edition check refinements #1347 (aubergine18)
+- [Updated] Reduce severity of some normal log messages #1348 #1350 (aubergine18)
+- [Steam] [TM:PE v11 STABLE](https://steamcommunity.com/sharedfiles/filedetails/?id=1637663252)
+
+#### TM:PE V11.6.4.5 TEST, 02/02/2022
+
+- [Meta] TM:PE 11.6.4-hotfix-5
+- [Meta] Updates to error logging, and refine pathfinder edition checks
+- [Updated] Catch and log errors in savegame options save/load #1345 (aubergine18)
+- [Updated] Pathfinder edition check refinements #1347 (aubergine18)
+- [Updated] Reduce severity of some normal log messages #1348 #1350 (aubergine18)
+- [Steam] [TM:PE v11 TEST](https://steamcommunity.com/sharedfiles/filedetails/?id=2489276785)
+
 #### TM:PE V11.6.4.4 STABLE, 01/02/2022
 
 - [Meta] TM:PE 11.6.4-hotfix-4
@@ -38,7 +56,8 @@ This changelog includes all versions and major variants of the mod going all the
 - [Fixed] Aircraft stuck at taxiway junction #1338 #1329 (krzychu124)
 - [Fixed] Aircraft taking off from taxiways #1338 #1327 (krzychu124)
 - [Fixed] Unable to edit underground nodes in Traffic info view #1333 #1330 (aubergine18)
-- [Updated] TM:PE toolbar closes in non-applicable info views #1333 (aubergine18)- [Steam] [TM:PE v11 STABLE](https://steamcommunity.com/sharedfiles/filedetails/?id=1637663252)
+- [Updated] TM:PE toolbar closes in non-applicable info views #1333 (aubergine18)
+- [Steam] [TM:PE v11 STABLE](https://steamcommunity.com/sharedfiles/filedetails/?id=1637663252)
 
 #### TM:PE V11.6.4.4 TEST, 01/02/2022
 
@@ -49,7 +68,8 @@ This changelog includes all versions and major variants of the mod going all the
 - [Fixed] Aircraft stuck at taxiway junction #1338 #1329 (krzychu124)
 - [Fixed] Aircraft taking off from taxiways #1338 #1327 (krzychu124)
 - [Fixed] Unable to edit underground nodes in Traffic info view #1333 #1330 (aubergine18)
-- [Updated] TM:PE toolbar closes in non-applicable info views #1333 (aubergine18)- [Steam] [TM:PE v11 TEST](https://steamcommunity.com/sharedfiles/filedetails/?id=2489276785)
+- [Updated] TM:PE toolbar closes in non-applicable info views #1333 (aubergine18)
+- [Steam] [TM:PE v11 TEST](https://steamcommunity.com/sharedfiles/filedetails/?id=2489276785)
 
 #### TM:PE V11.6.4.3 STABLE, 29/01/2022
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@
 - [Updated] Catch and log errors in savegame options save/load #1345 (aubergine18)
 - [Updated] Pathfinder edition check refinements #1347 (aubergine18)
 - [Updated] Reduce severity of some normal log messages #1348 #1350 (aubergine18)
+- [Updated] Add new `.Info()` panel to `Prompt` class #1347 (krzychu124)
 - [Steam] [TM:PE v11 STABLE](https://steamcommunity.com/sharedfiles/filedetails/?id=1637663252)
 
 #### TM:PE V11.6.4.4 STABLE, 01/02/2022
@@ -73,6 +74,7 @@
 - [Updated] Catch and log errors in savegame options save/load #1345 (aubergine18)
 - [Updated] Pathfinder edition check refinements #1347 (aubergine18)
 - [Updated] Reduce severity of some normal log messages #1348 #1350 (aubergine18)
+- [Updated] Add new `.Info()` panel to `Prompt` class #1347 (krzychu124)
 - [Steam] [TM:PE v11 TEST](https://steamcommunity.com/sharedfiles/filedetails/?id=2489276785)
 
 #### TM:PE V11.6.4.4 TEST, 01/02/2022

--- a/README.md
+++ b/README.md
@@ -41,6 +41,15 @@
 
 > Date format: dd/mm/yyyy
 
+#### TM:PE V11.6.4.5 STABLE, 02/02/2022
+
+- [Meta] TM:PE 11.6.4-hotfix-5
+- [Meta] Updates to error checking/logging, and refine pathfinder edition checks
+- [Updated] Catch and log errors in savegame options save/load #1345 (aubergine18)
+- [Updated] Pathfinder edition check refinements #1347 (aubergine18)
+- [Updated] Reduce severity of some normal log messages #1348 #1350 (aubergine18)
+- [Steam] [TM:PE v11 STABLE](https://steamcommunity.com/sharedfiles/filedetails/?id=1637663252)
+
 #### TM:PE V11.6.4.4 STABLE, 01/02/2022
 
 - [Meta] TM:PE 11.6.4-hotfix-4
@@ -53,19 +62,18 @@
 - [Updated] TM:PE toolbar closes in non-applicable info views #1333 (aubergine18)
 - [Steam] [TM:PE v11 STABLE](https://steamcommunity.com/sharedfiles/filedetails/?id=1637663252)
 
-#### TM:PE V11.6.4.3 STABLE, 29/01/2022
-
-- [Meta] TM:PE 11.6.4-hotfix-3
-- [Meta] This fixes rare issue on some PCs that are limited to single CPU core
-- [Fixed] Incorrect minimal number of path-find threads #1331 (krzychu124)
-- [Updated] Code clean-up: Refactor `OptionsManager.cs` #1321 (kvakvs, aubergine18)
-- [Updated] Show full version in UI and log file #1335 (aubergine18)
-- [Removed] Temporary: Don't auto-show What's New on TM:PE menu button click #1336 #1314 (krzychu124, aubergine18)
-- [Steam] [TM:PE v11 STABLE](https://steamcommunity.com/sharedfiles/filedetails/?id=1637663252)
-
 ### Recent TEST releases:
 
 > Date format: dd/mm/yyyy
+
+#### TM:PE V11.6.4.5 TEST, 02/02/2022
+
+- [Meta] TM:PE 11.6.4-hotfix-5
+- [Meta] Updates to error logging, and refine pathfinder edition checks
+- [Updated] Catch and log errors in savegame options save/load #1345 (aubergine18)
+- [Updated] Pathfinder edition check refinements #1347 (aubergine18)
+- [Updated] Reduce severity of some normal log messages #1348 #1350 (aubergine18)
+- [Steam] [TM:PE v11 TEST](https://steamcommunity.com/sharedfiles/filedetails/?id=2489276785)
 
 #### TM:PE V11.6.4.4 TEST, 01/02/2022
 
@@ -77,15 +85,6 @@
 - [Fixed] Aircraft taking off from taxiways #1338 #1327 (krzychu124)
 - [Fixed] Unable to edit underground nodes in Traffic info view #1333 #1330 (aubergine18)
 - [Updated] TM:PE toolbar closes in non-applicable info views #1333 (aubergine18)- [Steam] [TM:PE v11 TEST](https://steamcommunity.com/sharedfiles/filedetails/?id=2489276785)
-
-#### TM:PE V11.6.4.3 TEST, 29/01/2022
-
-- [Meta] TM:PE 11.6.4-hotfix-3
-- [Meta] This fixes rare issue on some PCs that are limited to single CPU core
-- [Fixed] Incorrect minimal number of path-find threads #1331 (krzychu124)
-- [Updated] Code clean-up: Refactor `OptionsManager.cs` #1321 (kvakvs, aubergine18)
-- [Updated] Show full version in UI and log file #1335 (aubergine18)
-- [Removed] Temporary: Don't auto-show What's New on TM:PE menu button click #1336 #1314 (krzychu124, aubergine18)
 - [Steam] [TM:PE v11 TEST](https://steamcommunity.com/sharedfiles/filedetails/?id=2489276785)
 
 ## Support Policy

--- a/TLM/TLM/Resources/whats_new.txt
+++ b/TLM/TLM/Resources/whats_new.txt
@@ -7,6 +7,7 @@
 [Updated] Catch and log errors in savegame options save/load #1345 (aubergine18)
 [Updated] Pathfinder edition check refinements #1347 (aubergine18)
 [Updated] Reduce severity of some normal log messages #1348 #1350 (aubergine18)
+[Updated] Add new `.Info()` panel to `Prompt` class #1347 (krzychu124)
 [/Version]
 
 [Version] 11.6.4.4

--- a/TLM/TLM/Resources/whats_new.txt
+++ b/TLM/TLM/Resources/whats_new.txt
@@ -1,3 +1,14 @@
+[Version] 11.6.4.5
+[Stable]
+[Released] February 2nd 2022
+[Link] tmpe-v11645-stable-02022022
+[Meta] TM:PE 11.6.4-hotfix-5
+[Meta] Updates to error checking/logging, and refine pathfinder edition checks
+[Updated] Catch and log errors in savegame options save/load #1345 (aubergine18)
+[Updated] Pathfinder edition check refinements #1347 (aubergine18)
+[Updated] Reduce severity of some normal log messages #1348 #1350 (aubergine18)
+[/Version]
+
 [Version] 11.6.4.4
 [Stable]
 [Released] February 1st 2022

--- a/TLM/TLM/UI/WhatsNew/WhatsNew.cs
+++ b/TLM/TLM/UI/WhatsNew/WhatsNew.cs
@@ -11,7 +11,7 @@ namespace TrafficManager.UI.WhatsNew {
 
     public class WhatsNew {
         // bump and update what's new changelogs when new features added
-        public static readonly Version CurrentVersion = new Version(11,6,4,4);
+        public static readonly Version CurrentVersion = new Version(11,6,4,5);
 
         private const string WHATS_NEW_FILE = "whats_new.txt";
         private const string RESOURCES_PREFIX = "TrafficManager.Resources.";


### PR DESCRIPTION
This release makes some refinements to error checking/logging, and refines the pathfinder edition check/warning.

- [Meta] TM:PE 11.6.4-hotfix-5
- [Meta] Updates to error checking/logging, and refine pathfinder edition checks
- [Updated] Catch and log errors in savegame options save/load #1345 (aubergine18)
- [Updated] Pathfinder edition check refinements #1347 (aubergine18)
- [Updated] Reduce severity of some normal log messages #1348 #1350 (aubergine18)