### PR TITLE
Fix regression with version naming

### DIFF
--- a/TLM/TLM/UI/WhatsNew/WhatsNew.cs
+++ b/TLM/TLM/UI/WhatsNew/WhatsNew.cs
@@ -102,7 +102,8 @@ namespace TrafficManager.UI.WhatsNew {
                     && lineKeyword == MarkupKeyword.VersionStart) {
 
                     var changelog = new Changelog() {
-                        Version = new Version(text),
+                        // version text can be 1.2.3.4 or 1.2.3.4-hotfix-<number>
+                        Version = new Version(text.Split('-')[0]),
                     };
                     var items = new List<Changelog.Item>();
 


### PR DESCRIPTION
Simplest possible fix for unsupported version string supplied to the C# `Version` constructor

In the future updates we should ensure that last number of version string `x.x.x.x` will be dedicated for hotfix releases so: 
`11(12?).<major - stable releases>.<minor - test releases>.<hotfix>`

Closes #1566 