### PR TITLE
Minor update to checkboxes

### DIFF
--- a/TLM/TLM/State/Options.cs
+++ b/TLM/TLM/State/Options.cs
@@ -182,43 +182,6 @@ namespace TrafficManager.State {
             }
         }
 
-        internal static void Indent(UIComponent component) {
-            UILabel label = component.Find<UILabel>("Label");
-
-            if (label != null) {
-                label.padding = new RectOffset(22, 0, 0, 0);
-            }
-
-            UISprite check = component.Find<UISprite>("Unchecked");
-
-            if (check != null) {
-                check.relativePosition += new Vector3(22.0f, 0);
-            }
-        }
-
-        /// <summary>
-        /// Allows long checkbox label text to wrap and adds padding to checkbox
-        /// </summary>
-        /// <param name="checkBox">Checkbox instance</param>
-        /// <param name="indented">Is checkbox indented</param>
-        public static void AllowTextWrap(UICheckBox checkBox, bool indented = false) {
-            UILabel label = checkBox.label;
-            bool requireTextWrap;
-            int maxWidth = indented ? CHECKBOX_LABEL_MAX_WIDTH_INDENTED : CHECKBOX_LABEL_MAX_WIDTH;
-            using (UIFontRenderer renderer = label.ObtainRenderer()) {
-                Vector2 size = renderer.MeasureString(label.text);
-                requireTextWrap = size.x > maxWidth;
-            }
-            label.autoSize = false;
-            label.wordWrap = true;
-            label.verticalAlignment = UIVerticalAlignment.Middle;
-            label.textAlignment = UIHorizontalAlignment.Left;
-            label.size = new Vector2(maxWidth, requireTextWrap ? 40 : 20);
-            if (requireTextWrap) {
-                checkBox.height = 42; // set new height + top/bottom 1px padding
-            }
-        }
-
         /// <summary>
         /// If the game is not loaded and warn is true, will display a warning about options being
         /// local to each savegame.

--- a/TLM/TLM/State/OptionsTabs/GameplayTab.cs
+++ b/TLM/TLM/State/OptionsTabs/GameplayTab.cs
@@ -88,7 +88,7 @@ namespace TrafficManager.State {
                       Translation.Options.Get("Gameplay.Checkbox:No excessive transfers"),
                       Options.realisticPublicTransport,
                       OnRealisticPublicTransportChanged) as UICheckBox;
