### PR TITLE
What's New in TM:PE 11.6.4.7 ?

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,24 @@ This changelog includes all versions and major variants of the mod going all the
 
 </details>
 
+#### TM:PE V11.6.4.7 STABLE, 06/02/2022
+
+- [Meta] TM:PE 11.6.4-hotfix-7
+- [Meta] Bugfix for default speeds which affects speed limits tool, overlays, and roundabout curvature speed
+- [Fixed] Default netinfo speed should only inspect customisable lanes #1362 #1346 (aubergine18)
+- [Fixed] Fix `SPEED_TO_MPH` value in `ApiConstants.cs` #1364 #1363 #988 (aubergine18)
+- [Removed] Obsolete: `SPEED_TO_MPH` and `SPEED_TO_KMPH` in `Constants.cs` #1364 #1363 (aubergine18)
+- [Steam] [TM:PE v11 STABLE](https://steamcommunity.com/sharedfiles/filedetails/?id=1637663252)
+
+#### TM:PE V11.6.4.7 TEST, 06/02/2022
+
+- [Meta] TM:PE 11.6.4-hotfix-7
+- [Meta] Bugfix for default speeds which affects speed limits tool, overlays, and roundabout curvature speed
+- [Fixed] Default netinfo speed should only inspect customisable lanes #1362 #1346 (aubergine18)
+- [Fixed] Fix `SPEED_TO_MPH` value in `ApiConstants.cs` #1364 #1363 #988 (aubergine18)
+- [Removed] Obsolete: `SPEED_TO_MPH` and `SPEED_TO_KMPH` in `Constants.cs` #1364 #1363 (aubergine18)
+- [Steam] [TM:PE v11 TEST](https://steamcommunity.com/sharedfiles/filedetails/?id=2489276785)
+
 #### TM:PE V11.6.4.6 STABLE, 05/02/2022
 
 - [Meta] TM:PE 11.6.4-hotfix-6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@ This changelog includes all versions and major variants of the mod going all the
 - [Meta] Bugfix for default speeds which affects speed limits tool, overlays, and roundabout curvature speed
 - [Fixed] Default netinfo speed should only inspect customisable lanes #1362 #1346 (aubergine18)
 - [Fixed] Fix `SPEED_TO_MPH` value in `ApiConstants.cs` #1364 #1363 #988 (aubergine18)
-- [Removed] Obsolete: `SPEED_TO_MPH` and `SPEED_TO_KMPH` in `Constants.cs` #1364 #1363 (aubergine18)
+- [Removed] Obsolete: `SPEED_TO_MPH` and `SPEED_TO_KMPH` in `Constants.cs` #1367 #1364 #1363 (aubergine18)
 - [Steam] [TM:PE v11 STABLE](https://steamcommunity.com/sharedfiles/filedetails/?id=1637663252)
 
 #### TM:PE V11.6.4.7 TEST, 06/02/2022
@@ -44,7 +44,7 @@ This changelog includes all versions and major variants of the mod going all the
 - [Meta] Bugfix for default speeds which affects speed limits tool, overlays, and roundabout curvature speed
 - [Fixed] Default netinfo speed should only inspect customisable lanes #1362 #1346 (aubergine18)
 - [Fixed] Fix `SPEED_TO_MPH` value in `ApiConstants.cs` #1364 #1363 #988 (aubergine18)
-- [Removed] Obsolete: `SPEED_TO_MPH` and `SPEED_TO_KMPH` in `Constants.cs` #1364 #1363 (aubergine18)
+- [Removed] Obsolete: `SPEED_TO_MPH` and `SPEED_TO_KMPH` in `Constants.cs` #1367 #1364 #1363 (aubergine18)
 - [Steam] [TM:PE v11 TEST](https://steamcommunity.com/sharedfiles/filedetails/?id=2489276785)
 
 #### TM:PE V11.6.4.6 STABLE, 05/02/2022

--- a/README.md
+++ b/README.md
@@ -37,9 +37,19 @@
 - [Download Binaries](https://github.com/CitiesSkylinesMods/TMPE/releases) (for non-Steam users)
 - [Installation Guide](https://github.com/CitiesSkylinesMods/TMPE/wiki/Installation) (for all users)
 
-### Recent STABLE releases:
+### Recent releases:
 
 > Date format: dd/mm/yyyy
+
+#### TM:PE V11.6.4.7 STABLE, 06/02/2022
+
+- [Meta] TM:PE 11.6.4-hotfix-7
+- [Meta] Bugfix for default speeds which affects speed limits tool, overlays, and roundabout curvature speed
+- [Fixed] Default netinfo speed should only inspect customisable lanes #1362 #1346 (aubergine18)
+- [Fixed] Fix `SPEED_TO_MPH` value in `ApiConstants.cs` #1364 #1363 #988 (aubergine18)
+- [Removed] Obsolete: `SPEED_TO_MPH` and `SPEED_TO_KMPH` in `Constants.cs` #1364 #1363 (aubergine18)
+- [Steam] [TM:PE v11 STABLE](https://steamcommunity.com/sharedfiles/filedetails/?id=1637663252)
+
 
 #### TM:PE V11.6.4.6 STABLE, 05/02/2022
 
@@ -49,39 +59,6 @@
 - [Fixed] Missing lane connectors on CSUR and similar networks #1355 #1357 (krzychu124)
 - [Updated] Internal changes to `CheckboxOption` code #1301 #1299 #1279 (aubergine18)
 - [Steam] [TM:PE v11 STABLE](https://steamcommunity.com/sharedfiles/filedetails/?id=1637663252)
-
-#### TM:PE V11.6.4.5 STABLE, 02/02/2022
-
-- [Meta] TM:PE 11.6.4-hotfix-5
-- [Meta] Updates to error checking/logging, and refine pathfinder edition checks
-- [Updated] Catch and log errors in savegame options save/load #1345 (aubergine18)
-- [Updated] Pathfinder edition check refinements #1347 (aubergine18)
-- [Updated] Reduce severity of some normal log messages #1348 #1350 (aubergine18)
-- [Updated] Add new `.Info()` panel to `Prompt` class #1347 (krzychu124)
-- [Steam] [TM:PE v11 STABLE](https://steamcommunity.com/sharedfiles/filedetails/?id=1637663252)
-
-### Recent TEST releases:
-
-> Date format: dd/mm/yyyy
-
-#### TM:PE V11.6.4.6 TEST, 05/02/2022
-
-- [Meta] TM:PE 11.6.4-hotfix-6
-- [Meta] Fixes some issues relating to CSUR and similar networks
-- [Mod] Incompatible: All versions of Cities Skylines Multiplayer (CSM) #1360 #1359 (aubergine18)
-- [Fixed] Missing lane connectors on CSUR and similar networks #1355 #1357 (krzychu124)
-- [Updated] Internal changes to `CheckboxOption` code #1301 #1299 #1279 (aubergine18)
-- [Steam] [TM:PE v11 TEST](https://steamcommunity.com/sharedfiles/filedetails/?id=2489276785)
-
-#### TM:PE V11.6.4.5 TEST, 02/02/2022
-
-- [Meta] TM:PE 11.6.4-hotfix-5
-- [Meta] Updates to error logging, and refine pathfinder edition checks
-- [Updated] Catch and log errors in savegame options save/load #1345 (aubergine18)
-- [Updated] Pathfinder edition check refinements #1347 (aubergine18)
-- [Updated] Reduce severity of some normal log messages #1348 #1350 (aubergine18)
-- [Updated] Add new `.Info()` panel to `Prompt` class #1347 (krzychu124)
-- [Steam] [TM:PE v11 TEST](https://steamcommunity.com/sharedfiles/filedetails/?id=2489276785)
 
 ## Support Policy
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@
 - [Meta] Bugfix for default speeds which affects speed limits tool, overlays, and roundabout curvature speed
 - [Fixed] Default netinfo speed should only inspect customisable lanes #1362 #1346 (aubergine18)
 - [Fixed] Fix `SPEED_TO_MPH` value in `ApiConstants.cs` #1364 #1363 #988 (aubergine18)
-- [Removed] Obsolete: `SPEED_TO_MPH` and `SPEED_TO_KMPH` in `Constants.cs` #1364 #1363 (aubergine18)
+- [Removed] Obsolete: `SPEED_TO_MPH` and `SPEED_TO_KMPH` in `Constants.cs` #1367 #1364 #1363 (aubergine18)
 - [Steam] [TM:PE v11 STABLE](https://steamcommunity.com/sharedfiles/filedetails/?id=1637663252)
 
 

--- a/TLM/TLM/Resources/whats_new.txt
+++ b/TLM/TLM/Resources/whats_new.txt
@@ -6,7 +6,7 @@
 [Meta] Bugfix for default speeds which affects speed limits tool, overlays, and roundabout curvature speed
 [Fixed] Default netinfo speed should only inspect customisable lanes #1362 #1346 (aubergine18)
 [Fixed] Fix `SPEED_TO_MPH` value in `ApiConstants.cs` #1364 #1363 #988 (aubergine18)
-[Removed] Obsolete: `SPEED_TO_MPH` and `SPEED_TO_KMPH` in `Constants.cs` #1364 #1363 (aubergine18)
+[Removed] Obsolete: `SPEED_TO_MPH` and `SPEED_TO_KMPH` in `Constants.cs` #1367 #1364 #1363 (aubergine18)
 [/Version]
 
 [Version] 11.6.4.6

--- a/TLM/TLM/Resources/whats_new.txt
+++ b/TLM/TLM/Resources/whats_new.txt
@@ -1,3 +1,14 @@
+[Version] 11.6.4.7
+[Stable]
+[Released] February 6th 2022
+[Link] tmpe-v11646-stable-06022022
+[Meta] TM:PE 11.6.4-hotfix-7
+[Meta] Bugfix for default speeds which affects speed limits tool, overlays, and roundabout curvature speed
+[Fixed] Default netinfo speed should only inspect customisable lanes #1362 #1346 (aubergine18)
+[Fixed] Fix `SPEED_TO_MPH` value in `ApiConstants.cs` #1364 #1363 #988 (aubergine18)
+[Removed] Obsolete: `SPEED_TO_MPH` and `SPEED_TO_KMPH` in `Constants.cs` #1364 #1363 (aubergine18)
+[/Version]
+
 [Version] 11.6.4.6
 [Stable]
 [Released] February 5th 2022

--- a/TLM/TLM/UI/WhatsNew/WhatsNew.cs
+++ b/TLM/TLM/UI/WhatsNew/WhatsNew.cs
@@ -11,7 +11,7 @@ namespace TrafficManager.UI.WhatsNew {
 
     public class WhatsNew {
         // bump and update what's new changelogs when new features added
-        public static readonly Version CurrentVersion = new Version(11,6,4,6);
+        public static readonly Version CurrentVersion = new Version(11,6,4,7);
 
         private const string WHATS_NEW_FILE = "whats_new.txt";
         private const string RESOURCES_PREFIX = "TrafficManager.Resources.";


### PR DESCRIPTION
- [Meta] TM:PE 11.6.4-hotfix-7
- [Meta] Bugfix for default speeds which affects speed limits tool, speed overlays, and roundabout curvature speed
- [Fixed] Default netinfo speed should only inspect customisable lanes #1362 #1346 (aubergine18)
- [Fixed] Fix `SPEED_TO_MPH` value in `ApiConstants.cs` #1364 #1363 #988 (aubergine18)
- [Removed] Obsolete: `SPEED_TO_MPH` and `SPEED_TO_KMPH` in `Constants.cs` #1367 #1364 #1363 (aubergine18)