### PR TITLE
Rename `OptionsMaintenanceTab` -> `MaintenanceTab`

### DIFF
--- a/TLM/TLM/Manager/Impl/OptionsManager.cs
+++ b/TLM/TLM/Manager/Impl/OptionsManager.cs
@@ -96,20 +96,20 @@ namespace TrafficManager.Manager.Impl {
                 OverlaysTab.SetConnectedLanesOverlay(LoadBool(data, idx: 17));
                 PoliciesTab.SetPrioritySignsEnabled(LoadBool(data, idx: 18));
                 PoliciesTab.SetTimedLightsEnabled(LoadBool(data, idx: 19));
-                OptionsMaintenanceTab.SetCustomSpeedLimitsEnabled(LoadBool(data, idx: 20));
-                OptionsMaintenanceTab.SetVehicleRestrictionsEnabled(LoadBool(data, idx: 21));
-                OptionsMaintenanceTab.SetLaneConnectorEnabled(LoadBool(data, idx: 22));
+                MaintenanceTab.SetCustomSpeedLimitsEnabled(LoadBool(data, idx: 20));
+                MaintenanceTab.SetVehicleRestrictionsEnabled(LoadBool(data, idx: 21));
+                MaintenanceTab.SetLaneConnectorEnabled(LoadBool(data, idx: 22));
                 OverlaysTab.SetJunctionRestrictionsOverlay(LoadBool(data, idx: 23));
-                OptionsMaintenanceTab.SetJunctionRestrictionsEnabled(LoadBool(data, idx: 24));
+                MaintenanceTab.SetJunctionRestrictionsEnabled(LoadBool(data, idx: 24));
                 GameplayTab.SetProhibitPocketCars(LoadBool(data, idx: 25));
                 PoliciesTab.SetPreferOuterLane(LoadBool(data, idx: 26));
                 GameplayTab.SetIndividualDrivingStyle(LoadBool(data, idx: 27));
                 PoliciesTab.SetEvacBussesMayIgnoreRules(LoadBool(data, idx: 28));
                 GeneralTab.SetInstantEffects(LoadBool(data, idx: 29));
-                OptionsMaintenanceTab.SetParkingRestrictionsEnabled(LoadBool(data, idx: 30));
+                MaintenanceTab.SetParkingRestrictionsEnabled(LoadBool(data, idx: 30));
                 OverlaysTab.SetParkingRestrictionsOverlay(LoadBool(data, idx: 31));
                 PoliciesTab.SetBanRegularTrafficOnBusLanes(LoadBool(data, idx: 32));
-                OptionsMaintenanceTab.SetShowPathFindStats(LoadBool(data, idx: 33));
+                MaintenanceTab.SetShowPathFindStats(LoadBool(data, idx: 33));
                 GameplayTab.SetDLSPercentage(LoadByte(data, idx: 34));
 
                 if (data.Length > 35) {
@@ -125,7 +125,7 @@ namespace TrafficManager.Manager.Impl {
 
                 PoliciesTab.SetTrafficLightPriorityRules(LoadBool(data, idx: 36));
                 GameplayTab.SetRealisticPublicTransport(LoadBool(data, idx: 37));
-                OptionsMaintenanceTab.SetTurnOnRedEnabled(LoadBool(data, idx: 38));
+                MaintenanceTab.SetTurnOnRedEnabled(LoadBool(data, idx: 38));
                 PoliciesTab.SetAllowNearTurnOnRed(LoadBool(data, idx: 39));
                 PoliciesTab.SetAllowFarTurnOnRed(LoadBool(data, idx: 40));
                 PoliciesTab.SetAddTrafficLightsIfApplicable(LoadBool(data, idx: 41));

--- a/TLM/TLM/State/Options.cs
+++ b/TLM/TLM/State/Options.cs
@@ -162,7 +162,7 @@ namespace TrafficManager.State {
                 GameplayTab.MakeSettings_Gameplay(tabStrip);
                 PoliciesTab.MakeSettings_VehicleRestrictions(tabStrip);
                 OverlaysTab.MakeSettings_Overlays(tabStrip);
-                OptionsMaintenanceTab.MakeSettings_Maintenance(tabStrip);
+                MaintenanceTab.MakeSettings_Maintenance(tabStrip);
                 KeybindsTab.MakeSettings_Keybinds(tabStrip);
                 tabStrip.Invalidate();
             } catch (Exception ex) {

--- a/TLM/TLM/State/OptionsTabs/MaintenanceTab.cs
+++ b/TLM/TLM/State/OptionsTabs/MaintenanceTab.cs
@@ -117,7 +117,7 @@ namespace TrafficManager.State {
 
             Options.Indent(_turnOnRedEnabledToggle);
 
-            OptionsMaintenanceTab_DespawnGroup.AddUI(panelHelper);
+            MaintenanceTab_DespawnGroup.AddUI(panelHelper);
 
             // TODO [issue ##959] remove when TTL is implemented in asset editor.
             bool inEditor = TMPELifecycle.InGameOrEditor()

--- a/TLM/TLM/State/OptionsTabs/MaintenanceTab.cs
+++ b/TLM/TLM/State/OptionsTabs/MaintenanceTab.cs
@@ -10,7 +10,7 @@ namespace TrafficManager.State {
     using ColossalFramework;
     using System.Collections.Generic;
 
-    public static class OptionsMaintenanceTab {
+    public static class MaintenanceTab {
         [UsedImplicitly]
         private static UIButton _resetStuckEntitiesBtn;
 

--- a/TLM/TLM/State/OptionsTabs/MaintenanceTab_DespawnGroup.cs
+++ b/TLM/TLM/State/OptionsTabs/MaintenanceTab_DespawnGroup.cs
@@ -2,7 +2,6 @@ namespace TrafficManager.State {
     using ColossalFramework;
     using ICities;
     using System.Collections.Generic;
-    using System.Diagnostics.CodeAnalysis;
     using TrafficManager.API.Traffic.Enums;
     using TrafficManager.Lifecycle;
     using TrafficManager.Manager.Impl;
@@ -10,49 +9,56 @@ namespace TrafficManager.State {
     using TrafficManager.UI.Helpers;
 
     /// <summary>Filterable despawn tool which only appears in-game (not from main menu or editors).</summary>
-    [SuppressMessage("StyleCop.CSharp.LayoutRules", "SA1516:Elements should be separated by blank line", Justification = "Brevity.")]
-    [SuppressMessage("StyleCop.CSharp.LayoutRules", "SA1500:Braces for multi-line statements should not share line", Justification = "Brevity.")]
-    public static class OptionsMaintenanceTab_DespawnGroup {
+    public static class MaintenanceTab_DespawnGroup {
+
         public static CheckboxOption DespawnerAll =
             new ("DespawnerAll", Options.PersistTo.None) {
                 Label = "Despawn.Checkbox:All vehicles",
                 Handler = OnDespawnerAllChange,
             };
+
         public static CheckboxOption DespawnerRoad =
             new ("DespawnerRoad", Options.PersistTo.None) {
                 Label = "Despawn.Checkbox:Road vehicles",
                 Handler = OnDespawnerChange,
             };
+
         public static CheckboxOption DespawnerParked =
             new ("DespawnerParked", Options.PersistTo.None) {
                 Label = "Despawn.Checkbox:Parked vehicles",
                 Handler = OnDespawnerChange,
             };
+
         public static CheckboxOption DespawnerServices =
             new ("DespawnerServices", Options.PersistTo.None) {
                 Label = "Despawn.Checkbox:Service vehicles",
                 Handler = OnDespawnerChange,
             };
+
         public static CheckboxOption DespawnerTransport =
             new ("DespawnerTransport", Options.PersistTo.None) {
                 Label = "Despawn.Checkbox:Public Transport vehicles",
                 Handler = OnDespawnerChange,
             };
+
         public static CheckboxOption DespawnerPassengerTrains =
             new ("DespawnerPassengerTrains", Options.PersistTo.None) {
                 Label = "Despawn.Checkbox:Passenger Trains",
                 Handler = OnDespawnerChange,
             };
+
         public static CheckboxOption DespawnerCargoTrains =
             new ("DespawnerCargoTrains", Options.PersistTo.None) {
                 Label = "Despawn.Checkbox:Cargo Trains",
                 Handler = OnDespawnerChange,
             };
+
         public static CheckboxOption DespawnerAircraft =
             new ("DespawnerAircraft", Options.PersistTo.None) {
                 Label = "Despawn.Checkbox:Aircraft",
                 Handler = OnDespawnerChange,
             };
+
         public static CheckboxOption DespawnerShips =
             new ("DespawnerShips", Options.PersistTo.None) {
                 Label = "Despawn.Checkbox:Ships",
@@ -94,6 +100,10 @@ namespace TrafficManager.State {
         // null = clear all traffic; ExtVehicleType.None = do nothing
         private static ExtVehicleType? despawnerMask = ExtVehicleType.None;
 
+        /// <summary>
+        /// Adds "Despawn" group to the specified <paramref name="tab"/>.
+        /// </summary>
+        /// <param name="tab">The parent UI panel.</param>
         public static void AddUI(UIHelperBase tab) {
             if (!TMPELifecycle.PlayMode) return;
 

--- a/TLM/TLM/State/OptionsTabs/PoliciesTab.cs
+++ b/TLM/TLM/State/OptionsTabs/PoliciesTab.cs
@@ -355,8 +355,8 @@ namespace TrafficManager.State {
             Options.RebuildMenu();
             Options.prioritySignsEnabled = newValue;
 
-            if (OptionsMaintenanceTab.EnablePrioritySignsToggle != null) {
-                OptionsMaintenanceTab.EnablePrioritySignsToggle.isChecked = newValue;
+            if (MaintenanceTab.EnablePrioritySignsToggle != null) {
+                MaintenanceTab.EnablePrioritySignsToggle.isChecked = newValue;
             }
 
             if (!newValue) {
@@ -368,8 +368,8 @@ namespace TrafficManager.State {
             Options.RebuildMenu();
             Options.timedLightsEnabled = newValue;
 
-            if (OptionsMaintenanceTab.EnableTimedLightsToggle != null) {
-                OptionsMaintenanceTab.EnableTimedLightsToggle.isChecked = newValue;
+            if (MaintenanceTab.EnableTimedLightsToggle != null) {
+                MaintenanceTab.EnableTimedLightsToggle.isChecked = newValue;
             }
 
             if (!newValue) {

--- a/TLM/TLM/TLM.csproj
+++ b/TLM/TLM/TLM.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -303,7 +303,7 @@
     <Compile Include="State\OptionsTabs\GameplayTab.cs" />
     <Compile Include="State\OptionsTabs\GeneralTab.cs" />
     <Compile Include="State\OptionsTabs\KeybindsTab.cs" />
-    <Compile Include="State\OptionsTabs\OptionsMaintenanceTab.cs" />
+    <Compile Include="State\OptionsTabs\MaintenanceTab.cs" />
     <Compile Include="State\OptionsTabs\OptionsMassEditTab.cs" />
     <Compile Include="State\OptionsTabs\OverlaysTab.cs" />
     <Compile Include="State\OptionsTabs\PoliciesTab.cs" />

--- a/TLM/TLM/TLM.csproj
+++ b/TLM/TLM/TLM.csproj
@@ -149,7 +149,7 @@
     <Compile Include="Manager\Impl\GeometryNotifier.cs" />
     <Compile Include="Patch\_External\RTramAIModPatch.cs" />
     <Compile Include="State\OptionsTabs\GeneralTab_DebugGroup.cs" />
-    <Compile Include="State\OptionsTabs\OptionsMaintenanceTab_DespawnGroup.cs" />
+    <Compile Include="State\OptionsTabs\MaintenanceTab_DespawnGroup.cs" />
     <Compile Include="State\VersionInfo.cs" />
     <Compile Include="UI\WhatsNew\MarkupKeyword.cs" />
     <Compile Include="UI\WhatsNew\WhatsNewMarkup.cs" />


### PR DESCRIPTION
Phase 1 refactor as per https://github.com/CitiesSkylinesMods/TMPE/issues/1356

Also renames related `OptionsMaintenanceTab_DespawnGroup` -> `MaintenanceTab_DespawnGroup`.

This is the final PR for phase 1.