### PR TITLE
Remove duplicate `RemoveCitizenInstanceButtonExtender` line

### DIFF
--- a/TLM/TLM/Lifecycle/TMPELifecycle.cs
+++ b/TLM/TLM/Lifecycle/TMPELifecycle.cs
@@ -326,13 +326,14 @@ namespace TrafficManager.Lifecycle {
 
                 GlobalConfig.OnLevelUnloading();
 
-                // destroy immidately to prevent duplicates after hot-reload.
-                var uiviewGO = UIView.GetAView().gameObject;
-                DestroyImmediate(uiviewGO.GetComponent<RoadSelectionPanels>());
-                DestroyImmediate(uiviewGO.GetComponent<RemoveVehicleButtonExtender>());
-                DestroyImmediate(uiviewGO.GetComponent<RemoveCitizenInstanceButtonExtender>());
-                DestroyImmediate(uiviewGO.GetComponent<RemoveCitizenInstanceButtonExtender>());
-                DestroyImmediate(uiviewGO.GetComponent<UITransportDemand>());
+                if (PlayMode) {
+                    // destroy immidately to prevent duplicates after hot-reload.
+                    var uiviewGO = UIView.GetAView().gameObject;
+                    DestroyImmediate(uiviewGO.GetComponent<RoadSelectionPanels>());
+                    DestroyImmediate(uiviewGO.GetComponent<RemoveVehicleButtonExtender>());
+                    DestroyImmediate(uiviewGO.GetComponent<RemoveCitizenInstanceButtonExtender>());
+                    DestroyImmediate(uiviewGO.GetComponent<UITransportDemand>());
+                }
 
                 Log.Info("Removing Controls from UI.");
                 if (ModUI.Instance) {


### PR DESCRIPTION
This line appeared twice in `TMPELifecycle.Unload()`:

```csharp
DestroyImmediate(uiviewGO.GetComponent<RemoveCitizenInstanceButtonExtender>());
DestroyImmediate(uiviewGO.GetComponent<RemoveCitizenInstanceButtonExtender>());
```

Removed the duplicate.

Also wrapped that chunk of code in `if (PlayMode)` block (see commit), as those things only exist in `PlayMode`.