### PR TITLE
Fix `GetVanillaNetInfoSpeedLimit()` to only inspect customisable lanes

### DIFF
--- a/TLM/TLM/Manager/Impl/SpeedLimitManager.cs
+++ b/TLM/TLM/Manager/Impl/SpeedLimitManager.cs
@@ -283,9 +283,9 @@ namespace TrafficManager.Manager.Impl {
         }
 
         /// <summary>
-        /// Determines the game default speed limit of the given NetInfo.
+        /// Scans lanes which may have customisaable speed limit and returns the fastest <c>m_speedLimit</c> encountered.
         /// </summary>
-        /// <param name="info">the NetInfo of which the game default speed limit should be determined</param>
+        /// <param name="info">The <see cref="NetInfo"/> to inspect.</param>
         /// <returns>The vanilla speed limit, in game units.</returns>
         private float FindFastestCustomisableVanillaLaneSpeedLimit(NetInfo info) {
             if (info == null) {
@@ -298,18 +298,22 @@ namespace TrafficManager.Manager.Impl {
                 return 0f;
             }
 
-            float? maxSpeedLimit = null;
+            if (info.m_lanes == null) {
+                return 0f;
+            }
 
-            if (info.m_lanes != null) {
-                foreach (var laneInfo in info.m_lanes) {
+            float maxSpeedLimit = 0f;
+
+            foreach (var laneInfo in info.m_lanes) {
+                if (laneInfo.MayHaveCustomSpeedLimits()) {
                     float speedLimit = laneInfo.m_speedLimit;
-                    if (maxSpeedLimit == null || speedLimit > maxSpeedLimit) {
+                    if (speedLimit > maxSpeedLimit) {
                         maxSpeedLimit = speedLimit;
                     }
                 }
             }
 
-            return maxSpeedLimit ?? 0f;
+            return maxSpeedLimit;
         }
 
         /// <summary>

--- a/TLM/TLM/Manager/Impl/SpeedLimitManager.cs
+++ b/TLM/TLM/Manager/Impl/SpeedLimitManager.cs
@@ -287,7 +287,7 @@ namespace TrafficManager.Manager.Impl {
         /// </summary>
         /// <param name="info">the NetInfo of which the game default speed limit should be determined</param>
         /// <returns>The vanilla speed limit, in game units.</returns>
-        private float GetVanillaNetInfoSpeedLimit(NetInfo info) {
+        private float FindFastestCustomisableVanillaLaneSpeedLimit(NetInfo info) {
             if (info == null) {
                 Log._DebugOnlyWarning("SpeedLimitManager.GetVanillaNetInfoSpeedLimit: info is null!");
                 return 0f;
@@ -324,7 +324,7 @@ namespace TrafficManager.Manager.Impl {
             }
 
             return !customNetinfoSpeedLimits_.TryGetValue(info, out float speedLimit)
-                       ? GetVanillaNetInfoSpeedLimit(info)
+                       ? FindFastestCustomisableVanillaLaneSpeedLimit(info)
                        : speedLimit;
         }
 
@@ -444,7 +444,7 @@ namespace TrafficManager.Manager.Impl {
                 return;
             }
 
-            var vanillaSpeedLimit = GetVanillaNetInfoSpeedLimit(netinfo);
+            var vanillaSpeedLimit = FindFastestCustomisableVanillaLaneSpeedLimit(netinfo);
 
             foreach (var relatedNetinfo in GetCustomisableRelatives(netinfo)) {
                 if (this.customNetinfoSpeedLimits_.ContainsKey(relatedNetinfo)) {


### PR DESCRIPTION
Fixes: #1346

`GetVanillaNetInfoSpeedLimit()` was not filtering lanes to those which may have custom speed limits, resulting in problems like this (trace logging from #1346):

```diff
- Info 440.2720848: m_vehicleType = None, laneInfo.m_laneType = None, speedLimit = 1
- Info 440.2727466: m_vehicleType = None, laneInfo.m_laneType = None, speedLimit = 1
- Info 440.2734355: m_vehicleType = None, laneInfo.m_laneType = None, speedLimit = 1
- Info 440.2740341: m_vehicleType = None, laneInfo.m_laneType = None, speedLimit = 1
- Info 440.2746089: m_vehicleType = None, laneInfo.m_laneType = None, speedLimit = 1
+ Info 440.2752129: m_vehicleType = Car, laneInfo.m_laneType = Vehicle, speedLimit = 0.6
+ Info 440.2757840: m_vehicleType = Car, laneInfo.m_laneType = Vehicle, speedLimit = 0.6
Info 440.2763682: m_vehicleType = None, laneInfo.m_laneType = Pedestrian, speedLimit = 0.1
Info 440.2769400: m_vehicleType = None, laneInfo.m_laneType = Pedestrian, speedLimit = 0.1
```

In the example above, we should have been getting a return value of `0.6` but were instead getting `1`.

This should fix some weird bugs at the following call sites:

- Cached network speeds (`LoadData()` of `SpeedLimitsManager`)
- Speed limit overlays
- Roundabout bulk applicator (where it sets speed of roundabout based on curvature)

My biggest worry with this PR is how it will affect networks which aren't applicable for custom speed limits (eg. ship paths, pedestrian paths, etc) - I suspect we will need to create an additional method (which merely skips `None, None` type lanes, rather than looking for customisable lanes) for use in the `LoadData()` of `SpeedLimitsManager` but will wait for feedback from devs who have worked on this code before doing that.