### PR TITLE
Update `CheckboxOption`

### DIFF
--- a/TLM/TLM/State/OptionsTabs/GeneralTab_DebugGroup.cs
+++ b/TLM/TLM/State/OptionsTabs/GeneralTab_DebugGroup.cs
@@ -21,9 +21,8 @@ namespace TrafficManager.State {
 
         static GeneralTab_DebugGroup() {
             try {
-                DebugCheckboxA.PropagatesTrueTo = new () {
-                    { DebugCheckboxB },
-                };
+                DebugCheckboxA
+                    .PropagateTrueTo(DebugCheckboxB);
             }
             catch (Exception ex) {
                 ex.LogException();

--- a/TLM/TLM/UI/Helpers/CheckboxOption.cs
+++ b/TLM/TLM/UI/Helpers/CheckboxOption.cs
@@ -17,7 +17,7 @@ namespace TrafficManager.UI.Helpers {
 
         /* Data */
 
-        public delegate bool ValidatorDelegate(bool desiredVal, out bool resultVal);
+        public delegate bool ValidatorDelegate(bool desired, out bool result);
 
         public event OnCheckChanged OnValueChanged;
 

--- a/TLM/TLM/UI/Helpers/CheckboxOption.cs
+++ b/TLM/TLM/UI/Helpers/CheckboxOption.cs
@@ -119,7 +119,7 @@ namespace TrafficManager.UI.Helpers {
         public bool ReadOnlyUI {
             get => _readOnlyUI;
             set {
-                // _readOnlyUI = !IsInScope || value;
+                _readOnlyUI = !IsInScope || value;
                 if (HasUI) {
                     _ui.readOnly = _readOnlyUI;
                     _ui.opacity = _readOnlyUI ? 0.3f : 1f;

--- a/TLM/TLM/UI/Helpers/CheckboxOption.cs
+++ b/TLM/TLM/UI/Helpers/CheckboxOption.cs
@@ -150,9 +150,9 @@ namespace TrafficManager.UI.Helpers {
         private void UpdateReadOnly() {
             if (!HasUI) return;
 
-            Log.Info($"CheckboxOption.Value: `{FieldName}` is readonly");
-
             var readOnly = !IsInScope || _readOnly;
+
+            Log._Debug($"CheckboxOption.UpdateReadOnly() - `{FieldName}` is {(readOnly ? "read-only" : "writeable")}");
 
             _ui.readOnly = readOnly;
             _ui.opacity = readOnly ? 0.3f : 1f;

--- a/TLM/TLM/UI/Helpers/CheckboxOption.cs
+++ b/TLM/TLM/UI/Helpers/CheckboxOption.cs
@@ -38,17 +38,31 @@ namespace TrafficManager.UI.Helpers {
             get => _propagatesTrueTo;
             set {
                 _propagatesTrueTo = value;
-                Log.Info($"CheckboxOption.PropagatesTrueTo: {nameof(Options)}.{FieldName} will proagate to:");
+                Log.Info($"CheckboxOption.PropagatesTrueTo: `{FieldName}` will proagate to:");
 
-                foreach (var requirement in _propagatesTrueTo) {
-                    Log.Info($"- {nameof(Options)}.{requirement.FieldName}");
+                foreach (var target in _propagatesTrueTo) {
+                    Log.Info($"- `{target.FieldName}`");
 
-                    if (requirement.PropagatesFalseTo == null) {
-                        requirement.PropagatesFalseTo = new ();
+                    if (target.PropagatesFalseTo == null) {
+                        target.PropagatesFalseTo = new ();
                     }
 
-                    requirement.PropagatesFalseTo.Add(this);
+                    target.PropagatesFalseTo.Add(this);
                 }
+            }
+        }
+
+        /// <summary>
+        /// An alternate way to add targets to the <see cref="_propagatesTrueTo"/> list.
+        /// Useful for keeping code concise when there's only single target (most common use case).
+        /// </summary>
+        /// <param name="target">The checkox to propagate <c>true</c> value to.</param>
+        public void PropagateTrueTo([NotNull] CheckboxOption target) {
+            Log.Info($"CheckboxOption.PropagateTrueTo: `{FieldName}` will proagate to `{target.FieldName}`");
+            if (_propagatesTrueTo != null) {
+                _propagatesTrueTo.Add(target);
+            } else {
+                _propagatesTrueTo = new() { { target } };
             }
         }
 
@@ -60,12 +74,12 @@ namespace TrafficManager.UI.Helpers {
         public List<CheckboxOption> PropagatesFalseTo { get; set; }
 
         public override void Load(byte data) {
-            Log.Info($"CheckboxOption.Load: {data} -> {data != 0} -> {nameof(Options)}.{FieldName}");
+            Log.Info($"CheckboxOption.Load({data}): `{FieldName}` = {data != 0}");
             Value = data != 0;
         }
 
         public override byte Save() {
-            Log.Info($"CheckboxOption.Save: {nameof(Options)}.{FieldName} -> {Value} -> {(Value ? (byte)1 : (byte)0)}");
+            Log.Info($"CheckboxOption.Save(): `{FieldName}` is {Value} -> {(Value ? (byte)1 : (byte)0)}");
             return Value ? (byte)1 : (byte)0;
         }
 
@@ -104,22 +118,22 @@ namespace TrafficManager.UI.Helpers {
                     if (Validator(value, out bool result)) {
                         value = result;
                     } else {
-                        Log.Info($"CheckboxOption.Value: {nameof(Options)}.{FieldName} validator rejected value: {value}");
+                        Log.Info($"CheckboxOption.Value: `{FieldName}` validator rejected value: {value}");
                         return;
                     }
                 }
 
-                Log.Info($"CheckboxOption.Value: {nameof(Options)}.{FieldName} changed to {value}");
+                Log.Info($"CheckboxOption.Value: `{FieldName}` changed to {value}");
 
                 if (value && _propagatesTrueTo != null) {
-                    foreach (var requirement in _propagatesTrueTo) {
-                        requirement.Value = true;
+                    foreach (var target in _propagatesTrueTo) {
+                        target.Value = true;
                     }
                 }
 
                 if (!value && PropagatesFalseTo != null) {
-                    foreach (var dependent in PropagatesFalseTo) {
-                        dependent.Value = false;
+                    foreach (var target in PropagatesFalseTo) {
+                        target.Value = false;
                     }
                 }
 

--- a/TLM/TLM/UI/Helpers/CheckboxOption.cs
+++ b/TLM/TLM/UI/Helpers/CheckboxOption.cs
@@ -26,7 +26,10 @@ namespace TrafficManager.UI.Helpers {
         public event OnCheckChanged OnValueChanged;
 
         public OnCheckChanged Handler {
-            set => OnValueChanged += value;
+            set {
+                OnValueChanged -= value;
+                OnValueChanged += value;
+            }
         }
 
         /// <summary>

--- a/TLM/TLM/UI/Helpers/SerializableUIOptionBase.cs
+++ b/TLM/TLM/UI/Helpers/SerializableUIOptionBase.cs
@@ -7,6 +7,7 @@ namespace TrafficManager.UI.Helpers {
     using System;
     using TrafficManager.State;
     using JetBrains.Annotations;
+    using TrafficManager.Lifecycle;
 
     public abstract class SerializableUIOptionBase<TVal, TUI> : ILegacySerializableOption
         where TUI : UIComponent {
@@ -56,12 +57,12 @@ namespace TrafficManager.UI.Helpers {
 
         /// <summary>Returns <c>true</c> if setting can persist in current <see cref="_scope"/>.</summary>
         /// <remarks>
-        /// When <c>false</c>, UI component should be <see cref="_readOnlyUI"/>
+        /// When <c>false</c>, UI component should be <see cref="_readOnly"/>
         /// and <see cref="_tooltip"/> should be set to <see cref="INGAME_ONLY_SETTING"/>.
         /// </remarks>
         protected bool IsInScope =>
             _scope.IsFlagSet(Options.PersistTo.Global) ||
-            (_scope.IsFlagSet(Options.PersistTo.Savegame) && Options.IsGameLoaded(false)) ||
+            (_scope.IsFlagSet(Options.PersistTo.Savegame) && TMPELifecycle.AppMode != null) ||
             _scope == Options.PersistTo.None;
 
         public static implicit operator TVal(SerializableUIOptionBase<TVal, TUI> a) => a.Value;
@@ -87,7 +88,7 @@ namespace TrafficManager.UI.Helpers {
         protected string _label;
         protected string _tooltip;
 
-        protected bool _readOnlyUI;
+        protected bool _readOnly;
 
         private TranslatorDelegate _translator;
         public delegate string TranslatorDelegate(string key);


### PR DESCRIPTION
Part of https://github.com/CitiesSkylinesMods/TMPE/issues/1356 phase 2.

- Re-enable the automatic readonly mode if option is not persistable in current scope
- Fix bug with options sometimes remaining disabled in-game
- Add `Validator` property from #1416
    - If specified, it intercepts value changes and decides what to do
    - Used for checking DLC requirement, etc., for an option
- `PropagatesTrueTo` renamed `PropagateTrueTo` and turned in to a method
    - Most common use case was single target so this cleans code up a lot in upcoming PRs
- Add `Indent` / `AllowTextWrap` methods (from `Options.cs`)
    - This is part of larger refactor from upcoming PR
- Refactor in prep for upcoming PRs relating to mod options

Note that not all mod option checkboxes are converted to using `CheckboxOption` yet - I've got subsequent PRs incoming for all of those. The result is that only a handful of checkboxes will auto-readonly when viewed from main menu (eg. bulk applicators on Policies tab); the others will still be normal mode until later PRs convert them.

I'm putting this PR in sooner than planned becuase it will simplify testing of the subsequent PRs.

An example of a checkbox validator:

* `desired` is what the value wants to change to
* `result` is what it must change to (if anything)
* if function returns `false` then value change is rejected entirely (no events fired, etc)

```csharp
        // Road conditions option requires Snowfall DLC
        private static bool SnowfallDlcValidator(bool desired, out bool result) {
            var dlcOwned = SteamHelper.IsDLCOwned(SteamHelper.DLC.SnowFallDLC);

            result = dlcOwned && desired;
            return dlcOwned;
        }
```

When added to a checkbox that will prevent it's value being anything other than `false` if the required DLC is not available.