### PR TITLE
Hotfix for 11.6.5.1 before release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ This changelog includes all versions and major variants of the mod going all the
 #### TM:PE V11.6.5.1 TEST, 13/03/2022
 
 - [Meta] This update adds two new features, overhauls mod options code, and improves modding API.
-- [New] `Disable Despawn` feature now has vehicle-type filters #1441 #1434 (Marconius6, lokpro, krzychu124)
+- [New] `Disable Despawn` feature now has vehicle-type filters #1465 #1441 #1434 (Marconius6, lokpro, krzychu124)
 - [New] Timed Traffic Lights now available in Map and Scenario editors #1425 #959 (aubergine18)
 - [Mod] API: Mods can now use TMPE.API.dll alone, without referencing TrafficManager.dll #1448 (kianzarrin)
 - [Mod] API: TM:PE Harmony ID changed from `de.viathinksoft.tmpe` to `me.tmpe` #1456 #897 (krzychu124)
@@ -53,9 +53,10 @@ This changelog includes all versions and major variants of the mod going all the
 - [Updated] Improved mod option lifecycle for game/editors #1452 #1449 #1425 (aubergine18)
 - [Updated] Extension for managed-type `vehicleId` to `ExtVehicleType` #1444 (aubergine18)
 - [Updated] Simplify Harmony patching for Reversible Tram AI #1457 (kianzarrin)
-- [Updated] Un-invert `Options.disableDespawning` data byte (aubergine18, kianzarrin)
+- [Updated] Un-invert `Options.disableDespawning` data byte #1465 #1463 (aubergine18, kianzarrin, krzychu124)
 - [Updated] `MayPublishSegmentChanges()` moved to `TMPELifecycle`; API unaffected #1432 (aubergine18)
 - [Updated] `Buses may ignore lane arrows` enabled by default when starting new city #1455 (aubergine18)
