### PR TITLE
Fix broken hovered element detection after hovering invalid element

### DIFF
--- a/TLM/TLM/UI/TrafficManagerTool.cs
+++ b/TLM/TLM/UI/TrafficManagerTool.cs
@@ -472,7 +472,7 @@ namespace TrafficManager.UI {
                   }
                 }
             } catch(Exception ex) {
-                ex.LogException();                  
+                ex.LogException();
             }
         }
 
@@ -555,10 +555,10 @@ namespace TrafficManager.UI {
                         InfoManager.SubInfoMode.Default);
                 }
                 ToolCursor = null;
+                bool elementsHovered = DetermineHoveredElements(activeLegacySubTool_ is not LaneConnectorTool);
                 if (activeLegacySubTool_?.OverrideCursor != null) {
                     ToolCursor = activeLegacySubTool_.OverrideCursor;
                 } else {
-                    bool elementsHovered = DetermineHoveredElements(activeLegacySubTool_ is not LaneConnectorTool);
                     if (activeLegacySubTool_ != null && NetTool != null && elementsHovered) {
                         ToolCursor = NetTool.m_upgradeCursor;
                     }


### PR DESCRIPTION
Steps to reproduce:
- activate `Lane connector tool`, 
- hover underground node in normal mode,
- cursor changes to 🚫 and all interactions are completely blocked for selected tool, 
- require reactivation of tool to temporary fix issue (until cursor will switch to 🚫 again) 

Build [ZIP file](https://ci.appveyor.com/api/projects/krzychu124/tmpe/artifacts/TMPE.zip?branch=bugfix/1491-regression-cursor-hover) for tests