-            Options.AllowTextWrap(_realisticPublicTransportToggle);
+            CheckboxOption.AllowTextWrap(_realisticPublicTransportToggle);
         }
 
         private static void OnRecklessDriversChanged(int newRecklessDrivers) {

--- a/TLM/TLM/State/OptionsTabs/GameplayTab.cs
+++ b/TLM/TLM/State/OptionsTabs/GameplayTab.cs
@@ -88,7 +88,7 @@ namespace TrafficManager.State {
                       Translation.Options.Get("Gameplay.Checkbox:No excessive transfers"),
                       Options.realisticPublicTransport,
                       OnRealisticPublicTransportChanged) as UICheckBox;
-            CheckboxOption.AllowTextWrap(_realisticPublicTransportToggle);
+            CheckboxOption.ApplyTextWrap(_realisticPublicTransportToggle);
         }
 
         private static void OnRecklessDriversChanged(int newRecklessDrivers) {

--- a/TLM/TLM/State/OptionsTabs/GeneralTab.cs
+++ b/TLM/TLM/State/OptionsTabs/GeneralTab.cs
@@ -185,7 +185,7 @@ namespace TrafficManager.State {
                                             text: Translation.ModConflicts.Get("Checkbox:Ignore disabled mods"),
                                             defaultValue: GlobalConfig.Instance.Main.IgnoreDisabledMods,
                                             eventCallback: OnIgnoreDisabledModsChanged) as UICheckBox;
-            Options.Indent(_ignoreDisabledModsToggle);
+            CheckboxOption.IndentUI(_ignoreDisabledModsToggle);
             _showCompatibilityCheckErrorToggle
                 = group.AddCheckbox(
                       T("General.Checkbox:Notify me about TM:PE startup conflicts"),

--- a/TLM/TLM/State/OptionsTabs/GeneralTab.cs
+++ b/TLM/TLM/State/OptionsTabs/GeneralTab.cs
@@ -185,7 +185,7 @@ namespace TrafficManager.State {
                                             text: Translation.ModConflicts.Get("Checkbox:Ignore disabled mods"),
                                             defaultValue: GlobalConfig.Instance.Main.IgnoreDisabledMods,
                                             eventCallback: OnIgnoreDisabledModsChanged) as UICheckBox;
-            CheckboxOption.IndentUI(_ignoreDisabledModsToggle);
+            CheckboxOption.ApplyIndent(_ignoreDisabledModsToggle);
             _showCompatibilityCheckErrorToggle
                 = group.AddCheckbox(
                       T("General.Checkbox:Notify me about TM:PE startup conflicts"),

--- a/TLM/TLM/State/OptionsTabs/MaintenanceTab.cs
+++ b/TLM/TLM/State/OptionsTabs/MaintenanceTab.cs
@@ -115,7 +115,7 @@ namespace TrafficManager.State {
                                              Options.laneConnectorEnabled,
                                              OnLaneConnectorEnabledChanged) as UICheckBox;
 
-            CheckboxOption.IndentUI(_turnOnRedEnabledToggle);
+            CheckboxOption.ApplyIndent(_turnOnRedEnabledToggle);
 
             MaintenanceTab_DespawnGroup.AddUI(panelHelper);
 

--- a/TLM/TLM/State/OptionsTabs/MaintenanceTab.cs
+++ b/TLM/TLM/State/OptionsTabs/MaintenanceTab.cs
@@ -115,7 +115,7 @@ namespace TrafficManager.State {
                                              Options.laneConnectorEnabled,
                                              OnLaneConnectorEnabledChanged) as UICheckBox;
 
-            Options.Indent(_turnOnRedEnabledToggle);
+            CheckboxOption.IndentUI(_turnOnRedEnabledToggle);
 
             MaintenanceTab_DespawnGroup.AddUI(panelHelper);
 

--- a/TLM/TLM/State/OptionsTabs/PoliciesTab.cs
+++ b/TLM/TLM/State/OptionsTabs/PoliciesTab.cs
@@ -78,8 +78,8 @@ namespace TrafficManager.State {
                       Translation.Options.Get("VR.Checkbox:Also apply to left/right turns between one-way streets"),
                       Options.allowFarTurnOnRed,
                       OnAllowFarTurnOnRedChanged) as UICheckBox;
-            Options.Indent(_allowFarTurnOnRedToggle);
-            Options.AllowTextWrap(_allowFarTurnOnRedToggle, indented: true);
+            CheckboxOption.IndentUI(_allowFarTurnOnRedToggle);
+            CheckboxOption.AllowTextWrap(_allowFarTurnOnRedToggle, indented: true);
             _allowLaneChangesWhileGoingStraightToggle
                 = atJunctionsGroup.AddCheckbox(
                       Translation.Options.Get("VR.Checkbox:Vehicles going straight may change lanes at junctions"),
@@ -90,7 +90,7 @@ namespace TrafficManager.State {
                       Translation.Options.Get("VR.Checkbox:Vehicles follow priority rules at junctions with timedTL"),
                       Options.trafficLightPriorityRules,
                       OnTrafficLightPriorityRulesChanged) as UICheckBox;
-            Options.AllowTextWrap(_trafficLightPriorityRulesToggle);
+            CheckboxOption.AllowTextWrap(_trafficLightPriorityRulesToggle);
             _automaticallyAddTrafficLightsIfApplicableToggle
                 = atJunctionsGroup.AddCheckbox(
                       Translation.Options.Get("VR.Checkbox:Automatically add traffic lights if applicable"),

--- a/TLM/TLM/State/OptionsTabs/PoliciesTab.cs
+++ b/TLM/TLM/State/OptionsTabs/PoliciesTab.cs
@@ -79,7 +79,7 @@ namespace TrafficManager.State {
                       Options.allowFarTurnOnRed,
                       OnAllowFarTurnOnRedChanged) as UICheckBox;
             CheckboxOption.ApplyIndent(_allowFarTurnOnRedToggle);
-            CheckboxOption.AllowTextWrap(_allowFarTurnOnRedToggle, indented: true);
+            CheckboxOption.ApplyTextWrap(_allowFarTurnOnRedToggle, indented: true);
             _allowLaneChangesWhileGoingStraightToggle
                 = atJunctionsGroup.AddCheckbox(
                       Translation.Options.Get("VR.Checkbox:Vehicles going straight may change lanes at junctions"),
@@ -90,7 +90,7 @@ namespace TrafficManager.State {
                       Translation.Options.Get("VR.Checkbox:Vehicles follow priority rules at junctions with timedTL"),
                       Options.trafficLightPriorityRules,
                       OnTrafficLightPriorityRulesChanged) as UICheckBox;
-            CheckboxOption.AllowTextWrap(_trafficLightPriorityRulesToggle);
+            CheckboxOption.ApplyTextWrap(_trafficLightPriorityRulesToggle);
             _automaticallyAddTrafficLightsIfApplicableToggle
                 = atJunctionsGroup.AddCheckbox(
                       Translation.Options.Get("VR.Checkbox:Automatically add traffic lights if applicable"),

--- a/TLM/TLM/State/OptionsTabs/PoliciesTab.cs
+++ b/TLM/TLM/State/OptionsTabs/PoliciesTab.cs
@@ -78,7 +78,7 @@ namespace TrafficManager.State {
                       Translation.Options.Get("VR.Checkbox:Also apply to left/right turns between one-way streets"),
                       Options.allowFarTurnOnRed,
                       OnAllowFarTurnOnRedChanged) as UICheckBox;
-            CheckboxOption.IndentUI(_allowFarTurnOnRedToggle);
+            CheckboxOption.ApplyIndent(_allowFarTurnOnRedToggle);
             CheckboxOption.AllowTextWrap(_allowFarTurnOnRedToggle, indented: true);
             _allowLaneChangesWhileGoingStraightToggle
                 = atJunctionsGroup.AddCheckbox(

--- a/TLM/TLM/UI/Helpers/CheckboxOption.cs
+++ b/TLM/TLM/UI/Helpers/CheckboxOption.cs
@@ -127,7 +127,7 @@ namespace TrafficManager.UI.Helpers {
         public override void AddUI(UIHelperBase container) {
             _ui = container.AddCheckbox(T(Label), Value, OnValueChanged) as UICheckBox;
 
-            if (Indent) IndentUI(_ui);
+            if (Indent) ApplyIndent(_ui);
 
             AllowTextWrap(_ui, Indent);
 
@@ -169,7 +169,7 @@ namespace TrafficManager.UI.Helpers {
 
         /* UI helper methods */
 
-        internal static void IndentUI(UIComponent component) {
+        internal static void ApplyIndent(UIComponent component) {
             UILabel label = component.Find<UILabel>("Label");
 
             if (label != null) {

--- a/TLM/TLM/UI/Helpers/CheckboxOption.cs
+++ b/TLM/TLM/UI/Helpers/CheckboxOption.cs
@@ -48,11 +48,17 @@ namespace TrafficManager.UI.Helpers {
         public CheckboxOption PropagateTrueTo([NotNull] CheckboxOption target) {
             Log.Info($"CheckboxOption.PropagateTrueTo: `{FieldName}` will proagate to `{target.FieldName}`");
 
-            if (_propagatesTrueTo == null) _propagatesTrueTo = new();
-            _propagatesTrueTo.Add(target);
+            if (_propagatesTrueTo == null)
+                _propagatesTrueTo = new();
 
-            if (target._propagatesFalseTo == null) target._propagatesFalseTo = new();
-            target._propagatesFalseTo.Add(this);
+            if (!_propagatesTrueTo.Contains(target))
+                _propagatesTrueTo.Add(target);
+
+            if (target._propagatesFalseTo == null)
+                target._propagatesFalseTo = new();
+
+            if (!target._propagatesFalseTo.Contains(this))
+                target._propagatesFalseTo.Add(this);
 
             return this;
         }

--- a/TLM/TLM/UI/Helpers/CheckboxOption.cs
+++ b/TLM/TLM/UI/Helpers/CheckboxOption.cs
@@ -129,7 +129,7 @@ namespace TrafficManager.UI.Helpers {
 
             if (Indent) ApplyIndent(_ui);
 
-            AllowTextWrap(_ui, Indent);
+            ApplyTextWrap(_ui, Indent);
 
             UpdateTooltip();
             UpdateReadOnly();
@@ -183,7 +183,7 @@ namespace TrafficManager.UI.Helpers {
             }
         }
 
-        internal static void AllowTextWrap(UICheckBox checkBox, bool indented = false) {
+        internal static void ApplyTextWrap(UICheckBox checkBox, bool indented = false) {
             UILabel label = checkBox.label;
             bool requireTextWrap;
             int maxWidth = indented ? CHECKBOX_LABEL_MAX_WIDTH_INDENTED : CHECKBOX_LABEL_MAX_WIDTH;


### PR DESCRIPTION
Part of #1356 ongoing work

- Ensure no duplicate targets in propagation lists for `CheckboxOption` components
- Duplicate propagation list entries could potentially occur due to:
    - Hot reloads (unlikely, but let's take no chances; fixed by this PR)
    - Second-loads (confirmed; fixed by this PR)
    - Post-editor loads (confirmed; fixed by this PR)
- Move `Indent` and `AllowTextWrap` from `Options.cs` to `CheckboxOption.cs`
    - These methods are checkbox-specific (it's the only place we use them) and not relevant to `Options.cs`
    - `Indent` method renamed `ApplyIndent` to avoid confusion with `Indent` property of checkbox
    - `AllowTextWrap` renamed `ApplyTextWrap` for consistency
- Update old-style checkboxes to use relocated methods

A goal here is to remove most, if not all, methods from `Options.cs` so the file contains just option fields. Most of the remaining methods will be moved in to `OptionsManager.cs` in subsequent PRs. `Options` should also ideally be instantiated (future PR) but further thought required there due to lots of hotpath call sites needing to query option field values.