### PR TITLE
Api hotfix

### DIFF
--- a/TLM/TMPE.API/Implementations.cs
+++ b/TLM/TMPE.API/Implementations.cs
@@ -15,8 +15,8 @@ namespace TrafficManager.API {
         private static T GetImplementation<T>()
             where T : class {
             constantsType_ ??= Type.GetType("TrafficManager.Constants, TrafficManager", throwOnError: true);
-            var field = constantsType_.GetFields().Single(item => typeof(T).IsAssignableFrom(item.FieldType));
-            return field.GetValue(null) as T;
+            var propertyInfo = constantsType_.GetProperties().Single(item => typeof(T).IsAssignableFrom(item.PropertyType));
+            return propertyInfo.GetValue(null, null) as T;
         }
     }
 }

--- a/TLM/TMPE.API/Implementations.cs
+++ b/TLM/TMPE.API/Implementations.cs
@@ -14,7 +14,7 @@ namespace TrafficManager.API {
 
         private static T GetImplementation<T>()
             where T : class {
-            constantsType_ ??= Type.GetType("TrafficManger.Constants, TrafficManager", throwOnError: true);
+            constantsType_ ??= Type.GetType("TrafficManager.Constants, TrafficManager", throwOnError: true);
             var field = constantsType_.GetFields().Single(item => typeof(T).IsAssignableFrom(item.FieldType));
             return field.GetValue(null) as T;
         }


### PR DESCRIPTION
I cherry picked these two commits from https://github.com/CitiesSkylinesMods/TMPE/pull/1546
I need them in both TMPE stable and Test so that my mods would not break when I switch to TMPE.API.

I fixed a bug in `TMPE.API` that failed to get `ManagersFactory`. Now it is working.

used TMPE API in my mods:
[HUT-DCR.zip](https://github.com/CitiesSkylinesMods/TMPE/files/8553363/HUT-DCR.zip)

I cannot upload these fixes to WS until both TMPE stable and Test get the hotfix.