### PR TITLE
Modernise several uses of `GetSortedLanes()`

### DIFF
--- a/TLM/TLM/Manager/Impl/LaneArrowManager.cs
+++ b/TLM/TLM/Manager/Impl/LaneArrowManager.cs
@@ -123,7 +123,7 @@ namespace TrafficManager.Manager.Impl {
 
             ref NetSegment segment = ref segmentId.ToSegment();
 
-            var sortedLanes = segment.GetSortedLanes(startNode, LANE_TYPES, VEHICLE_TYPES);
+            var sortedLanes = segment.GetSortedLanes(startNode, LANE_TYPES, VEHICLE_TYPES, sort: false);
 
             foreach (var lane in sortedLanes)
                 ResetLaneArrows(lane.laneId);

--- a/TLM/TLM/Manager/Impl/LaneArrowManager.cs
+++ b/TLM/TLM/Manager/Impl/LaneArrowManager.cs
@@ -117,19 +117,16 @@ namespace TrafficManager.Manager.Impl {
         /// <summary>
         /// Resets lane arrows to their default value for the given segment end.
         /// </summary>
-        /// <param name="segmentId">segment to reset</param>
-        /// <param name="startNode">determines the segment end to reset. if <c>null</c>
-        /// both ends are reset</param>
+        /// <param name="segmentId">Segment id.</param>
+        /// <param name="startNode">Determines the segment end to reset, or both if <c>null</c>.</param>
         public void ResetLaneArrows(ushort segmentId, bool? startNode = null) {
-            ExtSegmentManager extSegmentManager = ExtSegmentManager.Instance;
-            foreach (var lane in extSegmentManager.GetSortedLanes(
-                segmentId,
-                ref segmentId.ToSegment(),
-                startNode,
-                LANE_TYPES,
-                VEHICLE_TYPES)) {
+
+            ref NetSegment segment = ref segmentId.ToSegment();
+
+            var sortedLanes = segment.GetSortedLanes(startNode, LANE_TYPES, VEHICLE_TYPES);
+
+            foreach (var lane in sortedLanes)
                 ResetLaneArrows(lane.laneId);
-            }
         }
 
         /// <summary>

--- a/TLM/TLM/Manager/Impl/VehicleRestrictionsManager.cs
+++ b/TLM/TLM/Manager/Impl/VehicleRestrictionsManager.cs
@@ -382,7 +382,7 @@ namespace TrafficManager.Manager.Impl {
         }
 
         /// <summary>
-        /// Reset vehicel restrictions for all lanes on the specified segment.
+        /// Reset vehicle restrictions for all lanes on the specified segment.
         /// </summary>
         /// <param name="segmentId">The id of the segment to reset.</param>
         internal void ClearVehicleRestrictions(ushort segmentId) {

--- a/TLM/TLM/Manager/Impl/VehicleRestrictionsManager.cs
+++ b/TLM/TLM/Manager/Impl/VehicleRestrictionsManager.cs
@@ -363,16 +363,18 @@ namespace TrafficManager.Manager.Impl {
         }
 
         /// <summary>
-        /// Restores all vehicle restrictions on a given segment to default state.
+        /// Reset vehicle restrictions for a specific lane on the specified segment.
         /// </summary>
-        /// <param name="segmentId"></param>
-        /// <returns></returns>
-        internal bool ClearVehicleRestrictions(ushort segmentId, byte laneIndex, uint laneId) {
+        /// <param name="segmentId">The id of the segment containing the lane.</param>
+        /// <param name="laneIndex">The index of the lane in the segment.</param>
+        /// <param name="laneId">The id of the lane.</param>
+        internal void ClearVehicleRestrictions(ushort segmentId, byte laneIndex, uint laneId) {
             NetInfo segmentInfo = segmentId.ToSegment().Info;
             NetInfo.Lane laneInfo = segmentInfo.m_lanes[laneIndex];
-            return SetAllowedVehicleTypes(
+
+            SetAllowedVehicleTypes(
                 segmentId,
-                segmentId.ToSegment().Info,
+                segmentInfo,
                 laneIndex,
                 laneInfo,
                 laneId,
@@ -380,28 +382,23 @@ namespace TrafficManager.Manager.Impl {
         }
 
         /// <summary>
-        /// Restores all vehicle restrictions on a given segment to default state.
+        /// Reset vehicel restrictions for all lanes on the specified segment.
         /// </summary>
-        /// <param name="segmentId"></param>
-        /// <returns></returns>
-        internal bool ClearVehicleRestrictions(ushort segmentId) {
-            NetInfo segmentInfo = segmentId.ToSegment().Info;
-            bool ret = false;
-            ExtSegmentManager extSegmentManager = ExtSegmentManager.Instance;
-            IList<LanePos> lanes = extSegmentManager.GetSortedLanes(
-                segmentId,
-                ref segmentId.ToSegment(),
-                null,
-                LANE_TYPES,
-                VEHICLE_TYPES,
-                sort: false);
+        /// <param name="segmentId">The id of the segment to reset.</param>
+        internal void ClearVehicleRestrictions(ushort segmentId) {
 
-            foreach (LanePos laneData in lanes) {
-                uint laneId = laneData.laneId;
-                byte laneIndex = laneData.laneIndex;
+            ref NetSegment segment = ref segmentId.ToSegment();
+            NetInfo segmentInfo = segment.Info;
+
+            var sortedLanes = segment.GetSortedLanes(null, LANE_TYPES, VEHICLE_TYPES, sort: false);
+
+            foreach (var lane in sortedLanes) {
+
+                uint laneId = lane.laneId;
+                byte laneIndex = lane.laneIndex;
                 NetInfo.Lane laneInfo = segmentInfo.m_lanes[laneIndex];
 
-                ret |= SetAllowedVehicleTypes(
+                SetAllowedVehicleTypes(
                     segmentId,
                     segmentInfo,
                     laneIndex,
@@ -409,7 +406,6 @@ namespace TrafficManager.Manager.Impl {
                     laneId,
                     EXT_VEHICLE_TYPES);
             }
-            return ret;
         }
 
         /// <summary>

--- a/TLM/TLM/UI/SubTools/LaneArrows/LaneArrowTool.cs
+++ b/TLM/TLM/UI/SubTools/LaneArrows/LaneArrowTool.cs
@@ -168,7 +168,7 @@ namespace TrafficManager.UI.SubTools.LaneArrows {
                 startNode ?? false,
                 LaneArrowManager.LANE_TYPES,
                 LaneArrowManager.VEHICLE_TYPES,
-                reverse: false);
+                reverse: true);
 
             CreateLaneArrowsWindow(sortedLanes.Count);
             SetupLaneArrowsWindowButtons(laneList: sortedLanes,

--- a/TLM/TLM/UI/SubTools/LaneArrows/LaneArrowTool.cs
+++ b/TLM/TLM/UI/SubTools/LaneArrows/LaneArrowTool.cs
@@ -165,14 +165,14 @@ namespace TrafficManager.UI.SubTools.LaneArrows {
             }
 
             var sortedLanes = selectedSegment.GetSortedLanes(
-                startNode ?? false,
+                startNode.Value,
                 LaneArrowManager.LANE_TYPES,
                 LaneArrowManager.VEHICLE_TYPES,
                 reverse: true);
 
             CreateLaneArrowsWindow(sortedLanes.Count);
             SetupLaneArrowsWindowButtons(laneList: sortedLanes,
-                                         startNode: startNode ?? false);
+                                         startNode: startNode.Value);
             MainTool.RequestOnscreenDisplayUpdate();
         }
 

--- a/TLM/TLM/UI/SubTools/LaneArrows/LaneArrowTool.cs
+++ b/TLM/TLM/UI/SubTools/LaneArrows/LaneArrowTool.cs
@@ -152,27 +152,27 @@ namespace TrafficManager.UI.SubTools.LaneArrows {
             //     return; // do not draw if too distant
             // }
             // Calculate lanes and arrows
-            ref NetSegment selectedSegment = ref SelectedSegmentId.ToSegment();
-            ExtSegmentManager extSegmentManager = ExtSegmentManager.Instance;
-            IList<LanePos> laneList = extSegmentManager.GetSortedLanes(
-                SelectedSegmentId,
-                ref selectedSegment,
-                selectedSegment.m_startNode == SelectedNodeId,
-                LaneArrowManager.LANE_TYPES,
-                LaneArrowManager.VEHICLE_TYPES,
-                true);
 
-            bool? startNode = ExtSegmentManager.Instance.IsStartNode(SelectedSegmentId, SelectedNodeId);
-            if (startNode == null) {
+            ref NetSegment selectedSegment = ref SelectedSegmentId.ToSegment();
+
+            bool? startNode = selectedSegment.IsStartNode(SelectedNodeId);
+
+            if (!startNode.HasValue) {
                 Log.Error(
                     $"LaneArrowTool._guiLaneChangeWindow: Segment {SelectedSegmentId} " +
                     $"is not connected to node {SelectedNodeId}");
                 return;
             }
 
-            CreateLaneArrowsWindow(laneList.Count);
-            SetupLaneArrowsWindowButtons(laneList: laneList,
-                                         startNode: (bool)startNode);
+            var sortedLanes = selectedSegment.GetSortedLanes(
+                startNode ?? false,
+                LaneArrowManager.LANE_TYPES,
+                LaneArrowManager.VEHICLE_TYPES,
+                reverse: false);
+
+            CreateLaneArrowsWindow(sortedLanes.Count);
+            SetupLaneArrowsWindowButtons(laneList: sortedLanes,
+                                         startNode: startNode ?? false);
             MainTool.RequestOnscreenDisplayUpdate();
         }
 
@@ -258,17 +258,20 @@ namespace TrafficManager.UI.SubTools.LaneArrows {
         /// </summary>
         /// <returns>true if the segemnt can be reset.</returns>
         private static bool CanReset(ushort segmentId, bool startNode) {
-            ExtSegmentManager extSegmentManager = ExtSegmentManager.Instance;
-            foreach (var lanePos in extSegmentManager.GetSortedLanes(
-                segmentId,
-                ref segmentId.ToSegment(),
+
+            ref NetSegment segment = ref segmentId.ToSegment();
+
+            var lanes = segment.GetSortedLanes(
                 startNode,
                 LaneArrowManager.LANE_TYPES,
-                LaneArrowManager.VEHICLE_TYPES)) {
-                if (!LaneConnectionManager.Instance.HasOutgoingConnections(lanePos.laneId)) {
+                LaneArrowManager.VEHICLE_TYPES,
+                sort: false);
+
+            foreach (var lane in lanes) {
+                if (!LaneConnectionManager.Instance.HasOutgoingConnections(lane.laneId))
                     return true;
-                }
             }
+
             return false;
         }
 

--- a/TLM/TLM/UI/SubTools/LaneConnectorTool.cs
+++ b/TLM/TLM/UI/SubTools/LaneConnectorTool.cs
@@ -805,15 +805,20 @@ namespace TrafficManager.UI.SubTools {
         }
 
         private static int CountLanes(ushort segmentId, ushort nodeId, bool toward) {
-            ExtSegmentManager extSegmentManager = ExtSegmentManager.Instance;
-            return extSegmentManager.GetSortedLanes(
-                                segmentId,
-                                ref segmentId.ToSegment(),
-                                ExtSegmentManager.Instance.IsStartNode(segmentId, nodeId) ^ (!toward),
-                                LaneConnectionManager.LANE_TYPES,
-                                LaneConnectionManager.VEHICLE_TYPES,
-                                true).Count;
+
+            ref NetSegment segment = ref segmentId.ToSegment();
+
+            bool startNode = segment.IsStartnode(nodeId) ^ (!toward);
+
+            var lanes = segment.GetSortedLanes(
+                startNode,
+                LaneConnectionManager.LANE_TYPES,
+                LaneConnectionManager.VEHICLE_TYPES,
+                sort: false);
+
+            return lanes.Count;
         }
+
         internal static int CountLanesTowardJunction(ushort segmentId, ushort nodeId) => CountLanes(segmentId, nodeId, true);
         internal static int CountLanesAgainstJunction(ushort segmentId, ushort nodeId) => CountLanes(segmentId, nodeId, false);
 

--- a/TLM/TLM/UI/SubTools/SpeedLimits/Overlay/OverlayLaneSpeedlimitHandle.cs
+++ b/TLM/TLM/UI/SubTools/SpeedLimits/Overlay/OverlayLaneSpeedlimitHandle.cs
@@ -135,30 +135,28 @@ namespace TrafficManager.UI.SubTools.SpeedLimits.Overlay {
         /// <param name="segmentList">input list of roundabout segments (must be oneway, and in the same direction).</param>
         /// <param name="segmentId0">The segment to match lane agaisnt.</param>
         /// <param name="sortedLaneIndex">Index.</param>
-        internal IEnumerable<LanePos> FollowRoundaboutLane(List<ushort> segmentList,
-                                                           ushort segmentId0,
-                                                           int sortedLaneIndex) {
-            bool invert0 = segmentId0.ToSegment().m_flags.IsFlagSet(NetSegment.Flags.Invert);
-            ExtSegmentManager extSegmentManager = ExtSegmentManager.Instance;
+        internal IEnumerable<LanePos> FollowRoundaboutLane(
+            List<ushort> segmentList,
+            ushort segmentId0,
+            int sortedLaneIndex) {
 
-            int count0 = extSegmentManager.GetSortedLanes(
-               segmentId: segmentId0,
-               segment: ref segmentId0.ToSegment(),
-               startNode: null,
-               laneTypeFilter: SpeedLimitManager.LANE_TYPES,
-               vehicleTypeFilter: SpeedLimitManager.VEHICLE_TYPES,
-               sort: false).Count;
+            bool invert0 = segmentId0.ToSegment().m_flags.IsFlagSet(NetSegment.Flags.Invert);
+
+            int count0 = segmentId0.ToSegment().GetSortedLanes(
+                null,
+                SpeedLimitManager.LANE_TYPES,
+                SpeedLimitManager.VEHICLE_TYPES,
+                sort: false).Count;
 
             foreach (ushort segmentId in segmentList) {
                 bool invert = segmentId.ToSegment().m_flags.IsFlagSet(NetSegment.Flags.Invert);
-                IList<LanePos> lanes = extSegmentManager.GetSortedLanes(
-                    segmentId: segmentId,
-                    segment: ref segmentId.ToSegment(),
-                    startNode: null,
-                    laneTypeFilter: SpeedLimitManager.LANE_TYPES,
-                    vehicleTypeFilter: SpeedLimitManager.VEHICLE_TYPES,
-                    reverse: invert != invert0,
-                    sort: true);
+
+                var lanes = segmentId.ToSegment().GetSortedLanes(
+                    null,
+                    SpeedLimitManager.LANE_TYPES,
+                    SpeedLimitManager.VEHICLE_TYPES,
+                    reverse: invert != invert0);
+
                 int index = sortedLaneIndex;
 
                 // if lane count does not match, assume segments are connected from outer side of the roundabout.

--- a/TLM/TLM/Util/Extensions/NetSegmentExtensions.cs
+++ b/TLM/TLM/Util/Extensions/NetSegmentExtensions.cs
@@ -43,6 +43,12 @@ namespace TrafficManager.Util.Extensions {
             }
         }
 
+        /// <returns><c>true</c> if nodeId is start node.
+        /// <c>false</c> if nodeId is end node.
+        /// Undetermined if segment does not have nodeId</returns>
+        public static bool IsStartnode(this ref NetSegment netSegment, ushort nodeId) =>
+            netSegment.m_startNode == nodeId;
+
         /// <summary>
         /// Checks if the netSegment is Created, but neither Collapsed nor Deleted.
         /// </summary>
@@ -53,11 +59,6 @@ namespace TrafficManager.Util.Extensions {
                 required: NetSegment.Flags.Created,
                 forbidden: NetSegment.Flags.Collapsed | NetSegment.Flags.Deleted);
 
-        /// <returns><c>true</c> if nodeId is start node.
-        /// <c>false</c> if nodeId is end node.
-        /// Undetermined if segment does not have nodeId</returns>
-        public static bool IsStartnode(this ref NetSegment netSegment, ushort nodeId) =>
-            netSegment.m_startNode == nodeId;
         public static NetInfo.Lane GetLaneInfo(this ref NetSegment netSegment, int laneIndex) =>
             netSegment.Info?.m_lanes?[laneIndex];
 

--- a/TLM/TLM/Util/Extensions/NetSegmentExtensions.cs
+++ b/TLM/TLM/Util/Extensions/NetSegmentExtensions.cs
@@ -33,6 +33,16 @@ namespace TrafficManager.Util.Extensions {
             }//endif
         }
 
+        /// <summary>
+        /// Determine if specified <paramref name="nodeId"/> is the start node for
+        /// the <paramref name="netSegment"/>.
+        /// </summary>
+        /// <param name="netSegment">The segment to inspect.</param>
+        /// <param name="nodeId">The id of the node to examine.</param>
+        /// <returns>
+        /// Returns <c>true</c> if start node, <c>false</c> if end node,
+        /// or <c>null</c> if the node is not associated with the segment.
+        /// </returns>
         public static bool? IsStartNode(this ref NetSegment netSegment, ushort nodeId) {
             if (netSegment.m_startNode == nodeId) {
                 return true;
@@ -43,9 +53,16 @@ namespace TrafficManager.Util.Extensions {
             }
         }
 
-        /// <returns><c>true</c> if nodeId is start node.
-        /// <c>false</c> if nodeId is end node.
-        /// Undetermined if segment does not have nodeId</returns>
+        /// <summary>
+        /// Determine if specified <paramref name="nodeId"/> is the start node for
+        /// the <paramref name="netSegment"/>.
+        /// </summary>
+        /// <param name="netSegment">The segment to inspect.</param>
+        /// <param name="nodeId">The id of the node to examine.</param>
+        /// <returns>
+        /// Returns <c>true</c> if start node, otherwise <c>false</c> (even if the node
+        /// is not associated with the segment).
+        /// </returns>
         public static bool IsStartnode(this ref NetSegment netSegment, ushort nodeId) =>
             netSegment.m_startNode == nodeId;
 

--- a/TLM/TLM/Util/SegmentLaneTraverser.cs
+++ b/TLM/TLM/Util/SegmentLaneTraverser.cs
@@ -64,6 +64,7 @@ namespace TrafficManager.Util {
                                     NetInfo.LaneType? laneTypeFilter,
                                     VehicleInfo.VehicleType? vehicleTypeFilter,
                                     SegmentLaneVisitor laneVisitor) {
+
             IList<LanePos> initialSortedLanes = null;
 
             //-------------------------------------
@@ -77,18 +78,12 @@ namespace TrafficManager.Util {
                 //-------------------------------------
                 // Function applies for each segment
                 //-------------------------------------
-                bool VisitorProcessFun(ushort segmentId, ref NetSegment segment) {
+                bool VisitorProcessFun(ref NetSegment segment) {
                     // Log._Debug($"SegmentLaneTraverser: Reached segment {segmentId}:
                     //     isInitialSeg={isInitialSeg} viaStartNode={segData.viaStartNode}
                     //     viaInitialStartNode={segData.viaInitialStartNode} reverse={reverse}");
-                    ExtSegmentManager extSegmentManager = ExtSegmentManager.Instance;
-                    IList<LanePos> sortedLanes = extSegmentManager.GetSortedLanes(
-                        segmentId,
-                        ref segment,
-                        null,
-                        laneTypeFilter,
-                        vehicleTypeFilter,
-                        reverse);
+
+                    var sortedLanes = segment.GetSortedLanes(null, laneTypeFilter, vehicleTypeFilter, reverse);
 
                     if (isInitialSeg) {
                         initialSortedLanes = sortedLanes;
@@ -122,7 +117,7 @@ namespace TrafficManager.Util {
                 }
 
                 ushort currentSegmentId = segData.CurSeg.segmentId;
-                VisitorProcessFun(currentSegmentId, ref currentSegmentId.ToSegment());
+                VisitorProcessFun(ref currentSegmentId.ToSegment());
 
                 return ret;
             }


### PR DESCRIPTION
Got tired of seeing the `obsolete` warnings on big chunks of `extSegmentManager.GetSortedLanes()` so started porting some over to the newer NetSegment extension.

I'm doing these by hand as there seems to be lots of little fringe issues in code where GetSortedLanes() is used - for example, sometimes we don't need the lanes sorting (eg. if we're just counting the number of returned lanes).