### PR TITLE
Modernise remaining uses of `GetSortedLanes()`

### DIFF
--- a/TLM/TLM/Manager/Impl/ExtSegmentManager.cs
+++ b/TLM/TLM/Manager/Impl/ExtSegmentManager.cs
@@ -204,17 +204,6 @@ namespace TrafficManager.Manager.Impl {
         public GetSegmentLaneIdsEnumerable GetSegmentLaneIdsAndLaneIndexes(ushort segmentId) =>
             segmentId.ToSegment().GetSegmentLaneIdsAndLaneIndexes();
 
-        [Obsolete]
-        public IList<LanePos> GetSortedLanes(ushort segmentId,
-                                             ref NetSegment segment,
-                                             bool? startNode,
-                                             NetInfo.LaneType? laneTypeFilter = null,
-                                             VehicleInfo.VehicleType? vehicleTypeFilter = null,
-                                             bool reverse = false,
-                                             bool sort = true) {
-            return segment.GetSortedLanes(startNode, laneTypeFilter, vehicleTypeFilter, reverse, sort);
-        }
-
         protected override void InternalPrintDebugInfo() {
             base.InternalPrintDebugInfo();
             Log._Debug($"Extended segment data:");

--- a/TLM/TLM/Util/Record/LaneArrowsRecord.cs
+++ b/TLM/TLM/Util/Record/LaneArrowsRecord.cs
@@ -1,12 +1,10 @@
 namespace TrafficManager.Util.Record {
-    using ColossalFramework;
     using System;
     using System.Collections.Generic;
     using TrafficManager.API.Traffic.Enums;
     using TrafficManager.Manager.Impl;
     using TrafficManager.State;
     using TrafficManager.Util.Extensions;
-    using static TrafficManager.Util.Shortcuts;
 
     [Serializable]
     public class LaneArrowsRecord : IRecordable {
@@ -31,24 +29,32 @@ namespace TrafficManager.Util.Record {
             LaneArrowManager.Instance.SetLaneArrows(laneId, arrows_.Value);
         }
 
+        /// <summary>
+        /// Obtain lane arrow records for the lanes exiting the specified
+        /// end of a segment.
+        /// </summary>
+        /// <param name="segmentId">The id of the segment to inspect.</param>
+        /// <param name="startNode">
+        /// If <c>true</c>, get lanes exiting via the start node; otherwise
+        /// get lanes exiting via the end node.</param>
+        /// <returns>
+        /// Returns a sorted list of <see cref="LaneArrowsRecord"/> associated
+        /// with each lane exiting via the specified segment end. The list may
+        /// be empty if no matching lanes were found.
+        /// </returns>
         public static List<LaneArrowsRecord> GetLanes(ushort segmentId, bool startNode) {
-            int maxLaneCount = segmentId.ToSegment().Info.m_lanes.Length;
-            var ret = new List<LaneArrowsRecord>(maxLaneCount);
-            ExtSegmentManager extSegmentManager = ExtSegmentManager.Instance;
-            var lanes = extSegmentManager.GetSortedLanes(
-                segmentId,
-                ref segmentId.ToSegment(),
+
+            var lanes = segmentId.ToSegment().GetSortedLanes(
                 startNode,
                 LaneArrowManager.LANE_TYPES,
                 LaneArrowManager.VEHICLE_TYPES,
                 sort: false);
-            foreach (var lane in lanes) {
-                LaneArrowsRecord laneData = new LaneArrowsRecord {
-                    LaneId = lane.laneId,
-                };
-                ret.Add(laneData);
-            }
-            ret.TrimExcess();
+
+            var ret = new List<LaneArrowsRecord>(lanes.Count);
+
+            foreach (var lane in lanes)
+                ret.Add(new LaneArrowsRecord { LaneId = lane.laneId });
+
             return ret;
         }
 

--- a/TLM/TLM/Util/Record/SegmentRecord.cs
+++ b/TLM/TLM/Util/Record/SegmentRecord.cs
@@ -72,13 +72,11 @@ namespace TrafficManager.Util.Record {
             }
         }
 
+        // TODO: This should be called GetAllLaneIDs?
         public static List<uint> GetAllLanes(ushort segmentId) {
-            ExtSegmentManager extSegmentManager = ExtSegmentManager.Instance;
-            var lanes = extSegmentManager.GetSortedLanes(
-                segmentId,
-                ref segmentId.ToSegment(),
-                startNode: null,
-                sort: false);
+
+            var lanes = segmentId.ToSegment().GetSortedLanes(null, sort: false);
+
             return lanes.Select(lane => lane.laneId).ToList();
         }
     }

--- a/TLM/TLM/Util/Record/SpeedLimitLaneRecord.cs
+++ b/TLM/TLM/Util/Record/SpeedLimitLaneRecord.cs
@@ -43,29 +43,35 @@ namespace TrafficManager.Util.Record {
                 action: SetSpeedLimitAction.FromNullableFloat(this.speedLimit_));
         }
 
+        /// <summary>
+        /// Obtain speed limit records for applicable lanes within the segment.
+        /// </summary>
+        /// <param name="segmentId">The id of the segment to inspect.</param>
+        /// <returns>
+        /// Returns a list of <see cref="SpeedLimitLaneRecord"/> for all
+        /// speed-applicable lanes in the segment. The list may be empty if no
+        /// matching lanes were found.
+        /// </returns>
         public static List<SpeedLimitLaneRecord> GetLanes(ushort segmentId) {
-            int maxLaneCount = segmentId.ToSegment().Info.m_lanes.Length;
-            var ret = new List<SpeedLimitLaneRecord>(maxLaneCount);
-            ExtSegmentManager extSegmentManager = ExtSegmentManager.Instance;
-            var lanes = extSegmentManager.GetSortedLanes(
-                segmentId,
-                ref segmentId.ToSegment(),
+
+            var lanes = segmentId.ToSegment().GetSortedLanes(
                 null,
                 LANE_TYPES,
                 VEHICLE_TYPES,
                 sort: false);
+
+            var ret = new List<SpeedLimitLaneRecord>(lanes.Count);
+
             foreach (var lane in lanes) {
-                SpeedLimitLaneRecord laneData = new SpeedLimitLaneRecord {
+                ret.Add(new SpeedLimitLaneRecord {
                     LaneId = lane.laneId,
                     LaneIndex = lane.laneIndex,
-                };
-                ret.Add(laneData);
+                });
             }
-            ret.TrimExcess();
+
             return ret;
         }
 
         public byte[] Serialize() => SerializationUtil.Serialize(this);
-
     }
 }

--- a/TLM/TLM/Util/Record/SpeedLimitLaneRecord.cs
+++ b/TLM/TLM/Util/Record/SpeedLimitLaneRecord.cs
@@ -2,7 +2,6 @@ namespace TrafficManager.Util.Record {
     using System;
     using System.Collections.Generic;
     using TrafficManager.Manager.Impl;
-    using static TrafficManager.Util.Shortcuts;
     using TrafficManager.State;
     using TrafficManager.Util.Extensions;
 

--- a/TLM/TLM/Util/Record/VehicleRestrictionsLaneRecord.cs
+++ b/TLM/TLM/Util/Record/VehicleRestrictionsLaneRecord.cs
@@ -53,26 +53,33 @@ namespace TrafficManager.Util.Record {
             }
         }
 
+        /// <summary>
+        /// Obtain vehicle restriction records for applicable lanes within the segment.
+        /// </summary>
+        /// <param name="segmentId">The id of the segment to inspect.</param>
+        /// <returns>
+        /// Returns a list of <see cref="VehicleRestrictionsLaneRecord"/> for all
+        /// restriction-applicable lanes in the segment. The list may be empty if no
+        /// matching lanes were found.
+        /// </returns>
         public static List<VehicleRestrictionsLaneRecord> GetLanes(ushort segmentId) {
-            int maxLaneCount = segmentId.ToSegment().Info.m_lanes.Length;
-            var ret = new List<VehicleRestrictionsLaneRecord>(maxLaneCount);
-            ExtSegmentManager extSegmentManager = ExtSegmentManager.Instance;
-            var lanes = extSegmentManager.GetSortedLanes(
-                segmentId,
-                ref segmentId.ToSegment(),
+
+            var lanes = segmentId.ToSegment().GetSortedLanes(
                 null,
                 LANE_TYPES,
                 VEHICLE_TYPES,
                 sort: false);
+
+            var ret = new List<VehicleRestrictionsLaneRecord>(lanes.Count);
+
             foreach (var lane in lanes) {
-                VehicleRestrictionsLaneRecord laneData = new VehicleRestrictionsLaneRecord {
+                ret.Add(new VehicleRestrictionsLaneRecord {
                     SegmentId = segmentId,
                     LaneId = lane.laneId,
                     LaneIndex = lane.laneIndex,
-                };
-                ret.Add(laneData);
+                });
             }
-            ret.TrimExcess();
+
             return ret;
         }
 

--- a/TLM/TLM/Util/Record/VehicleRestrictionsLaneRecord.cs
+++ b/TLM/TLM/Util/Record/VehicleRestrictionsLaneRecord.cs
@@ -5,7 +5,6 @@ namespace TrafficManager.Util.Record {
     using TrafficManager.Manager.Impl;
     using TrafficManager.State;
     using TrafficManager.Util.Extensions;
-    using static TrafficManager.Util.Shortcuts;
 
     [Serializable]
     public class VehicleRestrictionsLaneRecord : IRecordable {

--- a/TLM/TLM/Util/SeparateTurningLanesUtil.cs
+++ b/TLM/TLM/Util/SeparateTurningLanesUtil.cs
@@ -1,5 +1,4 @@
 namespace TrafficManager.Util {
-    using ColossalFramework;
     using CSUtil.Commons;
     using System;
     using System.Collections.Generic;

--- a/TLM/TLM/Util/SeparateTurningLanesUtil.cs
+++ b/TLM/TLM/Util/SeparateTurningLanesUtil.cs
@@ -23,8 +23,9 @@ namespace TrafficManager.Util {
             ExtSegmentEnd segEnd = segEndMan.ExtSegmentEnds[segEndMan.GetIndex(segmentId, startNode)];
 
             ref NetNode node = ref nodeId.ToNode();
-            for (int i = 0; i < 8; ++i) {
-                ushort otherSegmentId = node.GetSegment(i);
+
+            for (int segmentIndex = 0; segmentIndex < Constants.MAX_SEGMENTS_OF_NODE; ++segmentIndex) {
+                ushort otherSegmentId = node.GetSegment(segmentIndex);
                 ref NetSegment otherSeg = ref otherSegmentId.ToSegment();
                 if (segmentId != 0) {
                     ArrowDirection dir2 = segEndMan.GetDirection(ref segEnd, otherSegmentId);

--- a/TLM/TLM/Util/SeparateTurningLanesUtil.cs
+++ b/TLM/TLM/Util/SeparateTurningLanesUtil.cs
@@ -221,18 +221,15 @@ namespace TrafficManager.Util {
 
             ref NetSegment seg = ref segmentId.ToSegment();
             bool startNode = seg.m_startNode == nodeId;
-            ExtSegmentManager extSegmentManager = ExtSegmentManager.Instance;
 
             //list of outgoing lanes from current segment to current node.
-            IList<LanePos> laneList =
-                extSegmentManager.GetSortedLanes(
-                    segmentId,
-                    ref seg,
-                    startNode,
-                    laneType,
-                    vehicleType,
-                    reverse: LHT,
-                    sort: true);
+            var laneList = seg.GetSortedLanes(
+                startNode,
+                laneType,
+                vehicleType,
+                reverse: LHT,
+                sort: true);
+
             int srcLaneCount = laneList.Count();
             if (srcLaneCount <= 1) {
                 return;
@@ -313,18 +310,14 @@ namespace TrafficManager.Util {
 
             ref NetSegment seg = ref segmentId.ToSegment();
             bool startNode = seg.m_startNode == nodeId;
-            ExtSegmentManager extSegmentManager = ExtSegmentManager.Instance;
 
             //list of outgoing lanes from current segment to current node.
-            IList<LanePos> laneList =
-                extSegmentManager.GetSortedLanes(
-                    segmentId,
-                    ref seg,
-                    startNode,
-                    laneType,
-                    vehicleType,
-                    reverse: LHT,
-                    sort: false);
+            var laneList = seg.GetSortedLanes(
+                startNode,
+                laneType,
+                vehicleType,
+                reverse: LHT,
+                sort: false);
 
             int forwardLanesCount = CountTargetLanesTowardDirection(segmentId, nodeId, ArrowDirection.Forward);
             if (forwardLanesCount == 0)
@@ -487,17 +480,14 @@ namespace TrafficManager.Util {
 
             ref NetSegment netSegment = ref segmentId.ToSegment();
             bool startNode = netSegment.m_startNode == nodeId;
-            ExtSegmentManager extSegmentManager = ExtSegmentManager.Instance;
 
             //list of outgoing lanes from current segment to current node.
-            IList<LanePos> laneList =
-                extSegmentManager.GetSortedLanes(
-                    segmentId,
-                    ref netSegment,
-                    startNode,
-                    LaneArrowManager.LANE_TYPES,
-                    LaneArrowManager.VEHICLE_TYPES,
-                    sort: false);
+            var laneList = netSegment.GetSortedLanes(
+                startNode,
+                LaneArrowManager.LANE_TYPES,
+                LaneArrowManager.VEHICLE_TYPES,
+                sort: false);
+
             int srcLaneCount = laneList.Count();
             for (int i = 0; i < srcLaneCount; ++i) {
                 if (LaneConnectionManager.Instance.HasOutgoingConnections(laneList[i].laneId, startNode)) {


### PR DESCRIPTION
Final batch of `GetSortedLanes()` updates.

Also reduced memalloc/gc of lists in some `Record` classes, and removed some unused `using` statements.