### PR TITLE
API Only

### DIFF
--- a/TLM/TMPE.API/Implementations.cs
+++ b/TLM/TMPE.API/Implementations.cs
@@ -1,0 +1,22 @@
+namespace TrafficManager.API {
+    using System;
+    using TrafficManager.API.Manager;
+    using TrafficManager.API.Notifier;
+    using System.Linq;
+
+    public static class Implementations {
+        private static Type constantsType_;
+        private static IManagerFactory managerFactory_;
+        private static INotifier notifier_;
+
+        public static IManagerFactory ManagerFactory => managerFactory_ ??= GetImplementation<IManagerFactory>();
+        public static INotifier Notifier => notifier_ ??= GetImplementation<INotifier>();
+
+        private static T GetImplementation<T>()
+            where T : class {
+            constantsType_ ??= Type.GetType("TrafficManger.Constants, TrafficManager", throwOnError: true);
+            var field = constantsType_.GetFields().Single(item => typeof(T).IsAssignableFrom(item.FieldType));
+            return field.GetValue(null) as T;
+        }
+    }
+}

--- a/TLM/TMPE.API/TMPE.API.csproj
+++ b/TLM/TMPE.API/TMPE.API.csproj
@@ -75,6 +75,7 @@
     <Compile Include="..\SharedAssemblyInfo.cs">
       <Link>Properties\SharedAssemblyInfo.cs</Link>
     </Compile>
+    <Compile Include="Implementations.cs" />
     <Compile Include="Geometry\SegmentEndReplacement.cs" />
     <Compile Include="Manager\IAdvancedParkingManager.cs" />
     <Compile Include="Manager\ICustomDataManager.cs" />


### PR DESCRIPTION
I created references from TMPE API to TranfficManager Implementations so that other mods will only need to reference `TMPE.API.dll`

I could not reference TrafficManager from TMPE.API because of the issue of cyclic dependency. So I used reflection instead.