### PR TITLE
Replace `CheckLane()` with extensions

### DIFF
--- a/TLM/TLM/Manager/Impl/SpeedLimitManager.cs
+++ b/TLM/TLM/Manager/Impl/SpeedLimitManager.cs
@@ -712,9 +712,8 @@ namespace TrafficManager.Manager.Impl {
 
         /// <summary>Private: Do not call from the outside.</summary>
         private void SetLaneSpeedLimit(uint laneId, SetSpeedLimitAction action) {
-            if (!Flags.CheckLane(laneId)) {
+            if (!laneId.IsValidWithSegment())
                 return;
-            }
 
             ushort segmentId = laneId.ToLane().m_segment;
             ref NetSegment netSegment = ref segmentId.ToSegment();

--- a/TLM/TLM/State/Flags.cs
+++ b/TLM/TLM/State/Flags.cs
@@ -275,8 +275,8 @@ namespace TrafficManager.State {
                 Log._Debug($"Flags.RemoveLaneConnection({lane1Id}, {lane2Id}, {startNode1}) called.");
             }
 #endif
-            bool lane1Valid = CheckLane(lane1Id);
-            bool lane2Valid = CheckLane(lane2Id);
+            bool lane1Valid = lane1Id.IsValidWithSegment();
+            bool lane2Valid = lane2Id.IsValidWithSegment();
 
             bool ret = false;
 
@@ -338,7 +338,7 @@ namespace TrafficManager.State {
                 return;
             }
 
-            bool laneValid = CheckLane(laneId);
+            bool laneValid = laneId.IsValidWithSegment();
             bool clearBothSides = startNode == null || !laneValid;
 #if DEBUG
             if (debug) {
@@ -395,8 +395,8 @@ namespace TrafficManager.State {
         /// <param name="startNode1"></param>
         /// <returns></returns>
         internal static bool AddLaneConnection(uint lane1Id, uint lane2Id, bool startNode1) {
-            bool lane1Valid = CheckLane(lane1Id);
-            bool lane2Valid = CheckLane(lane2Id);
+            bool lane1Valid = lane1Id.IsValidWithSegment();
+            bool lane2Valid = lane2Id.IsValidWithSegment();
 
             if (!lane1Valid) {
                 // remove all incoming/outgoing lane connections
@@ -459,50 +459,15 @@ namespace TrafficManager.State {
             laneConnections[sourceLaneId][nodeArrayIndex][oldConnections.Length] = targetLaneId;
         }
 
-        internal static bool CheckLane(uint laneId) {
-            // TODO refactor
-            if (laneId <= 0) {
-                return false;
-            }
-
-            ref NetLane netLane = ref laneId.ToLane();
-
-            if (((NetLane.Flags)netLane.m_flags & (NetLane.Flags.Created | NetLane.Flags.Deleted)) != NetLane.Flags.Created) {
-                return false;
-            }
-
-            ushort segmentId = netLane.m_segment;
-            if (segmentId <= 0) {
-                return false;
-            }
-
-            ref NetSegment netSegment = ref segmentId.ToSegment();
-
-            return (netSegment.m_flags & (NetSegment.Flags.Created | NetSegment.Flags.Deleted)) == NetSegment.Flags.Created;
-        }
-
         public static void SetLaneAllowedVehicleTypes(uint laneId, ExtVehicleType vehicleTypes) {
-            if (laneId <= 0) {
+            if (!laneId.IsValidWithSegment())
                 return;
-            }
 
             ref NetLane netLane = ref laneId.ToLane();
 
-            if (((NetLane.Flags)netLane.m_flags & (NetLane.Flags.Created | NetLane.Flags.Deleted)) != NetLane.Flags.Created) {
-                return;
-            }
-
             ushort segmentId = netLane.m_segment;
 
-            if (segmentId <= 0) {
-                return;
-            }
-
             ref NetSegment netSegment = ref segmentId.ToSegment();
-
-            if ((netSegment.m_flags & (NetSegment.Flags.Created | NetSegment.Flags.Deleted)) != NetSegment.Flags.Created) {
-                return;
-            }
 
             NetInfo segmentInfo = netSegment.Info;
             uint curLaneId = netSegment.m_lanes;
@@ -524,21 +489,10 @@ namespace TrafficManager.State {
                                                       uint laneId,
                                                       ExtVehicleType vehicleTypes)
         {
-            if (segmentId <= 0 || laneId <= 0) {
+            if (!laneId.IsValidWithSegment())
                 return;
-            }
 
             ref NetSegment netSegment = ref segmentId.ToSegment();
-
-            if ((netSegment.m_flags & (NetSegment.Flags.Created | NetSegment.Flags.Deleted)) != NetSegment.Flags.Created) {
-                return;
-            }
-
-            ref NetLane netLane = ref laneId.ToLane();
-
-            if (((NetLane.Flags)netLane.m_flags & (NetLane.Flags.Created | NetLane.Flags.Deleted)) != NetLane.Flags.Created) {
-                return;
-            }
 
             NetInfo segmentInfo = netSegment.Info;
 

--- a/TLM/TLM/Util/Extensions/NetLaneExtensions.cs
+++ b/TLM/TLM/Util/Extensions/NetLaneExtensions.cs
@@ -7,23 +7,53 @@ namespace TrafficManager.Util.Extensions {
         internal static ref NetLane ToLane(this uint laneId) => ref _laneBuffer[laneId];
 
         /// <summary>
-        /// Checks if the netLane is Created, but not Deleted.
+        /// Checks if <paramref name="netLane"/> is <c>Created</c> but not <c>Deleted</c>.
         /// </summary>
         /// <param name="netLane">netLane</param>
-        /// <returns>True if the netLane is valid, otherwise false.</returns>
+        /// <returns>Returns <c>true</c> if valid, otherwise <c>false</c>.</returns>
         public static bool IsValid(this ref NetLane netLane) =>
             ((NetLane.Flags)netLane.m_flags).CheckFlags(
                 required: NetLane.Flags.Created,
                 forbidden: NetLane.Flags.Deleted);
 
         /// <summary>
-        /// Checks if the netLane is Created, but not Deleted and if its netSegment is Created, but neither Collapsed nor Deleted.
+        /// Checks <paramref name="laneId"/> is not <c>0</c>,
+        /// then checks netLane is <c>Created</c> but not <c>Deleted</c>.
+        /// </summary>
+        /// <param name="laneId">The id of the lane to check.</param>
+        /// <returns>Returns <c>true</c> if valid, otherwise <c>false</c>.</returns>
+        public static bool IsValid(this uint laneId)
+            => (laneId != 0) && laneId.ToLane().IsValid();
+
+        /// <summary>
+        /// Checks <paramref name="netLane"/> is <c>Created</c> but not <c>Deleted</c>,
+        /// then checks its netSegment is <c>Created</c> but not <c>Collapsed|Deleted</c>.
         /// </summary>
         /// <param name="netLane">netLane</param>
-        /// <returns>True if the netLane and its netSegment is valid, otherwise false.</returns>
+        /// <returns>Returns <c>true</c> if valid, otherwise <c>false</c>.</returns>
         public static bool IsValidWithSegment(this ref NetLane netLane) {
             return netLane.IsValid()
                 && netLane.m_segment.ToSegment().IsValid();
+        }
+
+        /// <summary>
+        /// Checks <paramref name="laneId"/> is not <c>0</c>,
+        /// then checks netLane is <c>Created</c> but not <c>Deleted</c>,
+        /// then checks its segmentId is not <c>0</c>,
+        /// then checks its netSegment is <c>Created</c> but not <c>Collapsed|Deleted</c>.
+        /// </summary>
+        /// <param name="laneId">The id of the lane to check.</param>
+        /// <returns>Returns <c>true</c> if valid, otherwise <c>false</c>.</returns>
+        public static bool IsValidWithSegment(this uint laneId) {
+            if (laneId == 0)
+                return false;
+
+            ref NetLane netLane = ref laneId.ToLane();
+
+            if (!netLane.IsValid())
+                return false;
+
+            return netLane.m_segment.IsValid();
         }
     }
 }

--- a/TLM/TLM/Util/Extensions/NetSegmentExtensions.cs
+++ b/TLM/TLM/Util/Extensions/NetSegmentExtensions.cs
@@ -44,14 +44,23 @@ namespace TrafficManager.Util.Extensions {
         }
 
         /// <summary>
-        /// Checks if the netSegment is Created, but neither Collapsed nor Deleted.
+        /// Checks <paramref name="netSegment"/> is <c>Created</c> but not <c>Collapsed|Deleted</c>.
         /// </summary>
         /// <param name="netSegment">netSegment</param>
-        /// <returns>True if the netSegment is valid, otherwise false.</returns>
+        /// <returns>Returns <c>true</c> if valid, otherwise <c>false</c>.</returns>
         public static bool IsValid(this ref NetSegment netSegment) =>
             netSegment.m_flags.CheckFlags(
                 required: NetSegment.Flags.Created,
                 forbidden: NetSegment.Flags.Collapsed | NetSegment.Flags.Deleted);
+
+        /// <summary>
+        /// Checks <paramref name="segmentId"/> is not <c>0</c>,
+        /// then checks netSegment is <c>Created</c> but not <c>Collapsed|Deleted</c>.
+        /// </summary>
+        /// <param name="segmentId">The id of the segment to check.</param>
+        /// <returns>Returns <c>true</c> if valid, otherwise <c>false</c>.</returns>
+        public static bool IsValid(this ushort segmentId)
+            => (segmentId != 0) && segmentId.ToSegment().IsValid();
 
         public static NetInfo.Lane GetLaneInfo(this ref NetSegment netSegment, int laneIndex) =>
             netSegment.Info?.m_lanes?[laneIndex];


### PR DESCRIPTION
Adds new extensions:

- `laneId.IsValid()`
- `laneId.IsValidWithSegment()` -- this replaces `CheckLanes(laneId)`
- `segmentId.IsValid()`

In addition to usual flags check, these extensions also check that the id is non-zero.

The PR also simplifies some existing code in `Flags.cs` by using the new extensions, and also updates some xmldoc to be more consistent.