### PR TITLE
Rename `OptionsKeybindsTab` -> `KeybindsTab`

### DIFF
--- a/TLM/TLM/State/Options.cs
+++ b/TLM/TLM/State/Options.cs
@@ -163,7 +163,7 @@ namespace TrafficManager.State {
                 OptionsVehicleRestrictionsTab.MakeSettings_VehicleRestrictions(tabStrip);
                 OptionsOverlaysTab.MakeSettings_Overlays(tabStrip);
                 OptionsMaintenanceTab.MakeSettings_Maintenance(tabStrip);
-                OptionsKeybindsTab.MakeSettings_Keybinds(tabStrip);
+                KeybindsTab.MakeSettings_Keybinds(tabStrip);
                 tabStrip.Invalidate();
             } catch (Exception ex) {
                 ex.LogException();

--- a/TLM/TLM/State/OptionsTabs/KeybindsTab.cs
+++ b/TLM/TLM/State/OptionsTabs/KeybindsTab.cs
@@ -5,7 +5,7 @@ namespace TrafficManager.State {
     using TrafficManager.UI.Helpers;
     using TrafficManager.UI;
 
-    public static class OptionsKeybindsTab {
+    public static class KeybindsTab {
         internal static void MakeSettings_Keybinds(ExtUITabstrip tabStrip) {
             string keybindsTabText = Translation.Options.Get("Tab:Keybinds");
             UIHelper panelHelper = tabStrip.AddTabPage(keybindsTabText, false);

--- a/TLM/TLM/TLM.csproj
+++ b/TLM/TLM/TLM.csproj
@@ -300,7 +300,7 @@
     <Compile Include="State\Keybinds\KeybindUI.cs" />
     <Compile Include="State\OptionsTabs\OptionsGameplayTab.cs" />
     <Compile Include="State\OptionsTabs\OptionsGeneralTab.cs" />
-    <Compile Include="State\OptionsTabs\OptionsKeybindsTab.cs" />
+    <Compile Include="State\OptionsTabs\KeybindsTab.cs" />
     <Compile Include="State\OptionsTabs\OptionsMaintenanceTab.cs" />
     <Compile Include="State\OptionsTabs\OptionsMassEditTab.cs" />
     <Compile Include="State\OptionsTabs\OptionsOverlaysTab.cs" />


### PR DESCRIPTION
Phase 1 refactor as per #1356

There will be separate PR for each of the other tabs.

Note how little code this rename touched - very well organised tab!