### PR TITLE
Allow vehicles to use restricted lanes when spawning or arriving at destination

### DIFF
--- a/TLM/TLM/Custom/PathFinding/CustomPathFind.cs
+++ b/TLM/TLM/Custom/PathFinding/CustomPathFind.cs
@@ -4005,6 +4005,11 @@ namespace TrafficManager.Custom.PathFinding {
                 return true;
             }
 
+            if (startLaneA_ == laneId || startLaneB_ == laneId ||
+                endLaneA_ == laneId || endLaneB_ == laneId) {
+                return true;
+            }
+
             ExtVehicleType allowedTypes = vehicleRestrictionsManager.GetAllowedVehicleTypes(
                 segmentId,
                 segmentInfo,
@@ -4012,9 +4017,7 @@ namespace TrafficManager.Custom.PathFinding {
                 laneInfo,
                 VehicleRestrictionsMode.Configured);
 
-            return (allowedTypes & queueItem_.vehicleType) != ExtVehicleType.None ||
-                   startLaneA_ == laneId || startLaneB_ == laneId ||
-                   endLaneA_ == laneId || endLaneB_ == laneId;
+            return (allowedTypes & queueItem_.vehicleType) != ExtVehicleType.None;
         }
 #endif
 

--- a/TLM/TLM/Custom/PathFinding/CustomPathFind.cs
+++ b/TLM/TLM/Custom/PathFinding/CustomPathFind.cs
@@ -3541,7 +3541,7 @@ namespace TrafficManager.Custom.PathFinding {
              * Check vehicle restrictions, especially bans
              * =====================================================================================
              */
-            bool canUseLane = CanUseLane(prevSegmentId, prevSegmentInfo, prevLaneIndex, prevLaneInfo);
+            bool canUseLane = CanUseLane(prevSegmentId, prevSegmentInfo, prevLaneIndex, prevLaneInfo, item.LaneId);
             if (!canUseLane && Options.vehicleRestrictionsAggression ==
                 VehicleRestrictionsAggression.Strict) {
                 // vehicle is strictly prohibited to use this lane
@@ -3979,10 +3979,22 @@ namespace TrafficManager.Custom.PathFinding {
         }
 
 #if VEHICLERESTRICTIONS
+        /// <summary>
+        /// Check if lane can be used by vehicle requesting path
+        /// </summary>
+        /// <param name="segmentId">segment ID</param>
+        /// <param name="segmentInfo">">segment NetInfo</param>
+        /// <param name="laneIndex">lane index</param>
+        /// <param name="laneInfo">lane LaneInfo</param>
+        /// <param name="laneId">lane ID</param>
+        /// <returns>true if vehicle restrictions is disabled,
+        /// lane vehicle restriction allow vehicle type or lane is start/end of the path
+        /// otherwise false</returns>
         private bool CanUseLane(ushort segmentId,
                                 NetInfo segmentInfo,
                                 int laneIndex,
-                                NetInfo.Lane laneInfo) {
+                                NetInfo.Lane laneInfo,
+                                uint laneId) {
             if (!Options.vehicleRestrictionsEnabled ||
                 queueItem_.vehicleType == ExtVehicleType.None ||
                 queueItem_.vehicleType == ExtVehicleType.Tram ||
@@ -4000,7 +4012,9 @@ namespace TrafficManager.Custom.PathFinding {
                 laneInfo,
                 VehicleRestrictionsMode.Configured);
 
-            return (allowedTypes & queueItem_.vehicleType) != ExtVehicleType.None;
+            return (allowedTypes & queueItem_.vehicleType) != ExtVehicleType.None ||
+                   startLaneA_ == laneId || startLaneB_ == laneId ||
+                   endLaneA_ == laneId || endLaneB_ == laneId;
         }
 #endif
 


### PR DESCRIPTION
Improved `CanUseLane` PathFind function to skip checking vehicle restrictions at the `start` and `end` lanes of the calculating path. Solves issues with spawning and delivering goods/industry products

Closes #1380
Fixes #85 
It may also fix #494 since on some screenshots roads look like 6-lane with bus. Issue itself is pretty weird so... no idea.

_Note: workaround from #85 no longer be necessary_ 😉  

Build: [zip](https://ci.appveyor.com/api/projects/krzychu124/tmpe/artifacts/TMPE.zip?branch=bugfix/1380-vehicles-not-spawning-ban-cars-trucks-on-bus-lane)