### PR TITLE
What's New in TM:PE 11.6.4.8 ?

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ This changelog includes all versions and major variants of the mod going all the
 
 - [Meta] TM:PE 11.6.4-hotfix-8
 - [Meta] Bugfix for vehicle spawning/delivery on restricted lanes
+- [Mod] Malware: We are treating all mods by Chaos/Holy Water (same person) as targeted malware #1389 #1388 (aubergine18)
 - [Fixed] Allow vehicles to use restricted lanes when spawning/delivering #1381 #1380 #494 #85 (krzychu124)
 - [Steam] [TM:PE v11 STABLE](https://steamcommunity.com/sharedfiles/filedetails/?id=1637663252)
 
@@ -40,6 +41,7 @@ This changelog includes all versions and major variants of the mod going all the
 
 - [Meta] TM:PE 11.6.4-hotfix-8
 - [Meta] Bugfix for vehicle spawning/delivery on restricted lanes
+- [Mod] Malware: We are treating all mods by Chaos/Holy Water (same person) as targeted malware #1389 #1388 (aubergine18)
 - [Fixed] Allow vehicles to use restricted lanes when spawning/delivering #1381 #1380 #494 #85 (krzychu124)
 - [Steam] [TM:PE v11 TEST](https://steamcommunity.com/sharedfiles/filedetails/?id=2489276785)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,20 @@ This changelog includes all versions and major variants of the mod going all the
 
 </details>
 
+#### TM:PE V11.6.4.8 STABLE, 09/02/2022
+
+- [Meta] TM:PE 11.6.4-hotfix-8
+- [Meta] Bugfix for vehicle spawning/delivery on restricted lanes
+- [Fixed] Allow vehicles to use restricted lanes when spawning/delivering #1381 #1380 #494 #85 (krzychu124)
+- [Steam] [TM:PE v11 STABLE](https://steamcommunity.com/sharedfiles/filedetails/?id=1637663252)
+
+#### TM:PE V11.6.4.8 TEST, 09/02/2022
+
+- [Meta] TM:PE 11.6.4-hotfix-8
+- [Meta] Bugfix for vehicle spawning/delivery on restricted lanes
+- [Fixed] Allow vehicles to use restricted lanes when spawning/delivering #1381 #1380 #494 #85 (krzychu124)
+- [Steam] [TM:PE v11 TEST](https://steamcommunity.com/sharedfiles/filedetails/?id=2489276785)
+
 #### TM:PE V11.6.4.7 STABLE, 06/02/2022
 
 - [Meta] TM:PE 11.6.4-hotfix-7
@@ -964,11 +978,11 @@ This changelog includes all versions and major variants of the mod going all the
 - [Updated] Turn-on-red can now be toggled for unpreferred (far-side) turns between one-ways
 - [Updated] Train behaviour at shunts: Trains now prefer to stay on their track (#230)
 - [Updated] Parking AI: Improved public transport (PT) usage patterns, mixed car/PT paths are now possible (#218)
-- [Fixed] and optimized lane selection for U-turns and at dead ends (#101)
+- [Fixed] and optimized lane selection for U-turns and at dead ends (#233 #101 #85)
 - [Fixed] Parking AI: Tourist cars despawn because they assume they are at an outside connection (#218)
 - [Fixed] Parking AI: Return path calculation did not accept beautification segments (#218)
 - [Fixed] Parking AI: Cars/Citizens waiting for a path might jump around (#218)
-- [Fixed] Vanilla lane randomization does not work as intended at highway transitions (#112)
+- [Fixed] Vanilla lane randomization does not work as intended at highway transitions (#233 #112)
 - [Fixed] Vehicles change lanes at tollbooths (#225)
 - [Fixed] Path-finding: Array index is out of range due to a race condition (#221)
 - [Fixed] Citizen not found errors when using walking tours (#219)
@@ -982,11 +996,11 @@ This changelog includes all versions and major variants of the mod going all the
 - [New] Turn-on-red can now be toggled for unpreferred (far-side) turns between one-ways (#121)
 - [Updated] Train behaviour at shunts: Trains now prefer to stay on their track (#230)
 - [Updated] Parking AI - Improved public transport (PT) usage patterns, mixed car/PT paths are now possible  (#218)
-- [Fixed] Lane selection for U-turns and at dead ends (also optimised) (#101)
+- [Fixed] Lane selection for U-turns and at dead ends (also optimised) (#233 #101 #85)
 - [Fixed] Parking AI - Tourist cars despawn because they assume they are at an outside connection (#218)
 - [Fixed] Parking AI - Return path calculation did not accept beautification segments (#218)
 - [Fixed] Parking AI - Cars/Citizens waiting for a path might jump around (#218)
-- [Fixed] Vanilla lane randomization does not work as intended at highway transitions (#112)
+- [Fixed] Vanilla lane randomization does not work as intended at highway transitions (#233 #112)
 - [Fixed] Vehicles change lanes at tollbooths (#225)
 - [Fixed] Path-finding: Array index is out of range due to a race condition (#221)
 - [Fixed] Citizen not found errors when using walking tours (#219)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,21 +29,21 @@ This changelog includes all versions and major variants of the mod going all the
 
 </details>
 
-#### TM:PE V11.6.4.8 STABLE, 09/02/2022
+#### TM:PE V[11.6.4.8](https://github.com/CitiesSkylinesMods/TMPE/compare/11.6.4.7...11.6.4.8) STABLE, 10/02/2022
 
 - [Meta] TM:PE 11.6.4-hotfix-8
 - [Meta] Bugfix for vehicle spawning/delivery on restricted lanes
 - [Fixed] Allow vehicles to use restricted lanes when spawning/delivering #1381 #1380 #494 #85 (krzychu124)
 - [Steam] [TM:PE v11 STABLE](https://steamcommunity.com/sharedfiles/filedetails/?id=1637663252)
 
-#### TM:PE V11.6.4.8 TEST, 09/02/2022
+#### TM:PE V11.6.4.8 TEST, 10/02/2022
 
 - [Meta] TM:PE 11.6.4-hotfix-8
 - [Meta] Bugfix for vehicle spawning/delivery on restricted lanes
 - [Fixed] Allow vehicles to use restricted lanes when spawning/delivering #1381 #1380 #494 #85 (krzychu124)
 - [Steam] [TM:PE v11 TEST](https://steamcommunity.com/sharedfiles/filedetails/?id=2489276785)
 
-#### TM:PE V11.6.4.7 STABLE, 06/02/2022
+#### TM:PE V[11.6.4.7](https://github.com/CitiesSkylinesMods/TMPE/compare/11.6.4.6...11.6.4.7) STABLE, 06/02/2022
 
 - [Meta] TM:PE 11.6.4-hotfix-7
 - [Meta] Bugfix for default speeds which affects speed limits tool, overlays, and roundabout curvature speed
@@ -61,7 +61,7 @@ This changelog includes all versions and major variants of the mod going all the
 - [Removed] Obsolete: `SPEED_TO_MPH` and `SPEED_TO_KMPH` in `Constants.cs` #1367 #1364 #1363 (aubergine18)
 - [Steam] [TM:PE v11 TEST](https://steamcommunity.com/sharedfiles/filedetails/?id=2489276785)
 
-#### TM:PE V11.6.4.6 STABLE, 05/02/2022
+#### TM:PE V[11.6.4.6](https://github.com/CitiesSkylinesMods/TMPE/compare/11.6.4.5...11.6.4.6) STABLE, 05/02/2022
 
 - [Meta] TM:PE 11.6.4-hotfix-6
 - [Meta] Fixes some issues relating to CSUR and similar networks
@@ -79,7 +79,7 @@ This changelog includes all versions and major variants of the mod going all the
 - [Updated] Internal changes to `CheckboxOption` code #1301 #1299 #1279 (aubergine18)
 - [Steam] [TM:PE v11 TEST](https://steamcommunity.com/sharedfiles/filedetails/?id=2489276785)
 
-#### TM:PE V11.6.4.5 STABLE, 02/02/2022
+#### TM:PE V[11.6.4.5](https://github.com/CitiesSkylinesMods/TMPE/compare/11.6.4.4...11.6.4.5) STABLE, 02/02/2022
 
 - [Meta] TM:PE 11.6.4-hotfix-5
 - [Meta] Updates to error checking/logging, and refine pathfinder edition checks
@@ -99,7 +99,7 @@ This changelog includes all versions and major variants of the mod going all the
 - [Updated] Add new `.Info()` panel to `Prompt` class #1347 (krzychu124)
 - [Steam] [TM:PE v11 TEST](https://steamcommunity.com/sharedfiles/filedetails/?id=2489276785)
 
-#### TM:PE V11.6.4.4 STABLE, 01/02/2022
+#### TM:PE V[11.6.4.4](https://github.com/CitiesSkylinesMods/TMPE/compare/11.6.4.3...11.6.4.4) STABLE, 01/02/2022
 
 - [Meta] TM:PE 11.6.4-hotfix-4
 - [Meta] Bugfix release targeting aircraft pathfinding, and info views.
@@ -123,7 +123,7 @@ This changelog includes all versions and major variants of the mod going all the
 - [Updated] TM:PE toolbar closes in non-applicable info views #1333 (aubergine18)
 - [Steam] [TM:PE v11 TEST](https://steamcommunity.com/sharedfiles/filedetails/?id=2489276785)
 
-#### TM:PE V11.6.4.3 STABLE, 29/01/2022
+#### TM:PE V[11.6.4.3](https://github.com/CitiesSkylinesMods/TMPE/compare/11.6.4.2...11.6.4.3) STABLE, 29/01/2022
 
 - [Meta] TM:PE 11.6.4-hotfix-3
 - [Meta] This fixes rare issue on some PCs that are limited to single CPU core
@@ -143,7 +143,7 @@ This changelog includes all versions and major variants of the mod going all the
 - [Removed] Temporary: Don't auto-show What's New on TM:PE menu button click #1336 #1314 (krzychu124, aubergine18)
 - [Steam] [TM:PE v11 TEST](https://steamcommunity.com/sharedfiles/filedetails/?id=2489276785)
 
-#### TM:PE V11.6.4.2 STABLE, 27/01/2022
+#### TM:PE V[11.6.4.2](https://github.com/CitiesSkylinesMods/TMPE/compare/11.6.4.1...11.6.4.2) STABLE, 27/01/2022
 
 - [Meta] TM:PE 11.6.4-hotfix-2
 - [Fixed] Speed limit icons not appearing on metro tracks #1323 #1322 (krzychu124)
@@ -155,7 +155,7 @@ This changelog includes all versions and major variants of the mod going all the
 - [Fixed] Speed limit icons not appearing on metro tracks #1323 #1322 (krzychu124)
 - [Steam] [TM:PE v11 TEST](https://steamcommunity.com/sharedfiles/filedetails/?id=2489276785)
 
-#### TM:PE V11.6.4.1 STABLE, 26/01/2022
+#### TM:PE V[11.6.4.1](https://github.com/CitiesSkylinesMods/TMPE/compare/11.6.4...11.6.4.1) STABLE, 26/01/2022
 
 - [Meta] TM:PE 11.6.4-hotfix-1
 - [Updated] What's New panel updated to avoid recursive update issue #1319 #1317 #1314 (aubergine18)

--- a/README.md
+++ b/README.md
@@ -41,6 +41,13 @@
 
 > Date format: dd/mm/yyyy
 
+#### TM:PE V11.6.4.8 STABLE, 09/02/2022
+
+- [Meta] TM:PE 11.6.4-hotfix-8
+- [Meta] Bugfix for vehicle spawning/delivery on restricted lanes
+- [Fixed] Allow vehicles to use restricted lanes when spawning/delivering #1381 #1380 #494 #85 (krzychu124)
+- [Steam] [TM:PE v11 STABLE](https://steamcommunity.com/sharedfiles/filedetails/?id=1637663252)
+
 #### TM:PE V11.6.4.7 STABLE, 06/02/2022
 
 - [Meta] TM:PE 11.6.4-hotfix-7
@@ -48,16 +55,6 @@
 - [Fixed] Default netinfo speed should only inspect customisable lanes #1362 #1346 (aubergine18)
 - [Fixed] Fix `SPEED_TO_MPH` value in `ApiConstants.cs` #1364 #1363 #988 (aubergine18)
 - [Removed] Obsolete: `SPEED_TO_MPH` and `SPEED_TO_KMPH` in `Constants.cs` #1367 #1364 #1363 (aubergine18)
-- [Steam] [TM:PE v11 STABLE](https://steamcommunity.com/sharedfiles/filedetails/?id=1637663252)
-
-
-#### TM:PE V11.6.4.6 STABLE, 05/02/2022
-
-- [Meta] TM:PE 11.6.4-hotfix-6
-- [Meta] Fixes some issues relating to CSUR and similar networks
-- [Mod] Incompatible: All versions of Cities Skylines Multiplayer (CSM) #1360 #1359 (aubergine18)
-- [Fixed] Missing lane connectors on CSUR and similar networks #1355 #1357 (krzychu124)
-- [Updated] Internal changes to `CheckboxOption` code #1301 #1299 #1279 (aubergine18)
 - [Steam] [TM:PE v11 STABLE](https://steamcommunity.com/sharedfiles/filedetails/?id=1637663252)
 
 ## Support Policy

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@
 
 > Date format: dd/mm/yyyy
 
-#### TM:PE V11.6.4.8 STABLE, 09/02/2022
+#### TM:PE V11.6.4.8 STABLE, 10/02/2022
 
 - [Meta] TM:PE 11.6.4-hotfix-8
 - [Meta] Bugfix for vehicle spawning/delivery on restricted lanes

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@
 
 - [Meta] TM:PE 11.6.4-hotfix-8
 - [Meta] Bugfix for vehicle spawning/delivery on restricted lanes
+- [Mod] Malware: We are treating all mods by Chaos/Holy Water (same person) as targeted malware #1389 #1388 (aubergine18)
 - [Fixed] Allow vehicles to use restricted lanes when spawning/delivering #1381 #1380 #494 #85 (krzychu124)
 - [Steam] [TM:PE v11 STABLE](https://steamcommunity.com/sharedfiles/filedetails/?id=1637663252)
 

--- a/TLM/TLM/Resources/whats_new.txt
+++ b/TLM/TLM/Resources/whats_new.txt
@@ -5,6 +5,7 @@
 [Meta] TM:PE 11.6.4-hotfix-8
 [Meta] Bugfix for vehicle spawning/delivery on restricted lanes
 [Fixed] Allow vehicles to use restricted lanes when spawning/delivering #1381 #1380 #494 #85 (krzychu124)
+[Mod] Malware: We are treating all mods by Chaos/Holy Water (same person) as targeted malware #1389 #1388 (aubergine18)
 [/Version]
 
 [Version] 11.6.4.7

--- a/TLM/TLM/Resources/whats_new.txt
+++ b/TLM/TLM/Resources/whats_new.txt
@@ -1,7 +1,16 @@
+[Version] 11.6.4.8
+[Stable]
+[Released] February 9th 2022
+[Link] tmpe-v11648-stable-09022022
+[Meta] TM:PE 11.6.4-hotfix-8
+[Meta] Bugfix for vehicle spawning/delivery on restricted lanes
+[Fixed] Allow vehicles to use restricted lanes when spawning/delivering #1381 #1380 #494 #85 (krzychu124)
+[/Version]
+
 [Version] 11.6.4.7
 [Stable]
 [Released] February 6th 2022
-[Link] tmpe-v11646-stable-06022022
+[Link] tmpe-v11647-stable-06022022
 [Meta] TM:PE 11.6.4-hotfix-7
 [Meta] Bugfix for default speeds which affects speed limits tool, overlays, and roundabout curvature speed
 [Fixed] Default netinfo speed should only inspect customisable lanes #1362 #1346 (aubergine18)

--- a/TLM/TLM/Resources/whats_new.txt
+++ b/TLM/TLM/Resources/whats_new.txt
@@ -1,7 +1,7 @@
 [Version] 11.6.4.8
 [Stable]
-[Released] February 9th 2022
-[Link] tmpe-v11648-stable-09022022
+[Released] February 10th 2022
+[Link] tmpe-v11648-stable-10022022
 [Meta] TM:PE 11.6.4-hotfix-8
 [Meta] Bugfix for vehicle spawning/delivery on restricted lanes
 [Fixed] Allow vehicles to use restricted lanes when spawning/delivering #1381 #1380 #494 #85 (krzychu124)

--- a/TLM/TLM/UI/WhatsNew/WhatsNew.cs
+++ b/TLM/TLM/UI/WhatsNew/WhatsNew.cs
@@ -11,7 +11,7 @@ namespace TrafficManager.UI.WhatsNew {
 
     public class WhatsNew {
         // bump and update what's new changelogs when new features added
-        public static readonly Version CurrentVersion = new Version(11,6,4,7);
+        public static readonly Version CurrentVersion = new Version(11,6,4,8);
 
         private const string WHATS_NEW_FILE = "whats_new.txt";
         private const string RESOURCES_PREFIX = "TrafficManager.Resources.";


### PR DESCRIPTION
This is a bugfix release to solve an ancient bug in the pathfinder which prevents road vehicles spawning/delivering at lanes with vehicle restrictions.

- [Meta] TM:PE 11.6.4-hotfix-8
- [Meta] Bugfix for vehicle spawning/delivery on restricted lanes
- [Mod] Malware: We are treating all mods by Chaos/Holy Water (same person) as targeted malware #1389 #1388 (aubergine18)
- [Fixed] Allow vehicles to use vehicle-restricted lane when spawning/delivering #1381 #1380 #494 #85 (krzychu124)