### PR TITLE
use harmony prepare instead of manual patch

### DIFF
--- a/TLM/TLM/Lifecycle/Patcher.cs
+++ b/TLM/TLM/Lifecycle/Patcher.cs
@@ -8,8 +8,6 @@ namespace TrafficManager.Lifecycle {
     using TrafficManager.Util;
     using System.Linq;
     using Patch;
-    using Patch._PathFind;
-    using Patch._PathManager;
     using ColossalFramework.Plugins;
     using TrafficManager.UI.Helpers;
 
@@ -46,7 +44,6 @@ namespace TrafficManager.Lifecycle {
 #endif
             AssertCitiesHarmonyInstalled();
             fail = !PatchAll(HARMONY_ID, forbidden: typeof(CustomPathFindPatchAttribute));
-            fail |= !PatchManual(HARMONY_ID);
 
             if (fail) {
                 Log.Info("patcher failed");
@@ -108,32 +105,6 @@ namespace TrafficManager.Lifecycle {
                 }
                 return success;
             } catch (Exception ex) {
-                ex.LogException();
-                return false;
-            }
-        }
-
-        /// <summary>
-        /// manually applying harmony patches if target mods are enabled
-        /// </summary>
-        /// <returns>false if patching failed, true otherwise</returns>
-        private static bool PatchManual(string harmonyId) {
-            try {
-                var harmony = new Harmony(harmonyId);
-
-                // Patching SimulationStepPatch1 in Reversible Tram AI mod
-                if (IsAssemblyEnabled("ReversibleTramAI")) {
-                    Type simulationStepPatch1Type = Type.GetType("ReversibleTramAI.SimulationStepPatch1, ReversibleTramAI", false);
-                    if (simulationStepPatch1Type != null) {
-                        if (!TrafficManager.Patch._External._RTramAIModPatch.RTramAIModPatch.ApplyPatch(harmony, simulationStepPatch1Type)) return false;
-                    }
-                    else {
-                        return false;
-                    }
-                }
-                return true;
-            }
-            catch (Exception ex) {
                 ex.LogException();
                 return false;
             }

--- a/TLM/TLM/Patch/_External/RTramAIModPatch.cs
+++ b/TLM/TLM/Patch/_External/RTramAIModPatch.cs
@@ -1,55 +1,35 @@
-/// <summary>
-/// Patching SimulationStepPatch1 in Reversible Tram AI mod
-/// https://steamcommunity.com/sharedfiles/filedetails/?id=2740907672
-/// https://github.com/sway2020/ReversibleTramAI
-/// </summary>
-
 namespace TrafficManager.Patch._External._RTramAIModPatch {
     using System;
-    using System.Linq;
     using System.Collections.Generic;
+    using System.Linq;
     using System.Reflection;
     using System.Reflection.Emit;
+    using TrafficManager.API.Manager;
+    using TrafficManager.Manager.Impl;
+    using TrafficManager.Util;
+    using TrafficManager.State;
     using HarmonyLib;
-    using JetBrains.Annotations;
-    using UnityEngine;
-    using Util;
-    using API.Manager;
-    using Manager.Impl;
-    using State;
 
-    [UsedImplicitly]
+    /// <summary>
+    /// Patching SimulationStepPatch1 in Reversible Tram AI mod
+    /// https://steamcommunity.com/sharedfiles/filedetails/?id=2740907672
+    /// https://github.com/sway2020/ReversibleTramAI
+    /// </summary>
+    [HarmonyPatch]
     public static class RTramAIModPatch {
+        private static Type TargetType => Type.GetType("ReversibleTramAI.SimulationStepPatch1, ReversibleTramAI", false);
 
-        private delegate void TargetDelegate(VehicleAI __instance, ushort vehicleID, ref Vehicle data, Vector3 physicsLodRefPos, ref VehicleInfo ___m_info);
-        private delegate bool TrySpawnDelegate(ushort vehicleID, ref Vehicle vehicleData);
+        public static bool Prepare() => TargetType != null;
 
-        public static bool ApplyPatch(Harmony harmonyInstance, Type simulationStepPatch1Type) {
-            try {
-                var original = TranspilerUtil.DeclaredMethod<TargetDelegate>(simulationStepPatch1Type, "Prefix");
-                if (original == null) return false;
-
-                var transpiler = typeof(RTramAIModPatch).GetMethod("TranspileRTramSimulationStepPatch1");
-                harmonyInstance.Patch(original, transpiler: new HarmonyMethod(transpiler));
-                return true;
-            }
-            catch (Exception ex) {
-                ex.LogException();
-                return false;
-            }
-        }
+        public static MethodBase TargetMethod() => AccessTools.DeclaredMethod(TargetType, "Prefix");
 
         /// <summary>
-        /// Revrites instructions adding necessary TMPE calls. Same purpose as TranspileTramTrainSimulationStep()
+        /// Retrieves instructions adding necessary TMPE calls. Same purpose as TranspileTramTrainSimulationStep()
         /// </summary>
-        /// <param name="il"> Il Generator</param>
-        /// <param name="instructions">List of instructions</param>
-        /// <returns></returns>
-        /// <exception cref="Exception"></exception>
-        public static IEnumerable<CodeInstruction> TranspileRTramSimulationStepPatch1(ILGenerator il, IEnumerable<CodeInstruction> instructions) {
+        public static IEnumerable<CodeInstruction> Transpiler(ILGenerator il, IEnumerable<CodeInstruction> instructions) {
             List<CodeInstruction> codes = TranspilerUtil.ToCodeList(instructions);
 
-            MethodBase trySpawnCall = TranspilerUtil.DeclaredMethod<TrySpawnDelegate>(typeof(TramBaseAI), "TrySpawn");
+            MethodBase trySpawnCall = AccessTools.DeclaredMethod(typeof(TramBaseAI), "TrySpawn");
 
             CodeInstruction searchInstruction = new CodeInstruction(OpCodes.Callvirt, trySpawnCall);
             int index = codes.FindIndex(instruction => TranspilerUtil.IsSameInstruction(instruction, searchInstruction));


### PR DESCRIPTION
Review hint: I have not added any new line of code here. I have only moved/modified several lines. But mostly I have deleted lines.

@sway2020 Sorry to change your code but I think:
1- there is no need to use manual patch when we can just use harmony prepare. This way it patches are more consistent/self-contained and have less lines of code.
2- there is no need to use `DeclaredMethod<TargetDelegate>()` if the target method is not overloaded. A simple `Type.GetMethod()` would do.

latest test build: [https://ci.appveyor.com/api/projects/krzychu124/tmpe/artifacts/TMPE.zip?branch=prepare-patch](TMPE.zip)