### PR TITLE
ToCitizenUnit via extension methods.

### DIFF
--- a/TLM/TLM/Manager/Impl/ExtVehicleManager.cs
+++ b/TLM/TLM/Manager/Impl/ExtVehicleManager.cs
@@ -65,18 +65,23 @@ namespace TrafficManager.Manager.Impl {
             }
         }
 
+        /// <summary>
+        /// Gets the driver from a vehicle.
+        /// See PassengerCarAI.GetDriverInstance - almost stock code.
+        /// </summary>
+        /// <param name="vehicleId">Id of the vehicle.</param>
+        /// <param name="data">Vehicle data of the vehicle.</param>
+        /// <returns>CitizenInstanceId of the driver.</returns>
         public ushort GetDriverInstanceId(ushort vehicleId, ref Vehicle data) {
-            // (stock code from PassengerCarAI.GetDriverInstance)
             CitizenManager citizenManager = Singleton<CitizenManager>.instance;
             uint citizenUnitId = data.m_citizenUnits;
             uint maxUnitCount = citizenManager.m_units.m_size;
             int numIter = 0;
 
             while (citizenUnitId != 0) {
-                uint nextCitizenUnitId = citizenManager.m_units.m_buffer[citizenUnitId].m_nextUnit;
-
+                ref CitizenUnit citizenUnit = ref citizenUnitId.ToCitizenUnit();
                 for (int i = 0; i < 5; i++) {
-                    uint citizenId = citizenManager.m_units.m_buffer[citizenUnitId].GetCitizen(i);
+                    uint citizenId = citizenUnit.GetCitizen(i);
 
                     if (citizenId != 0) {
                         ushort citizenInstanceId =
@@ -87,7 +92,7 @@ namespace TrafficManager.Manager.Impl {
                     }
                 }
 
-                citizenUnitId = nextCitizenUnitId;
+                citizenUnitId = citizenUnit.m_nextUnit;
                 if (++numIter > maxUnitCount) {
                     CODebugBase<LogChannel>.Error(
                         LogChannel.Core,

--- a/TLM/TLM/Manager/Impl/VehicleBehaviorManager.cs
+++ b/TLM/TLM/Manager/Impl/VehicleBehaviorManager.cs
@@ -411,10 +411,10 @@ namespace TrafficManager.Manager.Impl {
                     int numIter = 0;
 
                     while (curUnitId != 0u) {
-                        uint nextUnit = citizenManager.m_units.m_buffer[curUnitId].m_nextUnit;
+                        ref CitizenUnit currentCitizenUnit = ref curUnitId.ToCitizenUnit();
 
                         for (int i = 0; i < 5; i++) {
-                            uint curCitizenId = citizenManager.m_units.m_buffer[curUnitId].GetCitizen(i);
+                            uint curCitizenId = currentCitizenUnit.GetCitizen(i);
 
                             if (curCitizenId != 0u) {
                                 ushort citizenInstanceId = citizenManager
@@ -459,7 +459,7 @@ namespace TrafficManager.Manager.Impl {
                             }
                         }
 
-                        curUnitId = nextUnit;
+                        curUnitId = currentCitizenUnit.m_nextUnit;
 
                         if (++numIter > maxUnitCount) {
                             CODebugBase<LogChannel>.Error(
@@ -485,10 +485,10 @@ namespace TrafficManager.Manager.Impl {
                 int numIter = 0;
 
                 while (curCitizenUnitId != 0u) {
-                    uint nextUnit = citizenManager.m_units.m_buffer[curCitizenUnitId].m_nextUnit;
+                    ref CitizenUnit currentCitizenUnit = ref curCitizenUnitId.ToCitizenUnit();
 
                     for (int j = 0; j < 5; j++) {
-                        uint citId = citizenManager.m_units.m_buffer[curCitizenUnitId].GetCitizen(j);
+                        uint citId = currentCitizenUnit.GetCitizen(j);
                         if (citId == 0u) {
                             continue;
                         }
@@ -534,7 +534,7 @@ namespace TrafficManager.Manager.Impl {
                         }
                     }
 
-                    curCitizenUnitId = nextUnit;
+                    curCitizenUnitId = currentCitizenUnit.m_nextUnit;
 
                     if (++numIter > maxUnitCount) {
                         CODebugBase<LogChannel>.Error(

--- a/TLM/TLM/Patch/_VehicleAI/_PassengerCarAI/ParkVehiclePatch.cs
+++ b/TLM/TLM/Patch/_VehicleAI/_PassengerCarAI/ParkVehiclePatch.cs
@@ -4,6 +4,7 @@ namespace TrafficManager.Patch._VehicleAI._PassengerCarAI {
     using HarmonyLib;
     using JetBrains.Annotations;
     using Manager.Impl;
+    using Util.Extensions;
 
     [UsedImplicitly]
     [HarmonyPatch(typeof(PassengerCarAI), "ParkVehicle")]
@@ -28,9 +29,9 @@ namespace TrafficManager.Patch._VehicleAI._PassengerCarAI {
             int numIterations = 0;
 
             while (curCitizenUnitId != 0u && driverCitizenId == 0u) {
-                uint nextUnit = citizenManager.m_units.m_buffer[curCitizenUnitId].m_nextUnit;
+                ref CitizenUnit currentCitizenUnit = ref curCitizenUnitId.ToCitizenUnit();
                 for (int i = 0; i < 5; i++) {
-                    uint citizenId = citizenManager.m_units.m_buffer[curCitizenUnitId].GetCitizen(i);
+                    uint citizenId = currentCitizenUnit.GetCitizen(i);
                     if (citizenId == 0u) {
                         continue;
                     }
@@ -49,7 +50,7 @@ namespace TrafficManager.Patch._VehicleAI._PassengerCarAI {
                     break;
                 }
 
-                curCitizenUnitId = nextUnit;
+                curCitizenUnitId = currentCitizenUnit.m_nextUnit;
                 if (++numIterations > maxUnitCount) {
                     CODebugBase<LogChannel>.Error(LogChannel.Core,
                                                   $"Invalid list detected!\n{Environment.StackTrace}");

--- a/TLM/TLM/TLM.csproj
+++ b/TLM/TLM/TLM.csproj
@@ -152,6 +152,7 @@
     <Compile Include="State\VersionInfo.cs" />
     <Compile Include="UI\WhatsNew\MarkupKeyword.cs" />
     <Compile Include="UI\WhatsNew\WhatsNewMarkup.cs" />
+    <Compile Include="Util\Extensions\CitizenUnitExtensions.cs" />
     <Compile Include="Util\Extensions\VersionExtension.cs" />
     <Compile Include="Util\Iterators\GetNodeSegmentIdsEnumerable.cs" />
     <Compile Include="Util\Iterators\GetNodeSegmentIdsEnumerator.cs" />

--- a/TLM/TLM/Util/Extensions/CitizenUnitExtensions.cs
+++ b/TLM/TLM/Util/Extensions/CitizenUnitExtensions.cs
@@ -1,0 +1,12 @@
+namespace TrafficManager.Util.Extensions
+{
+    using ColossalFramework;
+
+    public static class CitizenUnitExtensions
+    {
+        private static CitizenUnit[] _citizenUnitBuffer = Singleton<CitizenManager>.instance.m_units.m_buffer;
+
+        internal static ref CitizenUnit ToCitizenUnit(this uint citizenUnit) => ref _citizenUnitBuffer[citizenUnit];
+    }
+}
+


### PR DESCRIPTION
Created a ToCitizenUnit extension method.
Converted all Singleton<CitizenManager>.instance.m_units.m_buffer[citizenUnitId] calls to citizenUnitId.ToCitizenUnit().