### PR TITLE
Themed default speed signs (redux)

### DIFF
--- a/TLM/TLM/Manager/Impl/OptionsManager.cs
+++ b/TLM/TLM/Manager/Impl/OptionsManager.cs
@@ -151,6 +151,9 @@ namespace TrafficManager.Manager.Impl {
                 ToCheckbox(data, idx: 57, PoliciesTab.DedicatedTurningLanes);
 
                 Options.SavegamePathfinderEdition = LoadByte(data, idx: 58, defaultVal: 0);
+
+                ToCheckbox(data, idx: 59, OverlaysTab.ShowDefaultSpeedSubIcon, false);
+
                 return true;
             }
             catch (Exception ex) {
@@ -162,7 +165,7 @@ namespace TrafficManager.Manager.Impl {
         public byte[] SaveData(ref bool success) {
 
             // Remember to update this when adding new options (lastIdx + 1)
-            var save = new byte[59];
+            var save = new byte[60];
 
             try {
                 save[0] = ConvertFromSimulationAccuracy(Options.simulationAccuracy);
@@ -229,6 +232,8 @@ namespace TrafficManager.Manager.Impl {
                 save[57] = PoliciesTab.DedicatedTurningLanes.Save();
 
                 save[58] = (byte)Options.SavegamePathfinderEdition;
+
+                save[59] = OverlaysTab.ShowDefaultSpeedSubIcon.Save();
 
                 return save;
             }

--- a/TLM/TLM/State/Options.cs
+++ b/TLM/TLM/State/Options.cs
@@ -131,6 +131,8 @@ namespace TrafficManager.State {
         // See PathfinderUpdates.cs
         public static byte SavegamePathfinderEdition;
 
+        public static bool showDefaultSpeedSubIcon;
+
         /// <summary>
         /// Invoked on options change to refresh the main menu and possibly update the labels for
         /// a new language. Takes a second, very slow.

--- a/TLM/TLM/State/OptionsTabs/OverlaysTab.cs
+++ b/TLM/TLM/State/OptionsTabs/OverlaysTab.cs
@@ -24,6 +24,12 @@ namespace TrafficManager.State {
         private static UICheckBox _buildingOverlayToggle;
 #endif
 
+        public static CheckboxOption ShowDefaultSpeedSubIcon =
+            new(nameof(Options.showDefaultSpeedSubIcon), Options.PersistTo.Savegame) {
+                Label = "Overlays.Checkbox:Show default speed with customised speeds",
+                Indent = true,
+            };
+
         internal static void MakeSettings_Overlays(ExtUITabstrip tabStrip) {
             UIHelper panelHelper = tabStrip.AddTabPage(Translation.Options.Get("Tab:Overlays"));
 
@@ -39,6 +45,7 @@ namespace TrafficManager.State {
                                             Translation.Options.Get("Checkbox:Speed limits"),
                                             Options.speedLimitsOverlay,
                                             OnSpeedLimitsOverlayChanged) as UICheckBox;
+            ShowDefaultSpeedSubIcon.AddUI(panelHelper);
             _vehicleRestrictionsOverlayToggle
                 = panelHelper.AddCheckbox(
                       Translation.Options.Get("Checkbox:Vehicle restrictions"),

--- a/TLM/TLM/UI/SubTools/SpeedLimits/Overlay/SignRenderer.cs
+++ b/TLM/TLM/UI/SubTools/SpeedLimits/Overlay/SignRenderer.cs
@@ -1,7 +1,5 @@
-﻿namespace TrafficManager.UI.SubTools.SpeedLimits.Overlay {
-    using System.Collections.Generic;
+namespace TrafficManager.UI.SubTools.SpeedLimits.Overlay {
     using TrafficManager.API.Traffic.Data;
-    using TrafficManager.Lifecycle;
     using TrafficManager.UI.Textures;
     using UnityEngine;
 
@@ -76,6 +74,29 @@
                 y: this.screenPos_.y,
                 width: this.screenRect_.width * 0.5f,
                 height: this.screenRect_.height * 0.5f);
+
+            GUI.DrawTexture(
+                position: smallRect,
+                image: tex);
+        }
+
+        /// <summary>
+        /// Used to draw default speed sign subicon overlapping bottom right corner.
+        /// </summary>
+        /// <param name="speed">The default speed value.</param>
+        public void DrawDefaultSpeedSubIcon(SpeedValue speed) {
+            Texture2D tex = SignRenderer.ChooseTexture(
+                speedlimit: speed,
+                theme: RoadSignThemes.Instance.RoadDefaults);
+
+            float size = this.screenRect_.height * 0.4f;
+            float half = size / 2;
+
+            Rect smallRect = new Rect(
+                x: this.screenPos_.x + half,
+                y: this.screenPos_.y + half,
+                width: size,
+                height: size);
 
             GUI.DrawTexture(
                 position: smallRect,

--- a/TLM/TLM/UI/SubTools/SpeedLimits/Overlay/SpeedLimitsOverlay.cs
+++ b/TLM/TLM/UI/SubTools/SpeedLimits/Overlay/SpeedLimitsOverlay.cs
@@ -501,7 +501,7 @@ namespace TrafficManager.UI.SubTools.SpeedLimits.Overlay {
             [NotNull] DrawEnv drawEnv,
             [NotNull] DrawArgs args)
         {
-            Vector2 largeRatio = drawEnv.drawDefaults_
+            Vector2 aspectRatio = drawEnv.drawDefaults_
                                      ? RoadSignThemes.DefaultSpeedlimitsAspectRatio()
                                      : drawEnv.signsThemeAspectRatio_;
 
@@ -513,7 +513,7 @@ namespace TrafficManager.UI.SubTools.SpeedLimits.Overlay {
             SignRenderer squareSignRenderer = default;
 
             // Recalculate visible rect for screen position and size
-            Rect signScreenRect = signRenderer.Reset(screenPos, size: size * largeRatio);
+            Rect signScreenRect = signRenderer.Reset(screenPos, size: size * aspectRatio);
             bool isHoveredHandle = args.IsInteractive && signRenderer.ContainsMouse(args.Mouse);
 
             //-----------
@@ -562,16 +562,11 @@ namespace TrafficManager.UI.SubTools.SpeedLimits.Overlay {
                     speedlimit: isDefaultSpeed ? defaultSpeedLimit : drawSpeedlimit,
                     theme: drawEnv.largeSignsTextures_);
 
-                if (args.IsInteractive && Options.showDefaultSpeedSubIcon && !isDefaultSpeed) {
-                    squareSignRenderer.Reset(
-                        screenPos,
-                        size: 3f * RoadSignThemes.DefaultSpeedlimitsAspectRatio());
-
-                    Texture2D chosenTexture = SignRenderer.ChooseTexture(
-                        speedlimit: defaultSpeedLimit,
-                        theme: RoadSignThemes.Instance.RoadDefaults);
-
-                    signRenderer.DrawSmallTexture_BottomRight(chosenTexture);
+                if (args.IsInteractive &&
+                    drawSpeedlimit.HasValue &&
+                    !isDefaultSpeed &&
+                    Options.showDefaultSpeedSubIcon) {
+                    signRenderer.DrawDefaultSpeedSubIcon(defaultSpeedLimit);
                 }
             }
 
@@ -672,9 +667,6 @@ namespace TrafficManager.UI.SubTools.SpeedLimits.Overlay {
             // Sign renderer logic and chosen texture for signs
             SignRenderer signRenderer = default;
 
-            // For non-square road sign theme, need square renderer to display no-override
-            SignRenderer squareSignRenderer = default;
-
             // Defaults have 1:1 ratio (square textures)
             Vector2 largeRatio = drawEnv.drawDefaults_
                                      ? RoadSignThemes.DefaultSpeedlimitsAspectRatio()
@@ -735,16 +727,11 @@ namespace TrafficManager.UI.SubTools.SpeedLimits.Overlay {
                     speedlimit: isDefaultSpeed ? overrideSpeedlimit.DefaultValue.Value : overrideSpeedlimit.OverrideValue.Value,
                     theme: drawEnv.largeSignsTextures_);
 
-                if (args.IsInteractive && !isDefaultSpeed && Options.showDefaultSpeedSubIcon) {
-                    squareSignRenderer.Reset(
-                        screenPos,
-                        size: 3f * RoadSignThemes.DefaultSpeedlimitsAspectRatio());
-
-                    Texture2D chosenTexture = SignRenderer.ChooseTexture(
-                        speedlimit: overrideSpeedlimit.DefaultValue,
-                        theme: RoadSignThemes.Instance.RoadDefaults);
-
-                    signRenderer.DrawSmallTexture_BottomRight(chosenTexture);
+                if (args.IsInteractive &&
+                    overrideSpeedlimit.OverrideValue.HasValue &&
+                    !isDefaultSpeed &&
+                    Options.showDefaultSpeedSubIcon) {
+                    signRenderer.DrawDefaultSpeedSubIcon(overrideSpeedlimit.DefaultValue.Value);
                 }
 
                 if (args.IsInteractive

--- a/TLM/TLM/UI/SubTools/SpeedLimits/Overlay/SpeedLimitsOverlay.cs
+++ b/TLM/TLM/UI/SubTools/SpeedLimits/Overlay/SpeedLimitsOverlay.cs
@@ -562,7 +562,7 @@ namespace TrafficManager.UI.SubTools.SpeedLimits.Overlay {
                     speedlimit: isDefaultSpeed ? defaultSpeedLimit : drawSpeedlimit,
                     theme: drawEnv.largeSignsTextures_);
 
-                if (isDefaultSpeed) {
+                if (args.IsInteractive && Options.showDefaultSpeedSubIcon && !isDefaultSpeed) {
                     squareSignRenderer.Reset(
                         screenPos,
                         size: 3f * RoadSignThemes.DefaultSpeedlimitsAspectRatio());

--- a/TLM/TLM/UI/SubTools/SpeedLimits/Overlay/SpeedLimitsOverlay.cs
+++ b/TLM/TLM/UI/SubTools/SpeedLimits/Overlay/SpeedLimitsOverlay.cs
@@ -554,20 +554,24 @@ namespace TrafficManager.UI.SubTools.SpeedLimits.Overlay {
                     forward: overrideSpeedlimitForward,
                     back: overrideSpeedlimitBack);
 
-                if (!drawSpeedlimit.HasValue || drawSpeedlimit.Value.Equals(defaultSpeedLimit)) {
-                    // No value, no override
+                bool isDefaultSpeed =
+                    !drawSpeedlimit.HasValue ||
+                    drawSpeedlimit.Value.Equals(defaultSpeedLimit);
+
+                signRenderer.DrawLargeTexture(
+                    speedlimit: isDefaultSpeed ? defaultSpeedLimit : drawSpeedlimit,
+                    theme: drawEnv.largeSignsTextures_);
+
+                if (isDefaultSpeed) {
                     squareSignRenderer.Reset(
                         screenPos,
-                        size: size * RoadSignThemes.DefaultSpeedlimitsAspectRatio());
+                        size: 3f * RoadSignThemes.DefaultSpeedlimitsAspectRatio());
+
                     Texture2D chosenTexture = SignRenderer.ChooseTexture(
                         speedlimit: defaultSpeedLimit,
                         theme: RoadSignThemes.Instance.RoadDefaults);
-                    squareSignRenderer.DrawLargeTexture(chosenTexture);
-                    // squareSignRenderer.DrawSmallTexture_BottomRight(chosenTexture);
-                } else {
-                    signRenderer.DrawLargeTexture(
-                        speedlimit: drawSpeedlimit,
-                        theme: drawEnv.largeSignsTextures_);
+
+                    signRenderer.DrawSmallTexture_BottomRight(chosenTexture);
                 }
             }
 

--- a/TLM/TLM/UI/SubTools/SpeedLimits/Overlay/SpeedLimitsOverlay.cs
+++ b/TLM/TLM/UI/SubTools/SpeedLimits/Overlay/SpeedLimitsOverlay.cs
@@ -505,9 +505,12 @@ namespace TrafficManager.UI.SubTools.SpeedLimits.Overlay {
                                      ? RoadSignThemes.DefaultSpeedlimitsAspectRatio()
                                      : drawEnv.signsThemeAspectRatio_;
 
-            // TODO: Replace formula in visibleScale and size to use Constants.OVERLAY_INTERACTIVE_SIGN_SIZE and OVERLAY_READONLY_SIGN_SIZE
+            float signSize = args.IsInteractive
+                     ? Constants.OVERLAY_INTERACTIVE_SIGN_SIZE
+                     : Constants.OVERLAY_READONLY_SIGN_SIZE;
+
             float visibleScale = drawEnv.baseScreenSizeForSign_ / (segCenter - camPos).magnitude;
-            float size = (args.IsInteractive ? 1f : 0.8f) * SPEED_LIMIT_SIGN_SIZE * visibleScale;
+            float size = signSize * SPEED_LIMIT_SIGN_SIZE * visibleScale;
 
             SignRenderer signRenderer = default;
             SignRenderer squareSignRenderer = default;
@@ -726,29 +729,25 @@ namespace TrafficManager.UI.SubTools.SpeedLimits.Overlay {
                 GetSpeedLimitResult overrideSpeedlimit =
                     SpeedLimitManager.Instance.CalculateCustomSpeedLimit(laneId);
 
-                if (!overrideSpeedlimit.OverrideValue.HasValue
+                bool isDefaultSpeed =
+                    !overrideSpeedlimit.OverrideValue.HasValue
                     || (overrideSpeedlimit.DefaultValue.HasValue &&
-                        overrideSpeedlimit.OverrideValue.Value.Equals(
-                            overrideSpeedlimit.DefaultValue.Value)))
-                {
-                    //-------------------------------------
-                    // Draw default blue speed limit
-                    //-------------------------------------
+                        overrideSpeedlimit.OverrideValue.Value.Equals(overrideSpeedlimit.DefaultValue.Value));
+
+                signRenderer.DrawLargeTexture(
+                    speedlimit: isDefaultSpeed ? overrideSpeedlimit.DefaultValue.Value : overrideSpeedlimit.OverrideValue.Value,
+                    theme: drawEnv.largeSignsTextures_);
+
+                if (args.IsInteractive && !isDefaultSpeed && Options.showDefaultSpeedSubIcon) {
                     squareSignRenderer.Reset(
                         screenPos,
-                        size: size * RoadSignThemes.DefaultSpeedlimitsAspectRatio());
+                        size: 3f * RoadSignThemes.DefaultSpeedlimitsAspectRatio());
+
                     Texture2D chosenTexture = SignRenderer.ChooseTexture(
                         speedlimit: overrideSpeedlimit.DefaultValue,
                         theme: RoadSignThemes.Instance.RoadDefaults);
-                    squareSignRenderer.DrawLargeTexture(chosenTexture);
-                    // squareSignRenderer.DrawSmallTexture_BottomRight(chosenTexture);
-                } else {
-                    //-------------------------------------
-                    // Draw nice override
-                    //-------------------------------------
-                    signRenderer.DrawLargeTexture(
-                        speedlimit: overrideSpeedlimit.OverrideValue.Value,
-                        theme: drawEnv.largeSignsTextures_);
+
+                    signRenderer.DrawSmallTexture_BottomRight(chosenTexture);
                 }
 
                 if (args.IsInteractive

--- a/TLM/TLM/UI/SubTools/SpeedLimits/Overlay/SpeedLimitsOverlay.cs
+++ b/TLM/TLM/UI/SubTools/SpeedLimits/Overlay/SpeedLimitsOverlay.cs
@@ -505,12 +505,9 @@ namespace TrafficManager.UI.SubTools.SpeedLimits.Overlay {
                                      ? RoadSignThemes.DefaultSpeedlimitsAspectRatio()
                                      : drawEnv.signsThemeAspectRatio_;
 
-            float signSize = args.IsInteractive
-                     ? Constants.OVERLAY_INTERACTIVE_SIGN_SIZE
-                     : Constants.OVERLAY_READONLY_SIGN_SIZE;
-
+            // TODO: Replace formula in visibleScale and size to use Constants.OVERLAY_INTERACTIVE_SIGN_SIZE and OVERLAY_READONLY_SIGN_SIZE
             float visibleScale = drawEnv.baseScreenSizeForSign_ / (segCenter - camPos).magnitude;
-            float size = signSize * SPEED_LIMIT_SIGN_SIZE * visibleScale;
+            float size = (args.IsInteractive ? 1f : 0.8f) * SPEED_LIMIT_SIGN_SIZE * visibleScale;
 
             SignRenderer signRenderer = default;
             SignRenderer squareSignRenderer = default;
@@ -618,7 +615,6 @@ namespace TrafficManager.UI.SubTools.SpeedLimits.Overlay {
             [NotNull] DrawEnv drawEnv,
             [NotNull] DrawArgs args)
         {
-            var vehicleInfoSignTextures = RoadUI.Instance.VehicleInfoSignTextures;
             bool ret = false;
             ref NetSegment segment = ref segmentId.ToSegment();
 
@@ -712,8 +708,9 @@ namespace TrafficManager.UI.SubTools.SpeedLimits.Overlay {
                     continue;
                 }
 
-                float visibleScale = 100.0f / (worldPos - camPos).magnitude;
+                float visibleScale = drawEnv.baseScreenSizeForSign_ / (worldPos - camPos).magnitude;
                 float size = (args.IsInteractive ? 1f : 0.8f) * SPEED_LIMIT_SIGN_SIZE * visibleScale;
+
                 Rect signScreenRect = signRenderer.Reset(screenPos, size: largeRatio * size);
 
                 // Set render transparency based on mouse hover
@@ -754,6 +751,7 @@ namespace TrafficManager.UI.SubTools.SpeedLimits.Overlay {
                     && !onlyMonorailLanes
                     && ((laneInfo.m_vehicleType & VehicleInfo.VehicleType.Monorail) != VehicleInfo.VehicleType.None))
                 {
+                    var vehicleInfoSignTextures = RoadUI.Instance.VehicleInfoSignTextures;
                     Texture2D tex1 = vehicleInfoSignTextures[LegacyExtVehicleType.ToNew(old: ExtVehicleType.PassengerTrain)];
 
                     // TODO: Replace with direct call to GUI.DrawTexture as in the func above


### PR DESCRIPTION
Compiled mod for testing: [TMPE.zip](https://ci.appveyor.com/api/projects/krzychu124/tmpe/artifacts/TMPE.zip?branch=themed-defaults-redux)

This is a redux of #1320

![image](https://user-images.githubusercontent.com/19638970/151237909-1c6769d9-4fbe-4e76-a23e-8049d3af062b.png)

Changes to speed limits overlay:

* Segment and lane modes now always use themed icons (defaults mode still always shows unthemed icons).
* If user customises a speed to value other than network default, a green sub-icon is appended to the themed speed sign.

Example:

![image](https://user-images.githubusercontent.com/1386719/153963325-2283e3ba-02e9-4875-8f9c-612ba82ff54e.png) ![image](https://user-images.githubusercontent.com/1386719/153963362-433c6b1b-158a-4c78-97aa-3e84da034f9d.png)

That sub-icon is only shown in interactive mode, when used has customised the speed to non-default value, but only if a mod option is enabled in Overlays tab:

![image](https://user-images.githubusercontent.com/1386719/153811256-5a58bf2d-a584-48c8-96a9-e23964793479.png)

Todo:

- [x] Apply same thing to lane mode
- [x] Persist option to savegame
- [x] Fix size of lane mode icons (similar to #1320)
- [x] Test with monorail in lane mode (which adds passenger train sub-icon)

Updates: https://github.com/CitiesSkylinesMods/TMPE/issues/1221#issuecomment-1022557573