### PR TITLE
Refactor remainder of `Gameplay` tab

### DIFF
--- a/TLM/TLM/Manager/Impl/OptionsManager.cs
+++ b/TLM/TLM/Manager/Impl/OptionsManager.cs
@@ -95,7 +95,7 @@ namespace TrafficManager.Manager.Impl {
                 PoliciesTab.SetRelaxedBusses(LoadBool(data, idx: 3));
                 OverlaysTab.SetNodesOverlay(LoadBool(data, idx: 4));
                 PoliciesTab.SetMayEnterBlockedJunctions(LoadBool(data, idx: 5));
-                GameplayTab.SetAdvancedAi(LoadBool(data, idx: 6));
+                ToCheckbox(data, idx: 6, GameplayTab_AIGroups.AdvancedAI, false);
                 PoliciesTab.SetHighwayRules(LoadBool(data, idx: 7));
                 OverlaysTab.SetPrioritySignsOverlay(LoadBool(data, idx: 8));
                 OverlaysTab.SetTimedLightsOverlay(LoadBool(data, idx: 9));
@@ -114,7 +114,7 @@ namespace TrafficManager.Manager.Impl {
                 MaintenanceTab.SetLaneConnectorEnabled(LoadBool(data, idx: 22));
                 OverlaysTab.SetJunctionRestrictionsOverlay(LoadBool(data, idx: 23));
                 MaintenanceTab.SetJunctionRestrictionsEnabled(LoadBool(data, idx: 24));
-                GameplayTab.SetProhibitPocketCars(LoadBool(data, idx: 25));
+                ToCheckbox(data, idx: 25, GameplayTab_AIGroups.ParkingAI, false);
                 PoliciesTab.SetPreferOuterLane(LoadBool(data, idx: 26));
                 ToCheckbox(data, idx: 27, GameplayTab_VehicleBehaviourGroup.IndividualDrivingStyle, false);
                 PoliciesTab.SetEvacBussesMayIgnoreRules(LoadBool(data, idx: 28));
@@ -123,7 +123,7 @@ namespace TrafficManager.Manager.Impl {
                 OverlaysTab.SetParkingRestrictionsOverlay(LoadBool(data, idx: 31));
                 PoliciesTab.SetBanRegularTrafficOnBusLanes(LoadBool(data, idx: 32));
                 MaintenanceTab.SetShowPathFindStats(LoadBool(data, idx: 33));
-                GameplayTab.SetDLSPercentage(LoadByte(data, idx: 34));
+                ToSlider(data, idx: 34, GameplayTab_AIGroups.AltLaneSelectionRatio, 0);
 
                 if (data.Length > 35) {
                     try {
@@ -137,7 +137,7 @@ namespace TrafficManager.Manager.Impl {
                 }
 
                 PoliciesTab.SetTrafficLightPriorityRules(LoadBool(data, idx: 36));
-                GameplayTab.SetRealisticPublicTransport(LoadBool(data, idx: 37));
+                ToCheckbox(data, idx: 37, GameplayTab_AIGroups.RealisticPublicTransport, false);
                 MaintenanceTab.SetTurnOnRedEnabled(LoadBool(data, idx: 38));
                 PoliciesTab.SetAllowNearTurnOnRed(LoadBool(data, idx: 39));
                 PoliciesTab.SetAllowFarTurnOnRed(LoadBool(data, idx: 40));

--- a/TLM/TLM/Manager/Impl/OptionsManager.cs
+++ b/TLM/TLM/Manager/Impl/OptionsManager.cs
@@ -64,36 +64,20 @@ namespace TrafficManager.Manager.Impl {
             return (byte)(SimulationAccuracy.MaxValue - value);
         }
 
-        public bool MayPublishSegmentChanges() {
-            return Options.instantEffects && TMPELifecycle.InGameOrEditor() &&
-                !TMPELifecycle.Instance.Deserializing;
-        }
+        public bool MayPublishSegmentChanges() =>
+            Options.instantEffects &&
+            TMPELifecycle.InGameOrEditor() &&
+            !TMPELifecycle.Instance.Deserializing;
 
-        // Takes a bool from data and sets it in `out result`
-        private static bool LoadBool([NotNull] byte[] data, uint idx, bool defaultVal = false) {
-            if (data.Length > idx) {
-                var result = data[idx] == 1;
-                return result;
-            }
+        private static bool LoadBool([NotNull] byte[] data, uint idx, bool defaultVal = false)
+            => (data.Length > idx) ? data[idx] == 1 : defaultVal;
 
-            return defaultVal;
-        }
-
-        private static byte LoadByte([NotNull] byte[] data, uint idx, byte defaultVal = 0) {
-            if (data.Length > idx) {
-                var result = data[idx];
-                return result;
-            }
-
-            return defaultVal;
-        }
+        private static byte LoadByte([NotNull] byte[] data, uint idx, byte defaultVal = 0)
+            => (data.Length > idx) ? data[idx] : defaultVal;
 
         /// <summary>Load LegacySerializableOption bool.</summary>
-        private static void ToCheckbox([NotNull] byte[] data, uint idx, ILegacySerializableOption opt, bool defaultVal = false) {
-            if (data.Length > idx) {
-                opt.Load(data[idx]);
-                return;
-            }
+        private static void ToCheckbox(byte[] data, uint idx, ILegacySerializableOption opt, bool defaultVal = false)
+            => opt.Load((byte)(LoadBool(data, idx, defaultVal) ? 1 : 0));
 
         /// <summary>Load LegacySerializableOption byte.</summary>
         private static void ToSlider(byte[] data, uint idx, ILegacySerializableOption opt, byte defaultVal = 0)

--- a/TLM/TLM/Manager/Impl/OptionsManager.cs
+++ b/TLM/TLM/Manager/Impl/OptionsManager.cs
@@ -95,8 +95,9 @@ namespace TrafficManager.Manager.Impl {
                 return;
             }
 
-            opt.Load(defaultVal ? (byte)1 : (byte)0);
-        }
+        /// <summary>Load LegacySerializableOption byte.</summary>
+        private static void ToSlider(byte[] data, uint idx, ILegacySerializableOption opt, byte defaultVal = 0)
+            => opt.Load(LoadByte(data, idx, defaultVal));
 
         public bool LoadData(byte[] data) {
             try {

--- a/TLM/TLM/State/OptionsTabs/GameplayTab.cs
+++ b/TLM/TLM/State/OptionsTabs/GameplayTab.cs
@@ -1,7 +1,6 @@
 namespace TrafficManager.State {
     using TrafficManager.UI.Helpers;
     using TrafficManager.UI;
-    using TrafficManager.Lifecycle;
 
     public static class GameplayTab {
 
@@ -11,13 +10,6 @@ namespace TrafficManager.State {
             GameplayTab_VehicleBehaviourGroup.AddUI(tab);
 
             GameplayTab_AIGroups.AddUI(tab);
-        }
-
-        private static void OnAltLaneSelectionRatioChanged(float newVal) {
-            // Only call this if the game is running, not during the loading time
-            if (TMPELifecycle.Instance.IsGameLoaded) {
-                //_altLaneSelectionRatioSlider.RefreshTooltip();
-            }
         }
     }
 }

--- a/TLM/TLM/State/OptionsTabs/GameplayTab.cs
+++ b/TLM/TLM/State/OptionsTabs/GameplayTab.cs
@@ -1,151 +1,23 @@
 namespace TrafficManager.State {
-    using ColossalFramework.UI;
-    using CSUtil.Commons;
-    using ICities;
-    using TrafficManager.Manager.Impl;
     using TrafficManager.UI.Helpers;
     using TrafficManager.UI;
-    using UnityEngine;
     using TrafficManager.Lifecycle;
 
     public static class GameplayTab {
-        private static UICheckBox _prohibitPocketCarsToggle;
-        private static UICheckBox _advancedAIToggle;
-        private static UICheckBox _realisticPublicTransportToggle;
-        private static UISlider _altLaneSelectionRatioSlider;
 
         internal static void MakeSettings_Gameplay(ExtUITabstrip tabStrip) {
-            UIHelper panelHelper = tabStrip.AddTabPage(Translation.Options.Get("Tab:Gameplay"));
+            UIHelper tab = tabStrip.AddTabPage(Translation.Options.Get("Tab:Gameplay"));
 
-            GameplayTab_VehicleBehaviourGroup.AddUI(panelHelper);
+            GameplayTab_VehicleBehaviourGroup.AddUI(tab);
 
-            UIHelperBase vehAiGroup = panelHelper.AddGroup(
-                Translation.Options.Get("Gameplay.Group:Advanced vehicle AI"));
-            _advancedAIToggle = vehAiGroup.AddCheckbox(
-                                   Translation.Options.Get("Gameplay.Checkbox:Enable advanced vehicle AI"),
-                                   Options.advancedAI,
-                                   OnAdvancedAiChanged) as UICheckBox;
-            _altLaneSelectionRatioSlider
-                = vehAiGroup.AddSlider(
-                      Translation.Options.Get("Gameplay.Slider:Dynamic lane selection") + ":",
-                      0,
-                      100,
-                      5,
-                      Options.altLaneSelectionRatio,
-                      OnAltLaneSelectionRatioChanged) as UISlider;
-            _altLaneSelectionRatioSlider.parent.Find<UILabel>("Label").width = 450;
-
-            UIHelperBase parkAiGroup = panelHelper.AddGroup(
-                Translation.Options.Get("Gameplay.Group:Parking AI"));
-            _prohibitPocketCarsToggle
-                = parkAiGroup.AddCheckbox(
-                      Translation.Options.Get("Gameplay.Checkbox:Enable more realistic parking"),
-                      Options.parkingAI,
-                      OnProhibitPocketCarsChanged) as UICheckBox;
-
-            UIHelperBase ptGroup = panelHelper.AddGroup(
-                Translation.Options.Get("Gameplay.Group:Public transport"));
-            _realisticPublicTransportToggle
-                = ptGroup.AddCheckbox(
-                      Translation.Options.Get("Gameplay.Checkbox:No excessive transfers"),
-                      Options.realisticPublicTransport,
-                      OnRealisticPublicTransportChanged) as UICheckBox;
-            CheckboxOption.ApplyTextWrap(_realisticPublicTransportToggle);
-        }
-
-        private static void OnAdvancedAiChanged(bool newAdvancedAi) {
-            if (!Options.IsGameLoaded()) {
-                return;
-            }
-
-            Log._Debug($"advancedAI changed to {newAdvancedAi}");
-            SetAdvancedAi(newAdvancedAi);
-        }
-
-        private static void OnProhibitPocketCarsChanged(bool newValue) {
-            if (!Options.IsGameLoaded()) {
-                return;
-            }
-
-            Log._Debug($"prohibitPocketCars changed to {newValue}");
-            Options.parkingAI = newValue;
-
-            if (Options.parkingAI) {
-                AdvancedParkingManager.Instance.OnEnableFeature();
-            } else {
-                AdvancedParkingManager.Instance.OnDisableFeature();
-            }
-        }
-
-        private static void OnRealisticPublicTransportChanged(bool newValue) {
-            if (!Options.IsGameLoaded()) {
-                return;
-            }
-
-            Log._Debug($"realisticPublicTransport changed to {newValue}");
-            Options.realisticPublicTransport = newValue;
+            GameplayTab_AIGroups.AddUI(tab);
         }
 
         private static void OnAltLaneSelectionRatioChanged(float newVal) {
-            if (!Options.IsGameLoaded()) {
-                return;
-            }
-
-            SetDLSPercentage((byte)Mathf.RoundToInt(newVal));
-            _altLaneSelectionRatioSlider.tooltip =
-                Translation.Options.Get("Gameplay.Tooltip:DLS_percentage") + ": " +
-                Options.altLaneSelectionRatio + " %";
-
             // Only call this if the game is running, not during the loading time
             if (TMPELifecycle.Instance.IsGameLoaded) {
-                _altLaneSelectionRatioSlider.RefreshTooltip();
-            }
-
-            Log._Debug($"altLaneSelectionRatio changed to {Options.altLaneSelectionRatio}");
-        }
-
-        public static void SetDLSPercentage(byte val) {
-            bool changed = val != Options.altLaneSelectionRatio;
-            Options.altLaneSelectionRatio = val;
-
-            if (changed && _altLaneSelectionRatioSlider != null) {
-                _altLaneSelectionRatioSlider.value = val;
-            }
-
-            if (changed && Options.altLaneSelectionRatio > 0) {
-                SetAdvancedAi(true);
+                //_altLaneSelectionRatioSlider.RefreshTooltip();
             }
         }
-
-        public static void SetAdvancedAi(bool newAdvancedAi) {
-            bool changed = newAdvancedAi != Options.advancedAI;
-            Options.advancedAI = newAdvancedAi;
-
-            if (changed && _advancedAIToggle != null) {
-                _advancedAIToggle.isChecked = newAdvancedAi;
-            }
-
-            if (changed && !newAdvancedAi) {
-                SetDLSPercentage(0);
-            }
-        }
-
-        public static void SetProhibitPocketCars(bool newValue) {
-            // bool valueChanged = newValue != Options.parkingAI;
-            Options.parkingAI = newValue;
-
-            if (_prohibitPocketCarsToggle != null) {
-                _prohibitPocketCarsToggle.isChecked = newValue;
-            }
-        }
-
-        public static void SetRealisticPublicTransport(bool newValue) {
-            bool valueChanged = newValue != Options.realisticPublicTransport;
-            Options.realisticPublicTransport = newValue;
-
-            if (_realisticPublicTransportToggle != null) {
-                _realisticPublicTransportToggle.isChecked = newValue;
-            }
-        }
-    } // end class
+    }
 }

--- a/TLM/TLM/State/OptionsTabs/GameplayTab_AIGroups.cs
+++ b/TLM/TLM/State/OptionsTabs/GameplayTab_AIGroups.cs
@@ -1,0 +1,89 @@
+namespace TrafficManager.State {
+    using ICities;
+    using TrafficManager.Lifecycle;
+    using TrafficManager.Manager.Impl;
+    using TrafficManager.UI;
+    using TrafficManager.UI.Helpers;
+
+    public static class GameplayTab_AIGroups {
+
+        // Advanced AI group
+
+        public static CheckboxOption AdvancedAI =
+            new (nameof(Options.advancedAI), Options.PersistTo.Savegame) {
+                Label = "Gameplay.Checkbox:Enable advanced vehicle AI",
+                Handler = OnAdvancedAIChanged,
+            };
+
+        public static SliderOption AltLaneSelectionRatio =
+            new(nameof(Options.altLaneSelectionRatio), Options.PersistTo.None) {
+                Label = "Gameplay.Slider:Dynamic lane selection",
+                Tooltip = "%",
+                Min = 0,
+                Max = 100,
+                Handler = OnAltLaneSelectionRatioChanged,
+            };
+
+        // Parking AI group
+
+        public static CheckboxOption ParkingAI =
+            new(nameof(Options.parkingAI), Options.PersistTo.Savegame) {
+                Label = "Gameplay.Checkbox:Enable more realistic parking",
+                Handler = OnParkingAIChanged,
+            };
+
+        // Public Transport group
+
+        public static CheckboxOption RealisticPublicTransport =
+            new(nameof(Options.realisticPublicTransport), Options.PersistTo.Savegame) {
+                Label = "Gameplay.Checkbox:No excessive transfers",
+            };
+
+        internal static void AddUI(UIHelperBase tab) {
+            UIHelperBase group;
+
+            group = tab.AddGroup(T("Gameplay.Group:Advanced vehicle AI"));
+
+            AdvancedAI.AddUI(group);
+
+            AltLaneSelectionRatio.AddUI(group)
+                .ReadOnly = !TMPELifecycle.PlayMode;
+
+            group = tab.AddGroup(T("Gameplay.Group:Parking AI"));
+
+            ParkingAI.AddUI(group);
+
+            group = tab.AddGroup(T("Gameplay.Group:Public transport"));
+
+            RealisticPublicTransport.AddUI(group);
+        }
+
+        private static string T(string key) => Translation.Options.Get(key);
+
+        private static void OnAdvancedAIChanged(bool _) {
+            if (TMPELifecycle.Instance.Deserializing) return;
+
+            if (!Options.advancedAI)
+                AltLaneSelectionRatio.Value = 0;
+        }
+
+        private static void OnAltLaneSelectionRatioChanged(float _) {
+            if (TMPELifecycle.Instance.Deserializing) return;
+
+            Options.altLaneSelectionRatio = AltLaneSelectionRatio.Save();
+
+            if (Options.altLaneSelectionRatio > 0)
+                AdvancedAI.Value = true;
+        }
+
+        private static void OnParkingAIChanged(bool _) {
+            if (TMPELifecycle.Instance.Deserializing) return;
+
+            if (Options.parkingAI) {
+                AdvancedParkingManager.Instance.OnEnableFeature();
+            } else {
+                AdvancedParkingManager.Instance.OnDisableFeature();
+            }
+        }
+    }
+}

--- a/TLM/TLM/State/OptionsTabs/GameplayTab_VehicleBehaviourGroup.cs
+++ b/TLM/TLM/State/OptionsTabs/GameplayTab_VehicleBehaviourGroup.cs
@@ -9,19 +9,19 @@ namespace TrafficManager.State {
 
         public static CheckboxOption IndividualDrivingStyle =
             new (nameof(Options.individualDrivingStyle), Options.PersistTo.Savegame) {
-                Label = T("Gameplay.Checkbox:Individual driving styles"),
+                Label = "Gameplay.Checkbox:Individual driving styles",
             };
 
         // Requires Snowfall DLC
         public static CheckboxOption StrongerRoadConditionEffects =
             new(nameof(Options.strongerRoadConditionEffects), Options.PersistTo.Savegame) {
-                Label = T("Gameplay.Checkbox:Increase road condition impact"),
+                Label = "Gameplay.Checkbox:Increase road condition impact",
                 Validator = SnowfallDlcValidator,
             };
 
         public static CheckboxOption DisableDespawning =
             new(nameof(Options.disableDespawning), Options.PersistTo.Savegame) {
-                Label = T("Maintenance.Checkbox:Disable despawning"),
+                Label = "Maintenance.Checkbox:Disable despawning",
             };
 
         private static UIDropDown _recklessDriversDropdown;

--- a/TLM/TLM/TLM.csproj
+++ b/TLM/TLM/TLM.csproj
@@ -148,6 +148,7 @@
     <Compile Include="Manager\Impl\ExtSegmentManager.cs" />
     <Compile Include="Manager\Impl\GeometryNotifier.cs" />
     <Compile Include="Patch\_External\RTramAIModPatch.cs" />
+    <Compile Include="State\OptionsTabs\GameplayTab_AIGroups.cs" />
     <Compile Include="State\OptionsTabs\GeneralTab_CompatibilityGroup.cs" />
     <Compile Include="State\OptionsTabs\GeneralTab_LocalisationGroup.cs" />
     <Compile Include="State\OptionsTabs\GameplayTab_VehicleBehaviourGroup.cs" />


### PR DESCRIPTION
Part of ongoing work on #1356 phase 2 - https://github.com/CitiesSkylinesMods/TMPE/issues/1356#issuecomment-1040690406

- Moved the remaining AI-related Gameplay options to separate class
    - ...just one as there were only few options
- Updated to checkbox/slider options, removed unused `set...` functions, etc.
- Minified some methods in `OptionsManager` to make things more concise
- Fixed some minor blunders with locale keys from an earlier PR