### PR TITLE
Read elevation keybind from vanilla settings

### DIFF
--- a/TLM/TLM/State/Keybinds/KeybindSetting.cs
+++ b/TLM/TLM/State/Keybinds/KeybindSetting.cs
@@ -38,6 +38,25 @@ namespace TrafficManager.State.Keybinds {
         }
 
         /// <summary>
+        /// Keybind Setting for custom readonly keybind
+        /// </summary>
+        /// <param name="cat">Category </param>
+        /// <param name="keyName">key name in the settings file</param>
+        /// <param name="configFile">Config filename</param>
+        /// <param name="inputKey">inputKey instance</param>
+        public KeybindSetting(string cat,
+                              string keyName,
+                              string configFile,
+                              InputKey inputKey) {
+            Category = cat;
+            Key = new SavedInputKey(
+                keyName,
+                configFile,
+                inputKey,
+                true);
+        }
+
+        /// <summary>
         /// Used by the GUI to tell the button event handler which key is being edited
         /// </summary>
         public struct Editable {
@@ -150,6 +169,15 @@ namespace TrafficManager.State.Keybinds {
                 prev_value = value;
             }
             return ret;
+        }
+
+        /// <summary>
+        /// Determines when user releases the key
+        /// </summary>
+        /// <param name="e"></param>
+        /// <returns>true once when user releases the key.</returns>
+        public bool KeyUp() {
+            return Key.IsKeyUp();
         }
 
         /// <summary>

--- a/TLM/TLM/State/Keybinds/KeybindSettingsBase.cs
+++ b/TLM/TLM/State/Keybinds/KeybindSettingsBase.cs
@@ -77,6 +77,18 @@ namespace TrafficManager.State.Keybinds {
             defaultKey1: SavedInputKey.Encode(key: KeyCode.Delete, control: false, shift: false, alt: false),
             defaultKey2: SavedInputKey.Encode(key: KeyCode.Backspace, control: false, shift: false, alt: false));
 
+        public static KeybindSetting ElevationUp = new(
+            cat: "Global",
+            keyName: Settings.buildElevationUp,
+            configFile: Settings.gameSettingsFile,
+            inputKey: DefaultSettings.buildElevationUp);
+
+        public static KeybindSetting ElevationDown = new(
+            cat: "Global",
+            keyName: Settings.buildElevationDown,
+            configFile: Settings.gameSettingsFile,
+            inputKey: DefaultSettings.buildElevationDown);
+
         protected KeybindUI keybindUi_ = new();
 
         /// <summary>
