### PR TITLE
Mark known and potential `MALWARE` mods as incompatible

### DIFF
--- a/TLM/TLM/Resources/incompatible_mods.txt
+++ b/TLM/TLM/Resources/incompatible_mods.txt
@@ -76,3 +76,7 @@
 1731754018;CSM
 1558438291;Cities Multiplayer Mod (CSM) [Beta]
 1556669944;CSM
+2730687809;Network Extensions 3 - contains malware targeting TM:PE devs
+2399343344;Harmony (redesigned) - by same author of the malware, and potentially much more dangerous
+2389228470;Transfer Broker BETA - by same author of the malware
+2325122732;Supply Chain Coloring - by same author of the malware

--- a/TLM/TLM/Util/ModsCompatibilityChecker.cs
+++ b/TLM/TLM/Util/ModsCompatibilityChecker.cs
@@ -33,6 +33,7 @@ namespace TrafficManager.Util {
                 "CSM",
                 "Cities Skylines Multiplayer (CSM)",
                 "Cities: Skylines Multiplayer (CSM) [Beta]",
+                "Harmony (redesigned)",
             });
         }
 


### PR DESCRIPTION
Steam user `Chaos`, aka `Holy Water` (same person), has added malware specifically targeting multiple modders by their Steam IDs, including TM:PE devs, to Network Extensions 3 mod (which to this day still contains an old copy of TM:PE lol).

A [sample of code from NExt3](https://github.com/drok/NetworkExtensions3/blob/0c705c394e6bc48ad5776941bf73d8c5629a183a/Transit.Framework/_Extensions/NetInfoExtensions.Lane.cs#L29-L38):

> https://github.com/drok/NetworkExtensions3/blob/0c705c394e6bc48ad5776941bf73d8c5629a183a/Transit.Framework/_Extensions/NetInfoExtensions.Lane.cs#L29-L38
>  
> And an image if he blocks access to the repo at later date:
>  
> ![sample code from NExt3](https://imgur.com/tV15bdV.png)

He already has a [list of ~60 people in NExt 3](https://github.com/drok/NetworkExtensions3/blob/master/Transit.Framework/Mod/AccessControlLists.cs) - including people who worked on NExt back in the day, [myself included!](https://steamcommunity.com/sharedfiles/filedetails/?id=543703997) (to this day NExt3 still has "Transit Addon Mod" components), to alter road speeds should they use the mod.

He has also been caught (by actually telling everyone he did it) adding a "tripwire" to his mods so that they break if used with the main Harmony mod that most of the community uses, and then he uses those bugs as "evidence" that the mod he's attacking is broken (it's not, obviously given the 1+ million users it has!).

While altering road speeds is not a big deal, the fact that he's making lists and actively disrupting the community - whilst at the same time claiming that _he_ is the victim of harrassment - is cause for concern. Noably, Harmony includes Mono Cecil. And now it's in the hands of a lunatic with a track record of harassing people, targeted malware, and tripwire bugs.

As such, there's no way we can support his mods - and there's no telling what he's put in his Harmony mod which uses Mono Cecil.