+- [Updated] Missing translations show trimmed locale key in `TEST` builds too #1465 (krzychu124)
 - [Removed] Obsolete gamebridge stuff from build script #1436 (aubergine18)
 - [Removed] "Apply AI changes right away" option; changes always applied immediately now #1432 (aubergine18, kvakvs)
 - [Steam] [TM:PE v11 TEST](https://steamcommunity.com/sharedfiles/filedetails/?id=2489276785)

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@
 #### TM:PE V11.6.5.1 TEST, 13/03/2022
 
 - [Meta] This update adds two new features, overhauls mod options code, and improves modding API.
-- [New] `Disable Despawn` feature now has vehicle-type filters #1441 #1434 (Marconius6, lokpro, krzychu124)
+- [New] `Disable Despawn` feature now has vehicle-type filters #1465 #1441 #1434 (Marconius6, lokpro, krzychu124)
 - [New] Timed Traffic Lights now available in Map and Scenario editors #1425 #959 (aubergine18)
 - [Mod] API: Mods can now use TMPE.API.dll alone, without referencing TrafficManager.dll #1448 (kianzarrin)
 - [Mod] API: TM:PE Harmony ID changed from `de.viathinksoft.tmpe` to `me.tmpe` #1456 #897 (krzychu124)
@@ -65,9 +65,10 @@
 - [Updated] Improved mod option lifecycle for game/editors #1452 #1449 #1425 (aubergine18)
 - [Updated] Extension for managed-type `vehicleId` to `ExtVehicleType` #1444 (aubergine18)
 - [Updated] Simplify Harmony patching for Reversible Tram AI #1457 (kianzarrin)
-- [Updated] Un-invert `Options.disableDespawning` data byte (aubergine18, kianzarrin)
+- [Updated] Un-invert `Options.disableDespawning` data byte #1465 #1463 (aubergine18, kianzarrin, krzychu124)
 - [Updated] `MayPublishSegmentChanges()` moved to `TMPELifecycle`; API unaffected #1432 (aubergine18)
 - [Updated] `Buses may ignore lane arrows` enabled by default when starting new city #1455 (aubergine18)
+- [Updated] Missing translations show trimmed locale key in `TEST` builds too #1465 (krzychu124)
 - [Removed] Obsolete gamebridge stuff from build script #1436 (aubergine18)
 - [Removed] "Apply AI changes right away" option; changes always applied immediately now #1432 (aubergine18, kvakvs)
 - [Steam] [TM:PE v11 TEST](https://steamcommunity.com/sharedfiles/filedetails/?id=2489276785)

--- a/TLM/TLM/Lifecycle/SerializableDataExtension.cs
+++ b/TLM/TLM/Lifecycle/SerializableDataExtension.cs
@@ -16,7 +16,7 @@ namespace TrafficManager.Lifecycle {
     public class SerializableDataExtension
         : SerializableDataExtensionBase
     {
-        public static int Version => _configuration.Version;
+        public static int Version => _configuration?.Version ?? Configuration.CURRENT_VERSION;
 
         private const string DATA_ID = "TrafficManager_v1.0";
         private const string VERSION_INFO_DATA_ID = "TrafficManager_VersionInfo_v1.0";

--- a/TLM/TLM/Resources/whats_new.txt
+++ b/TLM/TLM/Resources/whats_new.txt
@@ -2,7 +2,7 @@
 [Released] March 13th 2022
 [Link] tmpe-v11651-test-13032022
 [Meta] This update adds two new features, overhauls mod options code, and improves modding API.
-[New] `Disable Despawn` feature now has vehicle-type filters #1441 #1434 (Marconius6, lokpro, krzychu124)
+[New] `Disable Despawn` feature now has vehicle-type filters #1465 #1441 #1434 (Marconius6, lokpro, krzychu124)
 [New] Timed Traffic Lights now available in Map and Scenario editors #1425 #959 (aubergine18)
 [Mod] API: Mods can now use TMPE.API.dll alone, without referencing TrafficManager.dll #1448 (kianzarrin)
 [Mod] API: TM:PE Harmony ID changed from `de.viathinksoft.tmpe` to `me.tmpe` #1456 #897 (krzychu124)
@@ -23,9 +23,10 @@
 [Updated] Improved mod option lifecycle for game/editors #1452 #1449 #1425 (aubergine18)
 [Updated] Extension for managed-type `vehicleId` to `ExtVehicleType` #1444 (aubergine18)
 [Updated] Simplify Harmony patching for Reversible Tram AI #1457 (kianzarrin)
-[Updated] Un-invert `Options.disableDespawning` data byte (aubergine18, kianzarrin)
+[Updated] Un-invert `Options.disableDespawning` data byte #1465 #1463 (aubergine18, kianzarrin, krzychu124)
 [Updated] `MayPublishSegmentChanges()` moved to `TMPELifecycle`; API unaffected #1432 (aubergine18)
 [Updated] `Buses may ignore lane arrows` enabled by default when starting new city #1455 (aubergine18)
+[Updated] Missing translations show trimmed locale key in `TEST` builds too #1465 (krzychu124)
 [Removed] Obsolete gamebridge stuff from build script #1436 (aubergine18)
 [Removed] "Apply AI changes right away" option; changes always applied immediately now #1432 (aubergine18, kvakvs)
 [/Version]

--- a/TLM/TLM/UI/Localization/LookupTable.cs
+++ b/TLM/TLM/UI/Localization/LookupTable.cs
@@ -46,23 +46,24 @@ namespace TrafficManager.UI.Localization {
             }
 #endif
 
-            // Try find translation in the current language first
-            if (AllLanguages[lang].TryGetValue(key, out string ret))
-            {
+            // Current language
+            if (AllLanguages[lang].TryGetValue(key, out string ret)) {
                 return ret;
             }
 
-            // If not found, try also get translation in the default English
-            // Untranslated keys are prefixed with ¶ in TEST & DEBUG builds;
-            // in STABLE builds prefix (upto and including `:`) is trimmed.
-            return AllLanguages[Translation.DEFAULT_LANGUAGE_CODE]
-                       .TryGetValue(key, out string ret2)
-                       ? ret2
-                       : (VersionUtil.BRANCH != "STABLE" && VersionUtil.BRANCH != "TEST")
-                            ? "¶" + key
-                            : key.IndexOf(":") > 0
-                                ? key.Substring(key.IndexOf(":") + 1)
-                                : key;
+            // Default language
+            if (AllLanguages[Translation.DEFAULT_LANGUAGE_CODE].TryGetValue(key, out string ret2)) {
+                return ret2;
+            }
+
+#if DEBUG
+            // Prefixed locale key
+            return "¶" + key;
+#else
+            // Trimmed locale key
+            int pos = key.IndexOf(":");
+            return pos > 0 ? key.Substring(pos + 1) : key;
+#endif
         }
 
         public bool HasString(string key) {

--- a/TLM/TLM/UI/Localization/LookupTable.cs
+++ b/TLM/TLM/UI/Localization/LookupTable.cs
@@ -58,7 +58,7 @@ namespace TrafficManager.UI.Localization {
             return AllLanguages[Translation.DEFAULT_LANGUAGE_CODE]
                        .TryGetValue(key, out string ret2)
                        ? ret2
-                       : (VersionUtil.BRANCH != "STABLE")
+                       : (VersionUtil.BRANCH != "STABLE" && VersionUtil.BRANCH != "TEST")
                             ? "¶" + key
                             : key.IndexOf(":") > 0
                                 ? key.Substring(key.IndexOf(":") + 1)

--- a/TLM/TLM/UI/MainMenu/DespawnButton.cs
+++ b/TLM/TLM/UI/MainMenu/DespawnButton.cs
@@ -48,7 +48,7 @@ namespace TrafficManager.UI.MainMenu {
         /// </summary>
         /// <param name="p"></param>
         protected override void OnMouseDown(UIMouseEventParameter p) {
-            if ((p.buttons & UIMouseButton.Right) != 0) {
+            if ((p.buttons & UIMouseButton.Right) != 0 && Options.disableDespawning) {
                 p.Use();
                 UIInput.MouseUsed();
                 AllowDespawn.AllowDespawningPanel.OpenModal();


### PR DESCRIPTION
- `NullReferenceException` while trying to read configuration version in New Game mode,
- Add translation beautification for **TEST** version if translation key not present in the lookup,
- Consistency change for trigger to open modal of vehicle type exclusions for `Disable Despawn` feature

Nothing new, so update of What's New lists not required