### PR TITLE
Add button classes for use in mod options

### DIFF
--- a/TLM/TLM/State/ConfigData/Main.cs
+++ b/TLM/TLM/State/ConfigData/Main.cs
@@ -106,6 +106,12 @@ namespace TrafficManager.State.ConfigData {
         public string RoadSignTheme = string.Empty;
 
         /// <summary>
+        /// If <c>true</c>, <see cref="UI.Helpers.UrlButton"/> links will open in
+        /// Steam Overlay if it is available.
+        /// </summary>
+        public bool OpenUrlsInSteamOverlay = true;
+
+        /// <summary>
         /// Storing version of What's New panel opened last time
         /// </summary>
         [XmlIgnore]

--- a/TLM/TLM/State/GlobalConfig.cs
+++ b/TLM/TLM/State/GlobalConfig.cs
@@ -15,7 +15,7 @@ namespace TrafficManager.State {
     public class GlobalConfig : GenericObservable<GlobalConfig> {
         public const string FILENAME = "TMPE_GlobalConfig.xml";
         public const string BACKUP_FILENAME = FILENAME + ".bak";
-        private static int LATEST_VERSION = 18;
+        private static int LATEST_VERSION = 19;
 
         public static GlobalConfig Instance {
             get => instance;

--- a/TLM/TLM/State/OptionsTabs/GeneralTab.cs
+++ b/TLM/TLM/State/OptionsTabs/GeneralTab.cs
@@ -1,5 +1,4 @@
 namespace TrafficManager.State {
-    using System;
     using System.Collections.Generic;
     using System.Linq;
     using TrafficManager.API.Traffic.Enums;
@@ -9,7 +8,6 @@ namespace TrafficManager.State {
     using JetBrains.Annotations;
     using TrafficManager.U;
     using TrafficManager.UI.Helpers;
-    using TrafficManager.UI.SubTools.SpeedLimits;
     using TrafficManager.UI;
     using UnityEngine;
     using TrafficManager.Lifecycle;
@@ -18,6 +16,19 @@ namespace TrafficManager.State {
     using UI.WhatsNew;
 
     public static class GeneralTab {
+        public static ActionButton WhatsNewButton = new() {
+            Label = "What's New?",
+            Handler = WhatsNew.OpenModal,
+        };
+
+        public static CheckboxOption OpenUrlsInSteamOverlay =
+            new (nameof(GlobalConfig.Instance.Main.OpenUrlsInSteamOverlay), Options.PersistTo.Global) {
+                Label = "Checkbox:Use Steam Overlay to show TM:PE website links",
+                Tooltip = "Checkbox.Tooltip:When disabled, website links will open in your default web browser",
+                Handler = OnOpenUrlsInSteamOverlayChanged,
+                Value = GlobalConfig.Instance.Main.OpenUrlsInSteamOverlay,
+            };
+
         private static UICheckBox _instantEffectsToggle;
 
         [UsedImplicitly]
@@ -60,7 +71,7 @@ namespace TrafficManager.State {
 #endif
 
             tab.AddSpace(5);
-            tab.AddButton("What's New?", WhatsNew.OpenModal);
+            WhatsNewButton.AddUI(tab);
             tab.AddSpace(5);
 
             group = tab.AddGroup(T("General.Group:Localisation"));
@@ -140,6 +151,8 @@ namespace TrafficManager.State {
                                         T("General.Checkbox:Enable tutorials"),
                                         GlobalConfig.Instance.Main.EnableTutorial,
                                         OnEnableTutorialsChanged) as UICheckBox;
+
+            OpenUrlsInSteamOverlay.AddUI(group);
 
             group = tab.AddGroup(T("General.Group:Simulation"));
 
@@ -425,6 +438,14 @@ namespace TrafficManager.State {
             }
 
             mainConfig.RoadSignTheme = newTheme;
+            GlobalConfig.WriteConfig();
+        }
+
+        private static void OnOpenUrlsInSteamOverlayChanged(bool val) {
+            var current = GlobalConfig.Instance.Main.OpenUrlsInSteamOverlay;
+            if (current == val) return;
+
+            GlobalConfig.Instance.Main.OpenUrlsInSteamOverlay = val;
             GlobalConfig.WriteConfig();
         }
 

--- a/TLM/TLM/TLM.csproj
+++ b/TLM/TLM/TLM.csproj
@@ -151,6 +151,9 @@
     <Compile Include="State\OptionsTabs\GeneralTab_DebugGroup.cs" />
     <Compile Include="State\OptionsTabs\MaintenanceTab_DespawnGroup.cs" />
     <Compile Include="State\VersionInfo.cs" />
+    <Compile Include="UI\Helpers\ActionButton.cs" />
+    <Compile Include="UI\Helpers\OptionButtonBase.cs" />
+    <Compile Include="UI\Helpers\UrlButton.cs" />
     <Compile Include="UI\WhatsNew\MarkupKeyword.cs" />
     <Compile Include="UI\WhatsNew\WhatsNewMarkup.cs" />
     <Compile Include="Util\Extensions\CitizenUnitExtensions.cs" />

--- a/TLM/TLM/UI/Helpers/ActionButton.cs
+++ b/TLM/TLM/UI/Helpers/ActionButton.cs
@@ -4,7 +4,10 @@ namespace TrafficManager.UI.Helpers {
     public class ActionButton : OptionButtonBase {
 
         public OnButtonClicked Handler {
-            set => OnClicked += value;
+            set {
+                OnClicked -= value;
+                OnClicked += value;
+            }
         }
     }
 }

--- a/TLM/TLM/UI/Helpers/ActionButton.cs
+++ b/TLM/TLM/UI/Helpers/ActionButton.cs
@@ -1,0 +1,10 @@
+namespace TrafficManager.UI.Helpers {
+    using ICities;
+
+    public class ActionButton : OptionButtonBase {
+
+        public OnButtonClicked Handler {
+            set => OnClicked += value;
+        }
+    }
+}

--- a/TLM/TLM/UI/Helpers/OptionButtonBase.cs
+++ b/TLM/TLM/UI/Helpers/OptionButtonBase.cs
@@ -9,7 +9,7 @@ namespace TrafficManager.UI.Helpers {
 
         protected UIButton _ui;
 
-        protected event OnButtonClicked OnClicked;
+        public event OnButtonClicked OnClicked;
 
         public bool HasUI => _ui != null;
 

--- a/TLM/TLM/UI/Helpers/OptionButtonBase.cs
+++ b/TLM/TLM/UI/Helpers/OptionButtonBase.cs
@@ -1,0 +1,72 @@
+namespace TrafficManager.UI.Helpers {
+    using ColossalFramework.UI;
+    using ICities;
+
+    public abstract class OptionButtonBase {
+        protected string _label;
+        protected string _tooltip;
+        protected bool _readOnly;
+
+        protected UIButton _ui;
+
+        protected event OnButtonClicked OnClicked;
+
+        public bool HasUI => _ui != null;
+
+        public string Label {
+            get => _label ?? string.Empty;
+            set {
+                _label = value;
+                UpdateLabel();
+            }
+        }
+
+        public string Tooltip {
+            get => _tooltip;
+            set {
+                _tooltip = value;
+                UpdateTooltip();
+            }
+        }
+
+        public bool ReadOnly {
+            get => _readOnly;
+            set {
+                _readOnly = value;
+                UpdateReadOnly();
+            }
+        }
+
+        public void AddUI(UIHelperBase container) {
+            _ui = container.AddButton(T(_label), OnClicked) as UIButton;
+
+            UpdateTooltip();
+            UpdateReadOnly();
+        }
+
+        protected virtual void UpdateLabel() {
+            if (!HasUI) return;
+
+            _ui.text = T(_label);
+        }
+
+        protected virtual void UpdateTooltip() {
+            if (!HasUI) return;
+
+            _ui.tooltip = string.IsNullOrEmpty(_tooltip)
+                ? string.Empty
+                : T(_tooltip);
+        }
+
+        protected virtual void UpdateReadOnly() {
+            if (!HasUI) return;
+
+            _ui.isInteractive = !_readOnly;
+            _ui.opacity = _readOnly ? 0.3f : 1f;
+        }
+
+        protected virtual string T(string key)
+            => Translation.Options.Get(key);
+
+    }
+}

--- a/TLM/TLM/UI/Helpers/UrlButton.cs
+++ b/TLM/TLM/UI/Helpers/UrlButton.cs
@@ -1,0 +1,52 @@
+namespace TrafficManager.UI.Helpers {
+    using ColossalFramework.PlatformServices;
+    using System.Diagnostics;
+    using TrafficManager.Lifecycle;
+    using TrafficManager.State;
+
+    public class UrlButton : OptionButtonBase {
+        private string _url;
+
+        public UrlButton() {
+            OnClicked += OpenURL;
+        }
+
+        public static bool SteamOverlayAvailable
+            => PlatformService.platformType == PlatformType.Steam &&
+               PlatformService.IsOverlayEnabled();
+
+        public string URL {
+            get => _url;
+            set {
+                _url = value;
+                UpdateTooltip();
+            }
+        }
+
+        protected override void UpdateTooltip() {
+            if (!HasUI) return;
+
+            _ui.tooltip = string.IsNullOrEmpty(_tooltip)
+                ? _url
+                : $"{T(_tooltip)}:\n{_url}";
+        }
+
+        private void OpenURL() {
+            if (string.IsNullOrEmpty(_url)) return;
+
+            if (TMPELifecycle.InGameOrEditor())
+                SimulationManager.instance.SimulationPaused = true;
+
+            bool useSteamOverlay =
+                SteamOverlayAvailable &&
+                GlobalConfig.Instance.Main.OpenUrlsInSteamOverlay;
+
+            if (useSteamOverlay) {
+                PlatformService.ActivateGameOverlayToWebPage(_url);
+            } else {
+                //Application.OpenURL(_url);
+                Process.Start(_url);
+            }
+        }
+    }
+}

--- a/TLM/TLM/UI/Helpers/UrlButton.cs
+++ b/TLM/TLM/UI/Helpers/UrlButton.cs
@@ -8,6 +8,7 @@ namespace TrafficManager.UI.Helpers {
         private string _url;
 
         public UrlButton() {
+            OnClicked -= OpenURL;
             OnClicked += OpenURL;
         }
 


### PR DESCRIPTION
Part of ongoing work for #1356

- `ActionButton` triggers handler on click
- `UrlButton` opens a url on click
- `OptionButtonBase` is base for both buttons
- `OpenUrlsInSteamOverlay` - new `Main` global option (also bumped global config version)
- ...configurable via General tab option

In preparation for: #813, #733, #659, etc.

Later, once all mod options are using helper components, I plan on updating options screen to be able to 'refresh' when language is changed (rather than forcing C:SL to rebuild entire mod options library).