### PR TITLE
Quickfix lets trams ignore lane arrows

### DIFF
--- a/TLM/TLM/Custom/PathFinding/CustomPathFind.cs
+++ b/TLM/TLM/Custom/PathFinding/CustomPathFind.cs
@@ -295,7 +295,7 @@ namespace TrafficManager.Custom.PathFinding {
                 (queueItem_.vehicleType & ExtVehicleType.RoadVehicle) != ExtVehicleType.None;
 
             isLaneArrowObeyingEntity_ =
-                (!Options.relaxedBusses || queueItem_.vehicleType != ExtVehicleType.Bus) &&
+                (!Options.relaxedBusses || (queueItem_.vehicleType != ExtVehicleType.Bus && queueItem_.vehicleType != ExtVehicleType.Tram)) &&
                 (vehicleTypes_ & LaneArrowManager.VEHICLE_TYPES) != VehicleInfo.VehicleType.None &&
                 (queueItem_.vehicleType & LaneArrowManager.EXT_VEHICLE_TYPES) != ExtVehicleType.None;
 #if DEBUG


### PR DESCRIPTION
Quick-Fix to enable trams to ignore lane arrows when busses are allowed to ignore them
fixes #1053