@@ -151,14 +163,26 @@ namespace TrafficManager.State.Keybinds {
         /// </summary>
         /// <param name="label">Localized label</param>
         /// <param name="keybind">The setting to edit</param>
-        protected void AddReadOnlyKeybind(string label, KeybindSetting keybind) {
+        /// <param name="autoUpdateText">attach callback to auto-update text on visibility change</param>
+        protected void AddReadOnlyKeybind(string label, KeybindSetting keybind, bool autoUpdateText = false) {
             var settingsRow = keybindUi_.CreateRowPanel();
             if (uiRowCount_++ % 2 == 1) {
                 settingsRow.backgroundSprite = null;
             }
 
             keybindUi_.CreateLabel(settingsRow, label, 0.6f);
-            keybindUi_.CreateKeybindText(settingsRow, keybind.Key, 0.3f);
+            UILabel keybindTextLabel = keybindUi_.CreateKeybindText(settingsRow, keybind.Key, 0.3f);
+
+            if (autoUpdateText) {
+                keybindTextLabel.objectUserData = keybind.Key;
+                keybindTextLabel.eventVisibilityChanged += OnKeybindLabelVisibilityChanged;
+            }
+        }
+
+        private void OnKeybindLabelVisibilityChanged(UIComponent label, bool value) {
+            if (value) {
+                (label as UILabel).text = Keybind.ToLocalizedString(label.objectUserData as SavedInputKey);
+            }
         }
 
         protected void OnEnable() {

--- a/TLM/TLM/State/Keybinds/KeybindSettingsPage.cs
+++ b/TLM/TLM/State/Keybinds/KeybindSettingsPage.cs
@@ -26,6 +26,12 @@ namespace TrafficManager.State.Keybinds {
         private void CreateUI_Global() {
             AddReadOnlyKeybind(Translation.Options.Get("Keybind:Generic exit subtool key"),
                                Esc);
+            AddReadOnlyKeybind(Translation.Options.Get("Keybind:Elevation up key"),
+                               ElevationUp,
+                               autoUpdateText: true);
+            AddReadOnlyKeybind(Translation.Options.Get("Keybind:Elevation down key"),
+                               ElevationDown,
+                               autoUpdateText: true);
 
             AddKeybindRowUI(Translation.Options.Get("Keybind:Toggle Main Menu"),
                             ToggleMainMenu);

--- a/TLM/TLM/State/Keybinds/KeybindUI.cs
+++ b/TLM/TLM/State/Keybinds/KeybindUI.cs
@@ -178,7 +178,8 @@ namespace TrafficManager.State.Keybinds {
         /// </summary>
         /// <param name="parent">The panel to host it</param>
         /// <param name="showKey">The key to display</param>
-        public void CreateKeybindText(UIPanel parent, SavedInputKey showKey, float widthFraction) {
+        /// <returns>The created UILabel</returns>
+        public UILabel CreateKeybindText(UIPanel parent, SavedInputKey showKey, float widthFraction) {
             var label = parent.AddUIComponent<UILabel>();
             label.autoSize = false;
             label.size = new Vector2(ROW_WIDTH * widthFraction, ROW_HEIGHT);
@@ -186,6 +187,7 @@ namespace TrafficManager.State.Keybinds {
             label.verticalAlignment = UIVerticalAlignment.Middle;
             label.textAlignment = UIHorizontalAlignment.Center;
             label.textColor = new Color32(128, 128, 128, 255); // grey
+            return label;
         }
 
         /// <summary>

--- a/TLM/TLM/U/UIUtil.cs
+++ b/TLM/TLM/U/UIUtil.cs
@@ -1,6 +1,8 @@
 namespace TrafficManager.U {
+    using System;
     using System.Collections.Generic;
     using System.Linq;
+    using System.Text.RegularExpressions;
     using ColossalFramework.UI;
     using CSUtil.Commons;
     using JetBrains.Annotations;
@@ -80,6 +82,27 @@ namespace TrafficManager.U {
         public static string ColorizeKeybind([NotNull] string s) {
             return s.Replace("[[", UConst.GetKeyboardShortcutColorTagOpener())
                     .Replace("]]", UConst.KEYBOARD_SHORTCUT_CLOSING_TAG);
+        }
+
+        /// <summary>
+        /// Replace special markup with UI shortcut color tag (orange).
+        /// Replace wrapped text from 'replacements' of matching index.
+        /// And place closing tag.
+        /// </summary>
+        /// <param name="sourceText">String with keybind wrapped in [[Ctrl]] double square brackets.</param>
+        /// <param name="replacements">Replacements array, each tag match will take own replacement</param>
+        /// <returns>Updated string.</returns>
+        public static string ColorizeDynamicKeybinds([NotNull] string sourceText, string[] replacements) {
+            int i = 0;
+            return new Regex(@"\[\[(.*?)\]\]")
+                .Replace(
+                    sourceText,
+                    new MatchEvaluator(
+                        match => {
+                            return i < replacements.Length
+                                       ? $"{UConst.GetKeyboardShortcutColorTagOpener()}{match.Result(replacements[i++])}{UConst.KEYBOARD_SHORTCUT_CLOSING_TAG}"
+                                       : match.Value;
+                        }));
         }
     }
 }

--- a/TLM/TLM/U/UIUtil.cs
+++ b/TLM/TLM/U/UIUtil.cs
@@ -98,11 +98,9 @@ namespace TrafficManager.U {
                 .Replace(
                     sourceText,
                     new MatchEvaluator(
-                        match => {
-                            return i < replacements.Length
-                                       ? $"{UConst.GetKeyboardShortcutColorTagOpener()}{match.Result(replacements[i++])}{UConst.KEYBOARD_SHORTCUT_CLOSING_TAG}"
-                                       : match.Value;
-                        }));
+                        match => i < replacements.Length
+                                     ? $"{UConst.GetKeyboardShortcutColorTagOpener()}{replacements[i++]}{UConst.KEYBOARD_SHORTCUT_CLOSING_TAG}"
+                                     : match.Value));
         }
     }
 }

--- a/TLM/TLM/UI/Localization/LookupTable.cs
+++ b/TLM/TLM/UI/Localization/LookupTable.cs
@@ -30,6 +30,14 @@ namespace TrafficManager.UI.Localization {
             return UIUtil.ColorizeKeybind(this.Get(lang, key));
         }
 
+        /// <summary>Get a translation string and dynamically find, replace and paint [[Key]] fragments with orange.</summary>
+        /// <param name="key">Translation key.</param>
+        /// <returns>Translated and colorized string.</returns>
+        public string ColorizeDynamicKeybinds(string key, string[] replacements) {
+            string lang = Translation.GetCurrentLanguage();
+            return UIUtil.ColorizeDynamicKeybinds(this.Get(lang, key), replacements);
+        }
+
         public string Get(string lang, string key) {
 #if DEBUG
             if (!AllLanguages.ContainsKey(lang)) {

--- a/TLM/TLM/UI/SubTools/LaneConnectorTool.cs
+++ b/TLM/TLM/UI/SubTools/LaneConnectorTool.cs
@@ -1446,6 +1446,7 @@ namespace TrafficManager.UI.SubTools {
             };
 
         private static string T(string key) => Translation.LaneRouting.Get(key);
+        private static string ColorKeyDynamic(string key, string[] replacements) => Translation.SpeedLimits.ColorizeDynamicKeybinds(key, replacements);
 
         /// <inheritdoc/>
         public void UpdateOnscreenDisplayPanel() {
@@ -1455,12 +1456,26 @@ namespace TrafficManager.UI.SubTools {
                 case SelectionMode.None: {
                     var items = new List<OsdItem>();
                     items.Add(new Label(localizedText: T("LaneConnector.Mode:Select")));
+                    items.Add(new Label(
+                                  localizedText: ColorKeyDynamic(
+                                      "UI.Key:PageUp/PageDown switch underground",
+                                      new[] {
+                                          KeybindSettingsPage.ElevationUp.ToLocalizedString(),
+                                          KeybindSettingsPage.ElevationDown.ToLocalizedString()
+                                      })));
                     OnscreenDisplay.Display(items);
                     return;
                 }
                 case SelectionMode.SelectTarget:
                 case SelectionMode.SelectSource: {
                     var items = new List<OsdItem>();
+                    items.Add(new Label(
+                                  localizedText: Translation.SpeedLimits.ColorizeDynamicKeybinds(
+                                      key: "UI.Key:PageUp/PageDown switch underground",
+                                      replacements: new[] {
+                                          KeybindSettingsPage.ElevationUp.ToLocalizedString(),
+                                          KeybindSettingsPage.ElevationDown.ToLocalizedString()
+                                      })));
                     items.Add(new Label(
                                   m == SelectionMode.SelectSource
                                       ? T("LaneConnector.Mode:Source")

--- a/TLM/TLM/UI/SubTools/LaneConnectorTool.cs
+++ b/TLM/TLM/UI/SubTools/LaneConnectorTool.cs
@@ -1470,16 +1470,16 @@ namespace TrafficManager.UI.SubTools {
                 case SelectionMode.SelectSource: {
                     var items = new List<OsdItem>();
                     items.Add(new Label(
+                                  m == SelectionMode.SelectSource
+                                      ? T("LaneConnector.Mode:Source")
+                                      : T("LaneConnector.Mode:Target")));
+                    items.Add(new Label(
                                   localizedText: Translation.SpeedLimits.ColorizeDynamicKeybinds(
                                       key: "UI.Key:PageUp/PageDown switch underground",
                                       replacements: new[] {
                                           KeybindSettingsPage.ElevationUp.ToLocalizedString(),
                                           KeybindSettingsPage.ElevationDown.ToLocalizedString()
                                       })));
-                    items.Add(new Label(
-                                  m == SelectionMode.SelectSource
-                                      ? T("LaneConnector.Mode:Source")
-                                      : T("LaneConnector.Mode:Target")));
                     items.Add(new Shortcut(
                                   keybindSetting: KeybindSettingsBase.LaneConnectorStayInLane,
                                   localizedText: T("LaneConnector.Label:Stay in lane, multiple modes")));

--- a/TLM/TLM/UI/SubTools/LaneConnectorTool.cs
+++ b/TLM/TLM/UI/SubTools/LaneConnectorTool.cs
@@ -1460,8 +1460,8 @@ namespace TrafficManager.UI.SubTools {
                                   localizedText: ColorKeyDynamic(
                                       "UI.Key:PageUp/PageDown switch underground",
                                       new[] {
-                                          KeybindSettingsPage.ElevationUp.ToLocalizedString(),
-                                          KeybindSettingsPage.ElevationDown.ToLocalizedString()
+                                          KeybindSettingsBase.ElevationUp.ToLocalizedString(),
+                                          KeybindSettingsBase.ElevationDown.ToLocalizedString()
                                       })));
                     OnscreenDisplay.Display(items);
                     return;
@@ -1477,8 +1477,8 @@ namespace TrafficManager.UI.SubTools {
                                   localizedText: Translation.SpeedLimits.ColorizeDynamicKeybinds(
                                       key: "UI.Key:PageUp/PageDown switch underground",
                                       replacements: new[] {
-                                          KeybindSettingsPage.ElevationUp.ToLocalizedString(),
-                                          KeybindSettingsPage.ElevationDown.ToLocalizedString()
+                                          KeybindSettingsBase.ElevationUp.ToLocalizedString(),
+                                          KeybindSettingsBase.ElevationDown.ToLocalizedString()
                                       })));
                     items.Add(new Shortcut(
                                   keybindSetting: KeybindSettingsBase.LaneConnectorStayInLane,

--- a/TLM/TLM/UI/SubTools/SpeedLimits/SpeedLimitsTool.cs
+++ b/TLM/TLM/UI/SubTools/SpeedLimits/SpeedLimitsTool.cs
@@ -382,8 +382,8 @@ namespace TrafficManager.UI.SubTools.SpeedLimits {
                     localizedText: ColorKeyDynamic(
                         key: "UI.Key:PageUp/PageDown switch underground",
                         replacements: new [] {
-                        KeybindSettingsPage.ElevationUp.ToLocalizedString(),
-                        KeybindSettingsPage.ElevationDown.ToLocalizedString()
+                            KeybindSettingsBase.ElevationUp.ToLocalizedString(),
+                            KeybindSettingsBase.ElevationDown.ToLocalizedString()
                     })),
                 new MainMenu.OSD.Label(
                     localizedText: ColorKey("UI.Key:Unlimited; Default; Select")),

--- a/TLM/TLM/UI/SubTools/SpeedLimits/SpeedLimitsTool.cs
+++ b/TLM/TLM/UI/SubTools/SpeedLimits/SpeedLimitsTool.cs
@@ -80,6 +80,7 @@ namespace TrafficManager.UI.SubTools.SpeedLimits {
 
         private static string T(string key) => Translation.SpeedLimits.Get(key);
         private static string ColorKey(string key) => Translation.SpeedLimits.ColorizeKeybind(key);
+        private static string ColorKeyDynamic(string key, string[] replacements) => Translation.SpeedLimits.ColorizeDynamicKeybinds(key, replacements);
 
         public override void OnActivateTool() {
             if (this.Window == null
@@ -378,7 +379,12 @@ namespace TrafficManager.UI.SubTools.SpeedLimits {
                     ctrl: true,
                     localizedText: T("UI.Key:Ctrl temporarily toggle between lanes and segments")),
                 new MainMenu.OSD.Label(
-                    localizedText: ColorKey("UI.Key:PageUp/PageDown switch underground")),
+                    localizedText: ColorKeyDynamic(
+                        key: "UI.Key:PageUp/PageDown switch underground",
+                        replacements: new [] {
+                        KeybindSettingsPage.ElevationUp.ToLocalizedString(),
+                        KeybindSettingsPage.ElevationDown.ToLocalizedString()
+                    })),
                 new MainMenu.OSD.Label(
                     localizedText: ColorKey("UI.Key:Unlimited; Default; Select")),
                 new MainMenu.OSD.Shortcut(

--- a/TLM/TLM/UI/TrafficManagerTool.cs
+++ b/TLM/TLM/UI/TrafficManagerTool.cs
@@ -544,12 +544,12 @@ namespace TrafficManager.UI {
             base.OnToolUpdate();
 
             // Log._Debug($"OnToolUpdate");
-            if (Input.GetKeyUp(KeyCode.PageDown)) {
+            if (KeybindSettingsBase.ElevationDown.KeyUp()) {
                 InfoManager.instance.SetCurrentMode(
                     InfoManager.InfoMode.Underground,
                     InfoManager.SubInfoMode.Default);
                 UIView.library.Hide("TrafficInfoViewPanel");
-            } else if (Input.GetKeyUp(KeyCode.PageUp)) {
+            } else if (KeybindSettingsBase.ElevationUp.KeyUp()) {
                 InfoManager.instance.SetCurrentMode(
                     InfoManager.InfoMode.None,
                     InfoManager.SubInfoMode.Default);
@@ -1423,7 +1423,7 @@ namespace TrafficManager.UI {
 
             for (uint citizenInstanceId = 1; citizenInstanceId < CitizenManager.MAX_INSTANCE_COUNT; ++citizenInstanceId) {
                 ref CitizenInstance citizenInstance = ref citizenInstanceId.ToCitizenInstance();
-                
+
                 if (!citizenInstance.IsCreated()) {
                     continue;
                 }

--- a/TLM/TMPE.UnitTest/TMPE.UnitTest.csproj
+++ b/TLM/TMPE.UnitTest/TMPE.UnitTest.csproj
@@ -94,6 +94,7 @@
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Translation\CsvParser.cs" />
+    <Compile Include="Util\DynamicKeybindReplaceTest.cs" />
     <Compile Include="Util\GetNodeSegmentIdsEnumerableTests.cs" />
     <Compile Include="Util\SpiralTests.cs" />
     <Compile Include="Util\LoopUtilTests.cs" />

--- a/TLM/TMPE.UnitTest/Util/DynamicKeybindReplaceTest.cs
+++ b/TLM/TMPE.UnitTest/Util/DynamicKeybindReplaceTest.cs
@@ -1,0 +1,76 @@
+namespace TMUnitTest.Util {
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using TrafficManager.U;
+
+    [TestClass]
+    public class DynamicKeybindReplaceTest {
+
+        [TestMethod]
+        public void Should_DynamicallyReplaceAndColorize_SingleValue_Having_OneReplacement() {
+            string testString = "[[Page Down]] To switch underground view";
+            string[] replacements = new[] { "Key_X" };
+            string expected =
+                $"{UConst.GetKeyboardShortcutColorTagOpener()}Key_X{UConst.KEYBOARD_SHORTCUT_CLOSING_TAG} To switch underground view";
+            string result = UIUtil.ColorizeDynamicKeybinds(testString, replacements);
+            Assert.AreEqual(expected, result);
+        }
+
+        [TestMethod]
+        public void Should_DynamicallyReplaceAndColorize_TwoValues_Having_TwoReplacements() {
+            string testString = "[[Page Up]] | [[Page Down]] To switch underground view";
+            string[] replacements = new[] { "Key_X", "Key_Y" };
+            string expected =
+                $"{UConst.GetKeyboardShortcutColorTagOpener()}Key_X{UConst.KEYBOARD_SHORTCUT_CLOSING_TAG} | {UConst.GetKeyboardShortcutColorTagOpener()}Key_Y{UConst.KEYBOARD_SHORTCUT_CLOSING_TAG} To switch underground view";
+            string result = UIUtil.ColorizeDynamicKeybinds(testString, replacements);
+            Assert.AreEqual(expected, result);
+        }
+
+        [TestMethod]
+        public void Should_DynamicallyReplaceAndColorize_SingleValue_Having_TwoReplacements() {
+            string testString = "[[Page Down]] To switch underground view";
+            string[] replacements = new[] { "Key_X", "Key_Y" };
+            string expected =
+                $"{UConst.GetKeyboardShortcutColorTagOpener()}Key_X{UConst.KEYBOARD_SHORTCUT_CLOSING_TAG} To switch underground view";
+            string result = UIUtil.ColorizeDynamicKeybinds(testString, replacements);
+            Assert.AreEqual(expected, result);
+        }
+
+        [TestMethod]
+        public void Should_DynamicallyReplaceAndColorize_FirstOfTwoValues_Having_OneReplacement() {
+            string testString = "[[Page Up]] | [[Page Down]] To switch underground view";
+            string[] replacements = new[] { "Key_X" };
+            string expected =
+                $"{UConst.GetKeyboardShortcutColorTagOpener()}Key_X{UConst.KEYBOARD_SHORTCUT_CLOSING_TAG} | [[Page Down]] To switch underground view";
+            string result = UIUtil.ColorizeDynamicKeybinds(testString, replacements);
+            Assert.AreEqual(expected, result);
+        }
+
+        [TestMethod]
+        public void Should_DynamicallyReplaceAndColorize_TwoValues_Having_ThreeReplacements() {
+            string testString = "[[Page Up]] | [[Page Down]] To switch underground view";
+            string[] replacements = new[] { "Key_X", "Key_Y", "Key_Z" };
+            string expected =
+                $"{UConst.GetKeyboardShortcutColorTagOpener()}Key_X{UConst.KEYBOARD_SHORTCUT_CLOSING_TAG} | {UConst.GetKeyboardShortcutColorTagOpener()}Key_Y{UConst.KEYBOARD_SHORTCUT_CLOSING_TAG} To switch underground view";
+            string result = UIUtil.ColorizeDynamicKeybinds(testString, replacements);
+            Assert.AreEqual(expected, result);
+        }
+
+        [TestMethod]
+        public void Should_Not_DynamicallyReplaceAndColorize_ZeroValues_Having_TwoReplacements() {
+            string testString = "Nothing to replace";
+            string[] replacements = new[] { "Key_X", "Key_Y"};
+            string expected = "Nothing to replace";
+            string result = UIUtil.ColorizeDynamicKeybinds(testString, replacements);
+            Assert.AreEqual(expected, result);
+        }
+
+        [TestMethod]
+        public void Should_Not_DynamicallyReplaceAndColorize_IncorrectValue_Having_TwoReplacements() {
+            string testString = "Not replace this incorrect key [incorrect key]";
+            string[] replacements = new[] { "Key_X", "Key_Y"};
+            string expected = "Not replace this incorrect key [incorrect key]";
+            string result = UIUtil.ColorizeDynamicKeybinds(testString, replacements);
+            Assert.AreEqual(expected, result);
+        }
+    }
+}


### PR DESCRIPTION
Closes #1326 

- list the currently set keybinds for elevation change action
- update values after rebinding via vanilla UI at `Keybinds` tab
- dynamically colorize and replace `[[xyz]]` tag with replacement values (each match gets own replacement value) - skip {x} matches could be added in the future if necessary for complex translations text,
- bunch of tests for tag colorize+replacement function

Changes in action:

https://user-images.githubusercontent.com/19638970/156675150-f5d06627-15f8-4955-a382-0fcfcca38929.mp4


