### PR TITLE
ignore saving TMPE metadata if there are no networks.

### DIFF
--- a/TLM/TLM/Lifecycle/AssetDataExtension.cs
+++ b/TLM/TLM/Lifecycle/AssetDataExtension.cs
@@ -40,9 +40,13 @@ namespace TrafficManager.Lifecycle {
             if (asset is BuildingInfo prefab) {
                 Log.Info("AssetDataExtension.OnAssetSavedImpl():  prefab is " + prefab);
                 var assetData = AssetData.GetAssetData(prefab);
-                Log._Debug("AssetDataExtension.OnAssetSavedImpl(): assetData=" + assetData);
-                userData = new Dictionary<string, byte[]>();
-                userData.Add(TMPE_RECORD_ID, SerializationUtil.Serialize(assetData));
+                if (assetData == null) {
+                    Log._Debug("AssetDataExtension.OnAssetSavedImpl(): No segments to record.");
+                } else {
+                    Log._Debug("AssetDataExtension.OnAssetSavedImpl(): assetData=" + assetData);
+                    userData = new Dictionary<string, byte[]>();
+                    userData.Add(TMPE_RECORD_ID, SerializationUtil.Serialize(assetData));
+                }
             }
         }
     }

--- a/TLM/TLM/State/Asset/AssetData.cs
+++ b/TLM/TLM/State/Asset/AssetData.cs
@@ -34,6 +34,10 @@ namespace TrafficManager.State.Asset {
         /// gathers all data for the given asset.
         /// </summary>
         public static AssetData GetAssetData(BuildingInfo prefab) {
+            if (!HasPaths(prefab)) {
+                return null;
+            }
+                
             return new AssetData {
                 Version = VersionUtil.ModVersion,
                 Record = RecordAll(),
@@ -65,6 +69,10 @@ namespace TrafficManager.State.Asset {
         /// </summary>
         public static SegmentNetworkIDs [] GetPathsNetworkIDs(BuildingInfo prefab) {
             // Code based on BuildingDecorations.SavePaths()
+            if (!HasPaths(prefab)) {
+                // null guard
+                return null;
+            }
             List<ushort> assetSegmentIds = new List<ushort>();
             List<ushort> buildingIds = new List<ushort>(prefab.m_paths.Length);
             var ret = new List<SegmentNetworkIDs>();
@@ -86,7 +94,8 @@ namespace TrafficManager.State.Asset {
                 }
             }
             return ret.ToArray();
-
         }
+
+        private static bool HasPaths(BuildingInfo prefab) => prefab.m_paths != null && prefab.m_paths.Length > 0;
     }
 }


### PR DESCRIPTION
fixes #1313
Added null guard for when there is no networks no need to save any asset data in such situations anyway
Ignore white space when reviewing.

test save building with sub-building and no networks: PASS
no on screen error
log shows:
```
Debug 1,316.7875336: AssetDataExtension.OnAssetSavedImpl(): No segments to record.
```
