### PR TITLE
Add options API

### DIFF
--- a/TLM/TLM/Lifecycle/TMPELifecycle.cs
+++ b/TLM/TLM/Lifecycle/TMPELifecycle.cs
@@ -305,6 +305,8 @@ namespace TrafficManager.Lifecycle {
 
         internal void Unload() {
             try {
+                Options.Available = false;
+
                 GeometryNotifierDisposable?.Dispose();
                 GeometryNotifierDisposable = null;
 

--- a/TLM/TLM/Manager/Impl/OptionsManager.cs
+++ b/TLM/TLM/Manager/Impl/OptionsManager.cs
@@ -31,13 +31,6 @@ namespace TrafficManager.Manager.Impl {
         }
 
         /// <summary>
-        /// Determine if TM:PE mod options in <see cref="Options"/> are safe to query.
-        /// </summary>
-        /// <returns>Returns <c>true</c> if safe to query, otherwise <c>false</c>.</returns>
-        /// <remarks>Options are only safe to query in editor/game, except while loading/saving.</remarks>
-        public bool OptionsAreSafeToQuery() => Options.Available;
-
-        /// <summary>
         /// API method for external mods to get option values by name.
         /// </summary>
         /// <typeparam name="TVal">Option type, eg. <c>bool</c>.</typeparam>
@@ -46,6 +39,11 @@ namespace TrafficManager.Manager.Impl {
         /// <returns>Returns <c>true</c> if successful, or <c>false</c> if there was a problem (eg. option not found, wrong TVal, etc).</returns>
         /// <remarks>Check <see cref="OptionsAreSafeToQuery"/> first before trying to get an option value.</remarks>
         public bool TryGetOptionByName<TVal>(string optionName, out TVal value) {
+            if (!Options.Available) {
+                value = default;
+                return false;
+            }
+
             var field = typeof(Options).GetField(optionName, BindingFlags.Static | BindingFlags.Public);
 
             if (field == null || field.FieldType is not TVal) {
@@ -198,8 +196,6 @@ namespace TrafficManager.Manager.Impl {
 
         public byte[] SaveData(ref bool success) {
 
-            Options.Available = false;
-
             // Remember to update this when adding new options (lastIdx + 1)
             var save = new byte[59];
 
@@ -269,15 +265,10 @@ namespace TrafficManager.Manager.Impl {
 
                 save[58] = (byte)Options.SavegamePathfinderEdition;
 
-                Options.Available = true;
-
                 return save;
             }
             catch (Exception ex) {
                 ex.LogException();
-
-                Options.Available = true;
-
                 return save; // try and salvage some of the settings
             }
         }

--- a/TLM/TLM/State/Options.cs
+++ b/TLM/TLM/State/Options.cs
@@ -36,12 +36,9 @@ namespace TrafficManager.State {
 
         /// <summary>
         /// When <c>true</c>, options are safe to query.
-        ///
-        /// When <c>false</c>, options are being loaded/saved/unloaded and should not be queried.
         /// </summary>
         /// <remarks>
         /// Is set <c>true</c> after options are loaded via <see cref="Manager.Impl.OptionsManager"/>.
-        /// 
         /// Is set <c>false</c> while options are being saved, and also when level unloads.
         /// </remarks>
         public static bool Available = false;

--- a/TLM/TLM/State/Options.cs
+++ b/TLM/TLM/State/Options.cs
@@ -25,6 +25,7 @@ namespace TrafficManager.State {
         // private static UITextField pathCostMultiplicator2Field = null;
 #endif
 
+        // Likely to change or be removed in future
         [Flags]
         public enum PersistTo {
             None = 0,
@@ -32,6 +33,18 @@ namespace TrafficManager.State {
             Savegame = 2,
             GlobalOrSavegame = Global | Savegame,
         }
+
+        /// <summary>
+        /// When <c>true</c>, options are safe to query.
+        ///
+        /// When <c>false</c>, options are being loaded/saved/unloaded and should not be queried.
+        /// </summary>
+        /// <remarks>
+        /// Is set <c>true</c> after options are loaded via <see cref="Manager.Impl.OptionsManager"/>.
+        /// 
+        /// Is set <c>false</c> while options are being saved, and also when level unloads.
+        /// </remarks>
+        public static bool Available = false;
 
         public static bool instantEffects = true;
         public static bool individualDrivingStyle = true;

--- a/TLM/TMPE.API/Manager/IOptionsManager.cs
+++ b/TLM/TMPE.API/Manager/IOptionsManager.cs
@@ -1,4 +1,4 @@
-﻿namespace TrafficManager.API.Manager {
+namespace TrafficManager.API.Manager {
     /// <summary>
     /// Manages mod options
     /// </summary>
@@ -8,5 +8,21 @@
         /// </summary>
         /// <returns>true if changes may be published, false otherwise</returns>
         bool MayPublishSegmentChanges();
+
+        /// <summary>
+        /// Determine if TM:PE mod options in <see cref="Options"/> are safe to query.
+        /// </summary>
+        /// <returns>Returns <c>true</c> if safe to query, otherwise <c>false</c>.</returns>
+        /// <remarks>Options are only safe to query in editor/game, except while loading/saving.</remarks>
+        public bool OptionsAreSafeToQuery();
+
+        /// <summary>
+        /// Get current value of TMPE mod option from <see cref="Options"/>.
+        /// </summary>
+        /// <typeparam name="TVal">Option type, eg. <c>bool</c>.</typeparam>
+        /// <param name="optionName">Name of the option in <see cref="Options"/>.</param>
+        /// <param name="value">The option value, if found, otherwise <c>default</c> for <typeparamref name="TVal"/>.</param>
+        /// <returns>Returns <c>true</c> if successful, or <c>false</c> if there was a problem (eg. option not found, wrong TVal, etc).</returns>
+        bool TryGetOptionByName<TVal>(string optionName, out TVal value);
     }
 }

--- a/TLM/TMPE.API/Manager/IOptionsManager.cs
+++ b/TLM/TMPE.API/Manager/IOptionsManager.cs
@@ -10,13 +10,6 @@ namespace TrafficManager.API.Manager {
         bool MayPublishSegmentChanges();
 
         /// <summary>
-        /// Determine if TM:PE mod options in <see cref="Options"/> are safe to query.
-        /// </summary>
-        /// <returns>Returns <c>true</c> if safe to query, otherwise <c>false</c>.</returns>
-        /// <remarks>Options are only safe to query in editor/game, except while loading/saving.</remarks>
-        public bool OptionsAreSafeToQuery();
-
-        /// <summary>
         /// Get current value of TMPE mod option from <see cref="Options"/>.
         /// </summary>
         /// <typeparam name="TVal">Option type, eg. <c>bool</c>.</typeparam>


### PR DESCRIPTION
Fixes: #1376 

Simple API for external mods to get TM:PE mod `Options` values. For example, if a mod needs to know which TMPE features are enabled, or get info on policy settings, icon theme, etc.

Vague example:

```csharp
var mgr = OptionsManager.Instance;

if (mgr != null && mgr.OptionsAreSafeToQuery()) {
    if (mgr.TryGetOptionByName<bool>("turnOnRedEnabled", out bool turnOnRedEnabled) {
        if (turnOnRedEnabled) {
            // show some extra features in your traffic lights mod or whatever
        }
    }
}
```

Options are referenced by name, thus allowing us to alter names at later date whilst keeping API intact (a simple oldname -> newname lookup can be added on our side).

Options are accessed via reflection - while not super fast, it's reliable and allows us to easily handle possible future transition from option fields to properties, etc.

Thanks to @DaEgi01 for suggestion to use generics.