### PR TITLE
Junction restrictions on unnecessary and unreachable pedestrian crossings

### DIFF
--- a/TLM/TLM/Manager/Impl/ExtNodeManager.cs
+++ b/TLM/TLM/Manager/Impl/ExtNodeManager.cs
@@ -41,11 +41,14 @@ namespace TrafficManager.Manager.Impl {
             return JunctionHasOnlyHighwayRoads(nodeId) && !LaneConnection.LaneConnectionManager.Instance.Sub.HasNodeConnections(nodeId);
         }
 
-        public GetNodeSegmentIdsEnumerable GetNodeSegmentIds(ushort nodeId, ClockDirection clockDirection) {
+        public GetNodeSegmentIdsEnumerable GetNodeSegmentIds(ushort nodeId, ClockDirection clockDirection)
+            => GetNodeSegmentIds(nodeId, clockDirection, null);
+
+        internal GetNodeSegmentIdsEnumerable GetNodeSegmentIds(ushort nodeId, ClockDirection clockDirection, ushort? initialSegmentId) {
             ref NetNode netNode = ref nodeId.ToNode();
-            var initialSegmentId = GetInitialSegment(ref netNode);
+            initialSegmentId ??= GetInitialSegment(ref netNode);
             var segmentBuffer = Singleton<NetManager>.instance.m_segments.m_buffer;
-            return new GetNodeSegmentIdsEnumerable(nodeId, initialSegmentId, clockDirection, segmentBuffer);
+            return new GetNodeSegmentIdsEnumerable(nodeId, initialSegmentId.Value, clockDirection, segmentBuffer);
         }
 
         /// <summary>

--- a/TLM/TLM/Manager/Impl/JunctionRestrictionsManager.cs
+++ b/TLM/TLM/Manager/Impl/JunctionRestrictionsManager.cs
@@ -729,7 +729,7 @@ namespace TrafficManager.Manager.Impl {
             if (segment.Info.m_hasPedestrianLanes) {
 
                 if (logLogic) {
-                    Log._Debug($"HasAnyPedestrianAccess(segmentId: {segmentId}, startNode: {startNode}, includeAllPossible: {includeAllPossible})\r\t"
+                    Log._Debug($"IsLikelyPedestrianRoute(segmentId: {segmentId}, startNode: {startNode}, includeAllPossible: {includeAllPossible})\r\t"
                                 + $"segment {segmentId} has pedestrian lanes"
                                 + $"returning true");
                 }
@@ -752,7 +752,7 @@ namespace TrafficManager.Manager.Impl {
             if (nearestClockwiseSegId == 0) {
 
                 if (logLogic) {
-                    Log._Debug($"HasAnyPedestrianAccess(segmentId: {segmentId}, startNode: {startNode}, includeAllPossible: {includeAllPossible})\r\t"
+                    Log._Debug($"IsLikelyPedestrianRoute(segmentId: {segmentId}, startNode: {startNode}, includeAllPossible: {includeAllPossible})\r\t"
                                 + $"no pedestrian lanes on node {nodeId}"
                                 + $"returning false");
                 }
@@ -763,7 +763,7 @@ namespace TrafficManager.Manager.Impl {
             if (includeAllPossible) {
 
                 if (logLogic) {
-                    Log._Debug($"HasAnyPedestrianAccess(segmentId: {segmentId}, startNode: {startNode}, includeAllPossible: {includeAllPossible})\r\t"
+                    Log._Debug($"IsLikelyPedestrianRoute(segmentId: {segmentId}, startNode: {startNode}, includeAllPossible: {includeAllPossible})\r\t"
                                 + $"pedestrian lanes found on segment {nearestClockwiseSegId}"
                                 + $"returning true");
                 }
@@ -784,7 +784,7 @@ namespace TrafficManager.Manager.Impl {
             if (nearestCounterClockwiseSegId == 0 || nearestClockwiseSegId == nearestCounterClockwiseSegId) {
 
                 if (logLogic) {
-                    Log._Debug($"HasAnyPedestrianAccess(segmentId: {segmentId}, startNode: {startNode}, includeAllPossible: {includeAllPossible})\r\t"
+                    Log._Debug($"IsLikelyPedestrianRoute(segmentId: {segmentId}, startNode: {startNode}, includeAllPossible: {includeAllPossible})\r\t"
                                 + $"no pedestrian lanes on segment {segmentId}"
                                 + $"only one segment on node {nodeId} has pedestrian lanes"
                                 + $"returning false");
@@ -804,7 +804,7 @@ namespace TrafficManager.Manager.Impl {
             bool result = distanceThisSide < distanceOtherSide;
 
             if (logLogic) {
-                Log._Debug($"HasAnyPedestrianAccess(segmentId: {segmentId}, startNode: {startNode}, includeAllPossible: {includeAllPossible})\r\t"
+                Log._Debug($"HasAnyPedestIsLikelyPedestrianRouterianAccess(segmentId: {segmentId}, startNode: {startNode}, includeAllPossible: {includeAllPossible})\r\t"
                             + $"segments with pedestrian lanes - clockwise: {nearestClockwiseSegId}, counter-clockwise: {nearestCounterClockwiseSegId}\r\t"
                             + $"distanceThisSide: {distanceThisSide}, distanceOtherSide: {distanceOtherSide}\r\t"
                             + $"returning {result}");


### PR DESCRIPTION
This resolves #1302.

* When a segment has no pedestrian lanes and is not part of the shortest path between two other segments with pedestrian lanes on the same node, crossings for that segment are disallowed by default.
* When none of the segments on a node have pedestrian lanes, crossings are disallowed and are not configurable.

The "shortest path" is determined by the number of segments a pedestrian must cross, without regard for geometry; so it may not reflect true distances.

```mermaid
graph TD

    Allowed[Allowed=true<br/>Configurable=true]
    Configurable[Allowed=false<br/>Configurable=true]
    Disallowed[Allowed=false<br/>Configurable=false]

    HasPedestrians{Does this segment<br/>have pedestrian lanes?}
    HasPedestrians -->|Yes| Allowed
    HasPedestrians -->|No| OtherSegments

    OtherSegments{How many other segments<br/>have pedestrian lanes?}
    OtherSegments -->|More than 1| ShortestPath
    OtherSegments -->|1| Configurable
    OtherSegments -->|0| Disallowed

    ShortestPath{Does any shortest path go<br/>through this segment?}
    ShortestPath -->|Yes| Allowed
    ShortestPath -->|No| Configurable
```
