### PR TITLE
ExtNetInfo class for lane grouping

### DIFF
--- a/TLM/TLM/ExtPrefabs/ExtNetInfo.cs
+++ b/TLM/TLM/ExtPrefabs/ExtNetInfo.cs
@@ -2,11 +2,318 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using TrafficManager.Util.Extensions;
 
 namespace TrafficManager.ExtPrefabs {
     internal class ExtNetInfo : ExtPrefabInfo<ExtNetInfo, NetInfo> {
 
-        public ExtNetInfo(NetInfo info) {
+        [Flags]
+        public enum ExtLaneFlags {
+
+            /// <summary>
+            /// Lanes outside a median (if any) that divides lanes going the same direction.
+            /// In the absence of such a median, these are simply lanes that are not displaced.
+            /// </summary>
+            Outer = 1 << 0,
+
+            /// <summary>
+            /// Lanes inside a median that divides lanes going the same direction.
+            /// </summary>
+            Inner = 1 << 1,
+
+            /// <summary>
+            /// Displaced lanes that are between lanes going the opposite direction.
+            /// </summary>
+            DisplacedInner = 1 << 2,
+
+            /// <summary>
+            /// Displaced lanes that are located on the far side of the road from what is normal for their direction.
+            /// </summary>
+            DisplacedOuter = 1 << 3,
+
+            /// <summary>
+            /// Lanes in a group whose prevailing direction is forward.
+            /// </summary>
+            ForwardGroup = 1 << 4,
+
+            /// <summary>
+            /// Lanes in a group whose prevailing direction is backward.
+            /// </summary>
+            BackwardGroup = 1 << 5,
+
+            /// <summary>
+            /// Lanes that may be treated as service lanes in controlled lane routing.
+            /// </summary>
+            AllowServiceLane = 1 << 6,
+
+            /// <summary>
+            /// Lanes that may be treated as express lanes in controlled lane routing.
+            /// </summary>
+            AllowExpressLane = 1 << 7,
+
+            /// <summary>
+            /// Lanes that may be treated as displaced far turn lanes in controlled lane routing.
+            /// </summary>
+            AllowCFI = 1 << 8,
+
+            /// <summary>
+            /// Lanes whose properties cause controlled lane routing to be disabled for the segment.
+            /// </summary>
+            ForbidControlledLanes = 1 << 9,
+
+            /// <summary>
+            /// Mask to obtain the lane grouping key.
+            /// </summary>
+            LaneGroupingKey = Outer | Inner | DisplacedInner | DisplacedOuter | ForwardGroup | BackwardGroup,
+
+            /// <summary>
+            /// Mask to test a segment for the presence of service lanes.
+            /// </summary>
+            ServiceLaneRule = AllowServiceLane | ForbidControlledLanes,
+
+            /// <summary>
+            /// Mask to test a segment for the presence of express lanes.
+            /// </summary>
+            ExpressLaneRule = AllowExpressLane | ForbidControlledLanes,
+
+            /// <summary>
+            /// Mask to test a segment for the presence of displaced far turn lanes.
+            /// </summary>
+            CFIRule = AllowCFI | ForbidControlledLanes,
+
+            /// <summary>
+            /// Mask to test the prevailing direction of a lane group.
+            /// </summary>
+            GroupDirection = ForwardGroup | BackwardGroup,
+
+            /// <summary>
+            /// Mask to test a segment for the presence of any displaced lanes.
+            /// </summary>
+            Displaced = DisplacedInner | DisplacedOuter,
+        }
+
+        public ExtLaneInfo[] m_extLanes;
+
+        public LaneGroupInfo[] m_laneGroups;
+
+        public int[] m_sortedLanes;
+
+        public ExtLaneFlags m_forwardExtFlags;
+        public ExtLaneFlags m_backwardExtFlags;
+
+        public ExtLaneFlags m_extFlags;
+
+        public ExtNetInfo(NetInfo info)
+            : this(info.m_lanes) {
+        }
+
+        public ExtNetInfo(NetInfo.Lane[] lanes) {
+
+            int GetDirectionalSortKey(ExtLaneFlags flags) {
+                switch (flags & ExtLaneFlags.GroupDirection) {
+                    case ExtLaneFlags.BackwardGroup:
+                        return 1;
+                    default:
+                        return 2;
+                    case ExtLaneFlags.ForwardGroup:
+                        return 3;
+                }
+            }
+
+            m_extLanes = lanes.Select(l => new ExtLaneInfo(l)).ToArray();
+
+            // TODO: Boundary conditions on sorting need work
+            m_sortedLanes = m_extLanes.Select((extInfo, index) => index)
+                                        .OrderBy(i => lanes[i].m_position)
+                                        .ThenBy(i => GetDirectionalSortKey(m_extLanes[i].m_extFlags))
+                                        .ToArray();
+
+            var minForward = float.MaxValue;
+            var maxForward = float.MinValue;
+            var minBackward = float.MaxValue;
+            var maxBackward = float.MinValue;
+
+            for (int i = 0; i < lanes.Length; i++) {
+                var flags = m_extLanes[i].m_extFlags;
+                if ((flags & ExtLaneFlags.ForwardGroup) != 0) {
+                    float position = lanes[i].m_position;
+                    minForward = Math.Min(minForward, (float)position);
+                    maxForward = Math.Max(maxForward, (float)position);
+
+                } else if ((flags & ExtLaneFlags.BackwardGroup) != 0) {
+                    float position = lanes[i].m_position;
+                    minBackward = Math.Min(minBackward, (float)position);
+                    maxBackward = Math.Max(maxBackward, (float)position);
+                }
+            }
+
+            bool oneWay = minForward == float.MaxValue || minBackward == float.MaxValue;
+            bool inverted = !oneWay && maxForward <= minBackward;
+
+            // bypass displaced scans for conventional, inverted, and one-way roads
+            if (oneWay || inverted || maxBackward <= minForward) {
+                for (int i = 0; i < m_extLanes.Length; i++)
+                    m_extLanes[i].m_extFlags |= ExtLaneFlags.Outer;
+            } else {
+
+                var lastDisplacedOuterBackward = -1;
+                var lastDisplacedOuterForward = lanes.Length;
+
+                int si;
+
+                // scan for DisplacedOuter|ForwardGroup
+                for (si = 0; si < lanes.Length; si++) {
+                    var direction = m_extLanes[m_sortedLanes[si]].m_extFlags & ExtLaneFlags.GroupDirection;
+                    if ((direction & ExtLaneFlags.ForwardGroup) != 0)
+                        lastDisplacedOuterForward = si;
+                    if (direction != 0)
+                        break;
+                }
+
+                // scan for DisplacedOuter|BackwardGroup
+                for (si = lanes.Length - 1; si >= 0; si--) {
+                    var direction = m_extLanes[m_sortedLanes[si]].m_extFlags & ExtLaneFlags.GroupDirection;
+                    if ((direction & ExtLaneFlags.BackwardGroup) != 0)
+                        lastDisplacedOuterBackward = si;
+                    if (direction != 0)
+                        break;
+                }
+
+                // scan for Outer|ForwardGroup (may convert some to Inner later)
+                for (si = lastDisplacedOuterBackward - 1; si > lastDisplacedOuterForward; si--) {
+                    var extLane = m_extLanes[m_sortedLanes[si]];
+                    var direction = extLane.m_extFlags & ExtLaneFlags.GroupDirection;
+                    if ((direction & ExtLaneFlags.ForwardGroup) != 0)
+                        extLane.m_extFlags |= ExtLaneFlags.Outer;
+                    if ((direction & ExtLaneFlags.BackwardGroup) != 0)
+                        break;
+                }
+
+                // skip BackwardGroup
+                for (; si > lastDisplacedOuterForward; si--) {
+                    if ((m_extLanes[m_sortedLanes[si]].m_extFlags & ExtLaneFlags.ForwardGroup) != 0)
+                        break;
+                }
+
+                // scan for DisplacedInner|ForwardGroup
+                for (; si > lastDisplacedOuterForward; si--) {
+                    int i = m_sortedLanes[si];
+                    var extLane = m_extLanes[i];
+                    if ((extLane.m_extFlags & ExtLaneFlags.ForwardGroup) != 0) {
+                        var lane = lanes[i];
+                        extLane.m_extFlags |= ExtLaneFlags.DisplacedInner;
+                        if (lane.m_allowConnect)
+                            extLane.m_extFlags |= ExtLaneFlags.ForbidControlledLanes;
+                        else if (lane.m_laneType == NetInfo.LaneType.Vehicle)
+                            extLane.m_extFlags |= ExtLaneFlags.AllowCFI;
+                    }
+                }
+
+                // scan for Outer|BackwardGroup (may convert some to Inner later)
+                for (si = lastDisplacedOuterForward + 1; si < lastDisplacedOuterBackward; si++) {
+                    var extLane = m_extLanes[m_sortedLanes[si]];
+                    var direction = extLane.m_extFlags & ExtLaneFlags.GroupDirection;
+                    if ((direction & ExtLaneFlags.BackwardGroup) != 0)
+                        extLane.m_extFlags |= ExtLaneFlags.Outer;
+                    if ((direction & ExtLaneFlags.ForwardGroup) != 0)
+                        break;
+                }
+
+                // skip ForwardGroup
+                for (; si < lastDisplacedOuterBackward; si++) {
+                    if ((m_extLanes[m_sortedLanes[si]].m_extFlags & ExtLaneFlags.BackwardGroup) != 0)
+                        break;
+                }
+
+                // scan for DisplacedInner|BackwardGroup
+                for (; si < lastDisplacedOuterBackward; si++) {
+                    int i = m_sortedLanes[si];
+                    var extLane = m_extLanes[i];
+                    if ((extLane.m_extFlags & ExtLaneFlags.BackwardGroup) != 0) {
+                        var lane = lanes[i];
+                        extLane.m_extFlags |= ExtLaneFlags.DisplacedInner;
+                        if (lane.m_allowConnect)
+                            extLane.m_extFlags |= ExtLaneFlags.ForbidControlledLanes;
+                        else if (lane.m_laneType == NetInfo.LaneType.Vehicle)
+                            extLane.m_extFlags |= ExtLaneFlags.AllowCFI;
+                    }
+                }
+
+                var forwardFlags = m_extLanes.Select(l => l.m_extFlags).Where(f => (f & ExtLaneFlags.ForwardGroup) != 0).Aggregate((x, y) => x | y);
+                var backwardFlags = m_extLanes.Select(l => l.m_extFlags).Where(f => (f & ExtLaneFlags.BackwardGroup) != 0).Aggregate((x, y) => x | y);
+
+                // TODO: Scan medians and express lanes here
+
+                // if applicable, set Outer|ForwardGroup|AllowServiceLane
+                if ((forwardFlags & ExtLaneFlags.DisplacedInner) != 0) {
+                    for (int i = 0; i < m_extLanes.Length; i++) {
+                        var extLane = m_extLanes[i];
+                        const ExtLaneFlags matchingFlags = ExtLaneFlags.Outer | ExtLaneFlags.ForwardGroup;
+                        if ((extLane.m_extFlags & matchingFlags) == matchingFlags)
+                            extLane.m_extFlags |= ExtLaneFlags.AllowServiceLane;
+                    }
+                }
+
+                // if applicable, set Outer|BackwardGroup|AllowServiceLane
+                if ((backwardFlags & ExtLaneFlags.DisplacedInner) != 0) {
+                    for (int i = 0; i < m_extLanes.Length; i++) {
+                        var extLane = m_extLanes[i];
+                        const ExtLaneFlags matchingFlags = ExtLaneFlags.Outer | ExtLaneFlags.BackwardGroup;
+                        if ((extLane.m_extFlags & matchingFlags) == matchingFlags)
+                            extLane.m_extFlags |= ExtLaneFlags.AllowServiceLane;
+                    }
+                }
+            }
+
+            m_laneGroups = Enumerable.Range(0, lanes.Length)
+                            .Select(index => new { index, lane = lanes[index], extLane = m_extLanes[index] })
+                            .GroupBy(l => l.extLane.m_extFlags & ExtLaneFlags.LaneGroupingKey)
+                            .Where(g => g.Key != 0)
+                            .Select(g => new LaneGroupInfo {
+                                m_extFlags = g.Select(l => l.extLane.m_extFlags).Aggregate((ExtLaneFlags x, ExtLaneFlags y) => x | y),
+                                m_sortedLanes = g.OrderBy(g => g.lane.m_position).Select(g => g.index).ToArray(),
+                            })
+                            .OrderBy(lg => lanes[lg.m_sortedLanes[0]].m_position)
+                            .ToArray();
+
+            m_forwardExtFlags = m_extLanes.Select(l => l.m_extFlags).Where(f => (f & ExtLaneFlags.ForwardGroup) != 0).Aggregate((x, y) => x | y);
+            m_backwardExtFlags = m_extLanes.Select(l => l.m_extFlags).Where(f => (f & ExtLaneFlags.BackwardGroup) != 0).Aggregate((x, y) => x | y);
+
+            m_extFlags = m_forwardExtFlags | m_backwardExtFlags;
+        }
+
+        internal class ExtLaneInfo {
+
+            public ExtLaneFlags m_extFlags;
+
+            public ExtLaneInfo(NetInfo.Lane lane) {
+                if (lane.IsRoadLane()) {
+
+                    switch (lane.m_direction) {
+                        case NetInfo.Direction.Forward:
+                        case NetInfo.Direction.AvoidBackward:
+                            m_extFlags |= ExtLaneFlags.ForwardGroup;
+                            break;
+
+                        case NetInfo.Direction.Backward:
+                        case NetInfo.Direction.AvoidForward:
+                            m_extFlags |= ExtLaneFlags.BackwardGroup;
+                            break;
+
+                        case NetInfo.Direction.Both:
+                        case NetInfo.Direction.AvoidBoth:
+                            m_extFlags |= ExtLaneFlags.ForwardGroup | ExtLaneFlags.BackwardGroup;
+                            break;
+                    }
+                }
+            }
+        }
+
+        internal class LaneGroupInfo {
+
+            public int[] m_sortedLanes;
+
+            public ExtLaneFlags m_extFlags;
         }
     }
 }

--- a/TLM/TLM/ExtPrefabs/ExtNetInfo.cs
+++ b/TLM/TLM/ExtPrefabs/ExtNetInfo.cs
@@ -1,0 +1,12 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace TrafficManager.ExtPrefabs {
+    internal class ExtNetInfo : ExtPrefabInfo<ExtNetInfo, NetInfo> {
+
+        public ExtNetInfo(NetInfo info) {
+        }
+    }
+}

--- a/TLM/TLM/ExtPrefabs/ExtNetInfo.cs
+++ b/TLM/TLM/ExtPrefabs/ExtNetInfo.cs
@@ -310,7 +310,7 @@ namespace TrafficManager.ExtPrefabs {
 
                 // scan for forward median
 
-                for (sortedIndex = firstOuterLane; sortedIndex > lastDisplacedOuterForward; sortedIndex--) {
+                for (sortedIndex = firstOuterLane - 1; sortedIndex > lastDisplacedOuterForward; sortedIndex--) {
                     var laneIndex = m_sortedLanes[sortedIndex];
                     var extLane = m_extLanes[laneIndex];
                     var lane = lanes[laneIndex];
@@ -386,7 +386,7 @@ namespace TrafficManager.ExtPrefabs {
 
                 // scan for backward raised median
 
-                for (sortedIndex = firstOuterLane; sortedIndex < lastDisplacedOuterBackward; sortedIndex++) {
+                for (sortedIndex = firstOuterLane + 1; sortedIndex < lastDisplacedOuterBackward; sortedIndex++) {
                     var laneIndex = m_sortedLanes[sortedIndex];
                     var extLane = m_extLanes[laneIndex];
                     var lane = lanes[laneIndex];

--- a/TLM/TLM/ExtPrefabs/ExtPrefabInfo.cs
+++ b/TLM/TLM/ExtPrefabs/ExtPrefabInfo.cs
@@ -1,8 +1,5 @@
 using System;
 using System.Collections.Concurrent;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using TrafficManager.Util;
 
 namespace TrafficManager.ExtPrefabs {

--- a/TLM/TLM/ExtPrefabs/ExtPrefabInfo.cs
+++ b/TLM/TLM/ExtPrefabs/ExtPrefabInfo.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using TrafficManager.Util;
+
+namespace TrafficManager.ExtPrefabs {
+    internal abstract class ExtPrefabInfo<TExtInfo, TInfo>
+            where TInfo : PrefabInfo
+            where TExtInfo : ExtPrefabInfo<TExtInfo, TInfo>
+            {
+        private static readonly ConcurrentDictionary<TInfo, TExtInfo> extInfos;
+
+        static ExtPrefabInfo() {
+            extInfos = new ConcurrentDictionary<TInfo, TExtInfo>(ReferenceEqualityComparer<TInfo>.Instance);
+        }
+
+        public static TExtInfo GetInstance(TInfo info) {
+            return extInfos.GetOrAdd(info, i => (TExtInfo)Activator.CreateInstance(typeof(TExtInfo), i));
+        }
+    }
+}

--- a/TLM/TLM/ExtPrefabs/NetInfoExtensions.cs
+++ b/TLM/TLM/ExtPrefabs/NetInfoExtensions.cs
@@ -1,0 +1,12 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace TrafficManager.ExtPrefabs {
+    internal static class NetInfoExtensions {
+
+        public static bool IsRoadLane(this NetInfo.Lane lane) =>
+            lane.m_laneType == NetInfo.LaneType.Vehicle && (lane.m_vehicleType & VehicleInfo.VehicleType.Car) != 0;
+    }
+}

--- a/TLM/TLM/ExtPrefabs/NetInfoExtensions.cs
+++ b/TLM/TLM/ExtPrefabs/NetInfoExtensions.cs
@@ -10,5 +10,9 @@ namespace TrafficManager.ExtPrefabs {
         public static bool IsRoadLane(this NetInfo.Lane lane) =>
             lane.m_laneType.IsFlagSet(NetInfo.LaneType.Vehicle | NetInfo.LaneType.TransportVehicle)
             && lane.m_vehicleType.IsFlagSet(VehicleInfo.VehicleType.Car | VehicleInfo.VehicleType.Trolleybus);
+
+        public static bool IsCarLane(this NetInfo.Lane lane) =>
+            lane.m_laneType.IsFlagSet(NetInfo.LaneType.Vehicle)
+            && lane.m_vehicleType.IsFlagSet(VehicleInfo.VehicleType.Car);
     }
 }

--- a/TLM/TLM/ExtPrefabs/NetInfoExtensions.cs
+++ b/TLM/TLM/ExtPrefabs/NetInfoExtensions.cs
@@ -2,11 +2,13 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using TrafficManager.Util.Extensions;
 
 namespace TrafficManager.ExtPrefabs {
     internal static class NetInfoExtensions {
 
         public static bool IsRoadLane(this NetInfo.Lane lane) =>
-            lane.m_laneType == NetInfo.LaneType.Vehicle && (lane.m_vehicleType & VehicleInfo.VehicleType.Car) != 0;
+            lane.m_laneType.IsFlagSet(NetInfo.LaneType.Vehicle | NetInfo.LaneType.TransportVehicle)
+            && lane.m_vehicleType.IsFlagSet(VehicleInfo.VehicleType.Car | VehicleInfo.VehicleType.Trolleybus);
     }
 }

--- a/TLM/TLM/Properties/AssemblyInfo.cs
+++ b/TLM/TLM/Properties/AssemblyInfo.cs
@@ -2,6 +2,8 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
+[assembly: InternalsVisibleTo("TMPE.UnitTest")]
+
 // General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.

--- a/TLM/TLM/TLM.csproj
+++ b/TLM/TLM/TLM.csproj
@@ -107,6 +107,9 @@
     <Reference Include="MoveItIntegration">
       <HintPath>..\libs\MoveItIntegration.dll</HintPath>
     </Reference>
+    <Reference Include="Portable.ConcurrentDictionary, Version=1.0.4.0, Culture=neutral, PublicKeyToken=8b3524163ea7a2b3, processorArchitecture=MSIL">
+      <HintPath>..\packages\Portable.ConcurrentDictionary.1.0.4\lib\net35\Portable.ConcurrentDictionary.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core">
       <HintPath>$(MangedDLLPath)\System.Core.dll</HintPath>
@@ -135,6 +138,8 @@
     </Compile>
     <Compile Include="Constants.cs" />
     <Compile Include="Custom\PathFinding\PathfinderUpdates.cs" />
+    <Compile Include="ExtPrefabs\ExtNetInfo.cs" />
+    <Compile Include="ExtPrefabs\ExtPrefabInfo.cs" />
     <Compile Include="Geometry\Impl\SegmentEndId.cs" />
     <Compile Include="Lifecycle\Patcher.cs" />
     <Compile Include="Lifecycle\TMPELifecycle.cs" />
@@ -471,6 +476,7 @@
     <Compile Include="Util\Extensions\VehicleExtensions.cs" />
     <Compile Include="Util\InGameUtil.cs" />
     <Compile Include="Util\IntVector2.cs" />
+    <Compile Include="Util\ReferenceEqualityComparer.cs" />
     <Compile Include="Util\TMPEVectorUtil.cs" />
     <Compile Include="Util\RoadFamilyUtil.cs" />
     <Compile Include="Util\Spiral.cs" />

--- a/TLM/TLM/TLM.csproj
+++ b/TLM/TLM/TLM.csproj
@@ -140,6 +140,7 @@
     <Compile Include="Custom\PathFinding\PathfinderUpdates.cs" />
     <Compile Include="ExtPrefabs\ExtNetInfo.cs" />
     <Compile Include="ExtPrefabs\ExtPrefabInfo.cs" />
+    <Compile Include="ExtPrefabs\NetInfoExtensions.cs" />
     <Compile Include="Geometry\Impl\SegmentEndId.cs" />
     <Compile Include="Lifecycle\Patcher.cs" />
     <Compile Include="Lifecycle\TMPELifecycle.cs" />

--- a/TLM/TLM/Util/ReferenceEqualityComparer.cs
+++ b/TLM/TLM/Util/ReferenceEqualityComparer.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text;
+
+namespace TrafficManager.Util {
+    internal sealed class ReferenceEqualityComparer<T> : IEqualityComparer<T>, IEqualityComparer {
+
+        public static ReferenceEqualityComparer<T> Instance { get; } = new ReferenceEqualityComparer<T>();
+        NetAI
+        private ReferenceEqualityComparer() { }
+
+        public bool Equals(T x, T y) => ReferenceEquals(x, y);
+
+        public int GetHashCode(T obj) => RuntimeHelpers.GetHashCode(obj);
+
+        bool IEqualityComparer.Equals(object x, object y) => ReferenceEquals(x, y);
+
+        int IEqualityComparer.GetHashCode(object obj) => RuntimeHelpers.GetHashCode(obj);
+    }
+}

--- a/TLM/TLM/Util/ReferenceEqualityComparer.cs
+++ b/TLM/TLM/Util/ReferenceEqualityComparer.cs
@@ -9,7 +9,7 @@ namespace TrafficManager.Util {
     internal sealed class ReferenceEqualityComparer<T> : IEqualityComparer<T>, IEqualityComparer {
 
         public static ReferenceEqualityComparer<T> Instance { get; } = new ReferenceEqualityComparer<T>();
-        NetAI
+
         private ReferenceEqualityComparer() { }
 
         public bool Equals(T x, T y) => ReferenceEquals(x, y);

--- a/TLM/TLM/packages.config
+++ b/TLM/TLM/packages.config
@@ -3,6 +3,7 @@
   <package id="CitiesHarmony.API" version="2.0.0" targetFramework="net35" />
   <package id="CitiesHarmony.Harmony" version="2.0.4" targetFramework="net35" developmentDependency="true" />
   <package id="Microsoft.Unity.Analyzers" version="1.13.0" targetFramework="net35" developmentDependency="true" />
+  <package id="Portable.ConcurrentDictionary" version="1.0.4" targetFramework="net35" />
   <package id="ReflectionIT.Analyzer.Structs" version="0.1.0" targetFramework="net35" />
   <package id="StyleCop.Analyzers" version="1.1.118" targetFramework="net35" developmentDependency="true" />
   <package id="UnifiedUILib" version="2.2.1" targetFramework="net35" />

--- a/TLM/TMPE.UnitTest/ExtPrefabs/ExtNetInfoTest.cs
+++ b/TLM/TMPE.UnitTest/ExtPrefabs/ExtNetInfoTest.cs
@@ -24,20 +24,20 @@ namespace TMUnitTest.ExtPrefabs {
             Assert.AreEqual(lanes.Length, extNetInfo.m_extLanes.Length);
             VerifySequence(extNetInfo.m_sortedLanes, 0, 2, 4, 5, 3, 1);
 
-            Assert.AreEqual(ExtLaneFlags.Outer | ExtLaneFlags.ForwardGroup, extNetInfo.m_forwardExtLaneFlags);
-            Assert.AreEqual(ExtLaneFlags.Outer | ExtLaneFlags.BackwardGroup, extNetInfo.m_backwardExtLaneFlags);
-            Assert.AreEqual(ExtLaneFlags.Outer | ExtLaneFlags.ForwardGroup | ExtLaneFlags.BackwardGroup, extNetInfo.m_extLaneFlags);
+            Assert.AreEqual(ExtLaneFlags.OuterForward, extNetInfo.m_forwardExtLaneFlags);
+            Assert.AreEqual(ExtLaneFlags.OuterBackward, extNetInfo.m_backwardExtLaneFlags);
+            Assert.AreEqual(ExtLaneFlags.OuterForward | ExtLaneFlags.OuterBackward, extNetInfo.m_extLaneFlags);
 
             Assert.AreEqual(2, extNetInfo.m_laneGroups.Length);
-            VerifyGroup(extNetInfo, 0, ExtLaneFlags.Outer | ExtLaneFlags.BackwardGroup, 4);
-            VerifyGroup(extNetInfo, 1, ExtLaneFlags.Outer | ExtLaneFlags.ForwardGroup, 5);
+            VerifyGroup(extNetInfo, 0, ExtLaneFlags.OuterBackward, 4);
+            VerifyGroup(extNetInfo, 1, ExtLaneFlags.OuterForward, 5);
 
             VerifyLane(extNetInfo, 0, ExtLaneFlags.None);
             VerifyLane(extNetInfo, 1, ExtLaneFlags.None);
             VerifyLane(extNetInfo, 2, ExtLaneFlags.None);
             VerifyLane(extNetInfo, 3, ExtLaneFlags.None);
-            VerifyLane(extNetInfo, 4, ExtLaneFlags.Outer | ExtLaneFlags.BackwardGroup);
-            VerifyLane(extNetInfo, 5, ExtLaneFlags.Outer | ExtLaneFlags.ForwardGroup);
+            VerifyLane(extNetInfo, 4, ExtLaneFlags.OuterBackward);
+            VerifyLane(extNetInfo, 5, ExtLaneFlags.OuterForward);
         }
 
         [TestMethod]
@@ -57,18 +57,18 @@ namespace TMUnitTest.ExtPrefabs {
             Assert.AreEqual(lanes.Length, extNetInfo.m_extLanes.Length);
             VerifySequence(extNetInfo.m_sortedLanes, 0, 2, 4, 5, 3, 1);
 
-            Assert.AreEqual(ExtLaneFlags.Outer | ExtLaneFlags.ForwardGroup, extNetInfo.m_forwardExtLaneFlags);
-            Assert.AreEqual(ExtLaneFlags.Outer | ExtLaneFlags.ForwardGroup, extNetInfo.m_extLaneFlags);
+            Assert.AreEqual(ExtLaneFlags.OuterForward, extNetInfo.m_forwardExtLaneFlags);
+            Assert.AreEqual(ExtLaneFlags.OuterForward, extNetInfo.m_extLaneFlags);
 
             Assert.AreEqual(1, extNetInfo.m_laneGroups.Length);
-            VerifyGroup(extNetInfo, 0, ExtLaneFlags.Outer | ExtLaneFlags.ForwardGroup, 4, 5);
+            VerifyGroup(extNetInfo, 0, ExtLaneFlags.OuterForward, 4, 5);
 
             VerifyLane(extNetInfo, 0, ExtLaneFlags.None);
             VerifyLane(extNetInfo, 1, ExtLaneFlags.None);
             VerifyLane(extNetInfo, 2, ExtLaneFlags.None);
             VerifyLane(extNetInfo, 3, ExtLaneFlags.None);
-            VerifyLane(extNetInfo, 4, ExtLaneFlags.Outer | ExtLaneFlags.ForwardGroup);
-            VerifyLane(extNetInfo, 5, ExtLaneFlags.Outer | ExtLaneFlags.ForwardGroup);
+            VerifyLane(extNetInfo, 4, ExtLaneFlags.OuterForward);
+            VerifyLane(extNetInfo, 5, ExtLaneFlags.OuterForward);
         }
 
         [TestMethod]
@@ -91,233 +91,23 @@ namespace TMUnitTest.ExtPrefabs {
             Assert.AreEqual(lanes.Length, extNetInfo.m_extLanes.Length);
             VerifySequence(extNetInfo.m_sortedLanes, 0, 2, 4, 6, 8, 7, 5, 3, 1);
 
-            Assert.AreEqual(ExtLaneFlags.Outer | ExtLaneFlags.ForwardGroup, extNetInfo.m_forwardExtLaneFlags);
-            Assert.AreEqual(ExtLaneFlags.Outer | ExtLaneFlags.BackwardGroup, extNetInfo.m_backwardExtLaneFlags);
-            Assert.AreEqual(ExtLaneFlags.Outer | ExtLaneFlags.ForwardGroup | ExtLaneFlags.BackwardGroup, extNetInfo.m_extLaneFlags);
+            Assert.AreEqual(ExtLaneFlags.OuterForward, extNetInfo.m_forwardExtLaneFlags);
+            Assert.AreEqual(ExtLaneFlags.OuterBackward, extNetInfo.m_backwardExtLaneFlags);
+            Assert.AreEqual(ExtLaneFlags.OuterForward | ExtLaneFlags.OuterBackward, extNetInfo.m_extLaneFlags);
 
             Assert.AreEqual(2, extNetInfo.m_laneGroups.Length);
-            VerifyGroup(extNetInfo, 0, ExtLaneFlags.Outer | ExtLaneFlags.BackwardGroup, 4, 6);
-            VerifyGroup(extNetInfo, 1, ExtLaneFlags.Outer | ExtLaneFlags.ForwardGroup, 7, 5);
+            VerifyGroup(extNetInfo, 0, ExtLaneFlags.OuterBackward, 4, 6);
+            VerifyGroup(extNetInfo, 1, ExtLaneFlags.OuterForward, 7, 5);
 
             VerifyLane(extNetInfo, 0, ExtLaneFlags.None);
             VerifyLane(extNetInfo, 1, ExtLaneFlags.None);
             VerifyLane(extNetInfo, 2, ExtLaneFlags.None);
             VerifyLane(extNetInfo, 3, ExtLaneFlags.None);
-            VerifyLane(extNetInfo, 4, ExtLaneFlags.Outer | ExtLaneFlags.BackwardGroup);
-            VerifyLane(extNetInfo, 5, ExtLaneFlags.Outer | ExtLaneFlags.ForwardGroup);
-            VerifyLane(extNetInfo, 6, ExtLaneFlags.Outer | ExtLaneFlags.BackwardGroup);
-            VerifyLane(extNetInfo, 7, ExtLaneFlags.Outer | ExtLaneFlags.ForwardGroup);
+            VerifyLane(extNetInfo, 4, ExtLaneFlags.OuterBackward);
+            VerifyLane(extNetInfo, 5, ExtLaneFlags.OuterForward);
+            VerifyLane(extNetInfo, 6, ExtLaneFlags.OuterBackward);
+            VerifyLane(extNetInfo, 7, ExtLaneFlags.OuterForward);
             VerifyLane(extNetInfo, 8, ExtLaneFlags.None);
-        }
-
-        [TestMethod]
-        public void TestCFI() {
-
-            var lanes = new[] {
-                CarLane(0f, true),
-                ThruCarLane(3f, false),
-                ThruCarLane(6f, false),
-                ThruCarLane(9f, true),
-                ThruCarLane(12f, true),
-                CarLane(15f, false),
-                CarLane(18f, false),
-                CarLane(21f, false),
-            };
-
-            var extNetInfo = new ExtNetInfo(lanes);
-
-            Assert.AreEqual(lanes.Length, extNetInfo.m_extLanes.Length);
-            VerifySequence(extNetInfo.m_sortedLanes, 0, 1, 2, 3, 4, 5, 6, 7);
-
-            Assert.AreEqual(ExtLaneFlags.Outer | ExtLaneFlags.DisplacedInner | ExtLaneFlags.AllowCFI | ExtLaneFlags.ForwardGroup, extNetInfo.m_forwardExtLaneFlags);
-            Assert.AreEqual(ExtLaneFlags.Outer | ExtLaneFlags.DisplacedInner | ExtLaneFlags.AllowCFI | ExtLaneFlags.BackwardGroup, extNetInfo.m_backwardExtLaneFlags);
-            Assert.AreEqual(ExtLaneFlags.Outer | ExtLaneFlags.DisplacedInner | ExtLaneFlags.AllowCFI | ExtLaneFlags.ForwardGroup | ExtLaneFlags.BackwardGroup, extNetInfo.m_extLaneFlags);
-
-            Assert.AreEqual(4, extNetInfo.m_laneGroups.Length);
-            VerifyGroup(extNetInfo, 0, ExtLaneFlags.Outer | ExtLaneFlags.BackwardGroup, 0);
-            VerifyGroup(extNetInfo, 1, ExtLaneFlags.DisplacedInner | ExtLaneFlags.AllowCFI | ExtLaneFlags.ForwardGroup, 1, 2);
-            VerifyGroup(extNetInfo, 2, ExtLaneFlags.DisplacedInner | ExtLaneFlags.AllowCFI | ExtLaneFlags.BackwardGroup, 3, 4);
-            VerifyGroup(extNetInfo, 3, ExtLaneFlags.Outer | ExtLaneFlags.ForwardGroup, 5, 6, 7);
-
-            VerifyLane(extNetInfo, 0, ExtLaneFlags.Outer | ExtLaneFlags.BackwardGroup);
-            VerifyLane(extNetInfo, 1, ExtLaneFlags.DisplacedInner | ExtLaneFlags.AllowCFI | ExtLaneFlags.ForwardGroup);
-            VerifyLane(extNetInfo, 2, ExtLaneFlags.DisplacedInner | ExtLaneFlags.AllowCFI | ExtLaneFlags.ForwardGroup);
-            VerifyLane(extNetInfo, 3, ExtLaneFlags.DisplacedInner | ExtLaneFlags.AllowCFI | ExtLaneFlags.BackwardGroup);
-            VerifyLane(extNetInfo, 4, ExtLaneFlags.DisplacedInner | ExtLaneFlags.AllowCFI | ExtLaneFlags.BackwardGroup);
-            VerifyLane(extNetInfo, 5, ExtLaneFlags.Outer | ExtLaneFlags.ForwardGroup);
-            VerifyLane(extNetInfo, 6, ExtLaneFlags.Outer | ExtLaneFlags.ForwardGroup);
-            VerifyLane(extNetInfo, 7, ExtLaneFlags.Outer | ExtLaneFlags.ForwardGroup);
-        }
-
-        [TestMethod]
-        public void TestUncontrolledDisplaced() {
-
-            var lanes = new[] {
-                CarLane(0f, true),
-                CarLane(3f, false),
-                CarLane(6f, true),
-                CarLane(9f, false),
-            };
-
-            var extNetInfo = new ExtNetInfo(lanes);
-
-            Assert.AreEqual(lanes.Length, extNetInfo.m_extLanes.Length);
-            VerifySequence(extNetInfo.m_sortedLanes, 0, 1, 2, 3);
-
-            Assert.AreEqual(ExtLaneFlags.Outer | ExtLaneFlags.DisplacedInner | ExtLaneFlags.ForbidControlledLanes | ExtLaneFlags.ForwardGroup, extNetInfo.m_forwardExtLaneFlags);
-            Assert.AreEqual(ExtLaneFlags.Outer | ExtLaneFlags.DisplacedInner | ExtLaneFlags.ForbidControlledLanes | ExtLaneFlags.BackwardGroup, extNetInfo.m_backwardExtLaneFlags);
-            Assert.AreEqual(ExtLaneFlags.Outer | ExtLaneFlags.DisplacedInner | ExtLaneFlags.ForbidControlledLanes | ExtLaneFlags.ForwardGroup | ExtLaneFlags.BackwardGroup, extNetInfo.m_extLaneFlags);
-
-            Assert.AreEqual(4, extNetInfo.m_laneGroups.Length);
-            VerifyGroup(extNetInfo, 0, ExtLaneFlags.Outer | ExtLaneFlags.BackwardGroup, 0);
-            VerifyGroup(extNetInfo, 1, ExtLaneFlags.DisplacedInner | ExtLaneFlags.ForbidControlledLanes | ExtLaneFlags.ForwardGroup, 1);
-            VerifyGroup(extNetInfo, 2, ExtLaneFlags.DisplacedInner | ExtLaneFlags.ForbidControlledLanes | ExtLaneFlags.BackwardGroup, 2);
-            VerifyGroup(extNetInfo, 3, ExtLaneFlags.Outer | ExtLaneFlags.ForwardGroup, 3);
-
-            VerifyLane(extNetInfo, 0, ExtLaneFlags.Outer | ExtLaneFlags.BackwardGroup);
-            VerifyLane(extNetInfo, 1, ExtLaneFlags.DisplacedInner | ExtLaneFlags.ForbidControlledLanes | ExtLaneFlags.ForwardGroup);
-            VerifyLane(extNetInfo, 2, ExtLaneFlags.DisplacedInner | ExtLaneFlags.ForbidControlledLanes | ExtLaneFlags.BackwardGroup);
-            VerifyLane(extNetInfo, 3, ExtLaneFlags.Outer | ExtLaneFlags.ForwardGroup);
-        }
-
-        [TestMethod]
-        public void TestForwardTurnaround() {
-
-            var lanes = new[] {
-                CarLane(0f, false),
-                CarLane(3f, true),
-                CarLane(6f, true),
-                CarLane(9f, false),
-                CarLane(12f, false),
-            };
-
-            var extNetInfo = new ExtNetInfo(lanes);
-
-            Assert.AreEqual(lanes.Length, extNetInfo.m_extLanes.Length);
-            VerifySequence(extNetInfo.m_sortedLanes, 0, 1, 2, 3, 4);
-
-            Assert.AreEqual(ExtLaneFlags.Outer | ExtLaneFlags.DisplacedOuter | ExtLaneFlags.ForwardGroup, extNetInfo.m_forwardExtLaneFlags);
-            Assert.AreEqual(ExtLaneFlags.Outer | ExtLaneFlags.BackwardGroup, extNetInfo.m_backwardExtLaneFlags);
-            Assert.AreEqual(ExtLaneFlags.Outer | ExtLaneFlags.DisplacedOuter | ExtLaneFlags.ForwardGroup | ExtLaneFlags.BackwardGroup, extNetInfo.m_extLaneFlags);
-
-            Assert.AreEqual(3, extNetInfo.m_laneGroups.Length);
-            VerifyGroup(extNetInfo, 0, ExtLaneFlags.DisplacedOuter | ExtLaneFlags.ForwardGroup, 0);
-            VerifyGroup(extNetInfo, 1, ExtLaneFlags.Outer | ExtLaneFlags.BackwardGroup, 1, 2);
-            VerifyGroup(extNetInfo, 2, ExtLaneFlags.Outer | ExtLaneFlags.ForwardGroup, 3, 4);
-
-            VerifyLane(extNetInfo, 0, ExtLaneFlags.DisplacedOuter | ExtLaneFlags.ForwardGroup);
-            VerifyLane(extNetInfo, 1, ExtLaneFlags.Outer | ExtLaneFlags.BackwardGroup);
-            VerifyLane(extNetInfo, 2, ExtLaneFlags.Outer | ExtLaneFlags.BackwardGroup);
-            VerifyLane(extNetInfo, 3, ExtLaneFlags.Outer | ExtLaneFlags.ForwardGroup);
-            VerifyLane(extNetInfo, 4, ExtLaneFlags.Outer | ExtLaneFlags.ForwardGroup);
-        }
-
-        [TestMethod]
-        public void TestBackwardTurnaround() {
-
-            var lanes = new[] {
-                CarLane(0f, true),
-                CarLane(3f, true),
-                CarLane(6f, false),
-                CarLane(9f, false),
-                CarLane(12f, true),
-            };
-
-            var extNetInfo = new ExtNetInfo(lanes);
-
-            Assert.AreEqual(lanes.Length, extNetInfo.m_extLanes.Length);
-            VerifySequence(extNetInfo.m_sortedLanes, 0, 1, 2, 3, 4);
-
-            Assert.AreEqual(ExtLaneFlags.Outer | ExtLaneFlags.ForwardGroup, extNetInfo.m_forwardExtLaneFlags);
-            Assert.AreEqual(ExtLaneFlags.Outer | ExtLaneFlags.DisplacedOuter | ExtLaneFlags.BackwardGroup, extNetInfo.m_backwardExtLaneFlags);
-            Assert.AreEqual(ExtLaneFlags.Outer | ExtLaneFlags.DisplacedOuter | ExtLaneFlags.ForwardGroup | ExtLaneFlags.BackwardGroup, extNetInfo.m_extLaneFlags);
-
-            Assert.AreEqual(3, extNetInfo.m_laneGroups.Length);
-            VerifyGroup(extNetInfo, 0, ExtLaneFlags.Outer | ExtLaneFlags.BackwardGroup, 0, 1);
-            VerifyGroup(extNetInfo, 1, ExtLaneFlags.Outer | ExtLaneFlags.ForwardGroup, 2, 3);
-            VerifyGroup(extNetInfo, 2, ExtLaneFlags.DisplacedOuter | ExtLaneFlags.BackwardGroup, 4);
-
-            VerifyLane(extNetInfo, 0, ExtLaneFlags.Outer | ExtLaneFlags.BackwardGroup);
-            VerifyLane(extNetInfo, 1, ExtLaneFlags.Outer | ExtLaneFlags.BackwardGroup);
-            VerifyLane(extNetInfo, 2, ExtLaneFlags.Outer | ExtLaneFlags.ForwardGroup);
-            VerifyLane(extNetInfo, 3, ExtLaneFlags.Outer | ExtLaneFlags.ForwardGroup);
-            VerifyLane(extNetInfo, 4, ExtLaneFlags.DisplacedOuter | ExtLaneFlags.BackwardGroup);
-        }
-
-        [TestMethod]
-        public void TestDualTurnaround() {
-
-            var lanes = new[] {
-                CarLane(0f, false),
-                CarLane(3f, true),
-                CarLane(6f, true),
-                CarLane(9f, false),
-                CarLane(12f, false),
-                CarLane(15f, true),
-            };
-
-            var extNetInfo = new ExtNetInfo(lanes);
-
-            Assert.AreEqual(lanes.Length, extNetInfo.m_extLanes.Length);
-            VerifySequence(extNetInfo.m_sortedLanes, 0, 1, 2, 3, 4, 5);
-
-            Assert.AreEqual(ExtLaneFlags.Outer | ExtLaneFlags.DisplacedOuter | ExtLaneFlags.ForwardGroup, extNetInfo.m_forwardExtLaneFlags);
-            Assert.AreEqual(ExtLaneFlags.Outer | ExtLaneFlags.DisplacedOuter | ExtLaneFlags.BackwardGroup, extNetInfo.m_backwardExtLaneFlags);
-            Assert.AreEqual(ExtLaneFlags.Outer | ExtLaneFlags.DisplacedOuter | ExtLaneFlags.ForwardGroup | ExtLaneFlags.BackwardGroup, extNetInfo.m_extLaneFlags);
-
-            Assert.AreEqual(4, extNetInfo.m_laneGroups.Length);
-            VerifyGroup(extNetInfo, 0, ExtLaneFlags.DisplacedOuter | ExtLaneFlags.ForwardGroup, 0);
-            VerifyGroup(extNetInfo, 1, ExtLaneFlags.Outer | ExtLaneFlags.BackwardGroup, 1, 2);
-            VerifyGroup(extNetInfo, 2, ExtLaneFlags.Outer | ExtLaneFlags.ForwardGroup, 3, 4);
-            VerifyGroup(extNetInfo, 3, ExtLaneFlags.DisplacedOuter | ExtLaneFlags.BackwardGroup, 5);
-
-            VerifyLane(extNetInfo, 0, ExtLaneFlags.DisplacedOuter | ExtLaneFlags.ForwardGroup);
-            VerifyLane(extNetInfo, 1, ExtLaneFlags.Outer | ExtLaneFlags.BackwardGroup);
-            VerifyLane(extNetInfo, 2, ExtLaneFlags.Outer | ExtLaneFlags.BackwardGroup);
-            VerifyLane(extNetInfo, 3, ExtLaneFlags.Outer | ExtLaneFlags.ForwardGroup);
-            VerifyLane(extNetInfo, 4, ExtLaneFlags.Outer | ExtLaneFlags.ForwardGroup);
-            VerifyLane(extNetInfo, 5, ExtLaneFlags.DisplacedOuter | ExtLaneFlags.BackwardGroup);
-        }
-
-        [TestMethod]
-        public void TestInnerDisplacedBusLanes() {
-
-            var lanes = new[] {
-                CarLane(0f, true),
-                CarLane(3f, true),
-                ThruBusLane(6f, false),
-                ThruBusLane(9f, false),
-                PedestrianLane(13.5f, 6f),
-                ThruBusLane(18f, true),
-                ThruBusLane(21f, true),
-                CarLane(24f, false),
-                CarLane(27f, false),
-            };
-
-            var extNetInfo = new ExtNetInfo(lanes);
-
-            Assert.AreEqual(lanes.Length, extNetInfo.m_extLanes.Length);
-            VerifySequence(extNetInfo.m_sortedLanes, 0, 1, 2, 3, 4, 5, 6, 7, 8);
-
-            Assert.AreEqual(ExtLaneFlags.Outer | ExtLaneFlags.DisplacedInner | ExtLaneFlags.ForwardGroup, extNetInfo.m_forwardExtLaneFlags);
-            Assert.AreEqual(ExtLaneFlags.Outer | ExtLaneFlags.DisplacedInner | ExtLaneFlags.BackwardGroup, extNetInfo.m_backwardExtLaneFlags);
-            Assert.AreEqual(ExtLaneFlags.Outer | ExtLaneFlags.DisplacedInner | ExtLaneFlags.ForwardGroup | ExtLaneFlags.BackwardGroup, extNetInfo.m_extLaneFlags);
-
-            Assert.AreEqual(4, extNetInfo.m_laneGroups.Length);
-            VerifyGroup(extNetInfo, 0, ExtLaneFlags.Outer | ExtLaneFlags.BackwardGroup, 0, 1);
-            VerifyGroup(extNetInfo, 1, ExtLaneFlags.DisplacedInner | ExtLaneFlags.ForwardGroup, 2, 3);
-            VerifyGroup(extNetInfo, 2, ExtLaneFlags.DisplacedInner | ExtLaneFlags.BackwardGroup, 5, 6);
-            VerifyGroup(extNetInfo, 3, ExtLaneFlags.Outer | ExtLaneFlags.ForwardGroup, 7, 8);
-
-            VerifyLane(extNetInfo, 0, ExtLaneFlags.Outer | ExtLaneFlags.BackwardGroup);
-            VerifyLane(extNetInfo, 1, ExtLaneFlags.Outer | ExtLaneFlags.BackwardGroup);
-            VerifyLane(extNetInfo, 2, ExtLaneFlags.DisplacedInner | ExtLaneFlags.ForwardGroup);
-            VerifyLane(extNetInfo, 3, ExtLaneFlags.DisplacedInner | ExtLaneFlags.ForwardGroup);
-            VerifyLane(extNetInfo, 4, ExtLaneFlags.None);
-            VerifyLane(extNetInfo, 5, ExtLaneFlags.DisplacedInner | ExtLaneFlags.BackwardGroup);
-            VerifyLane(extNetInfo, 6, ExtLaneFlags.DisplacedInner | ExtLaneFlags.BackwardGroup);
-            VerifyLane(extNetInfo, 7, ExtLaneFlags.Outer | ExtLaneFlags.ForwardGroup);
-            VerifyLane(extNetInfo, 8, ExtLaneFlags.Outer | ExtLaneFlags.ForwardGroup);
         }
 
         [TestMethod]
@@ -340,23 +130,433 @@ namespace TMUnitTest.ExtPrefabs {
             Assert.AreEqual(lanes.Length, extNetInfo.m_extLanes.Length);
             VerifySequence(extNetInfo.m_sortedLanes, 0, 2, 4, 6, 8, 7, 5, 3, 1);
 
-            Assert.AreEqual(ExtLaneFlags.Outer | ExtLaneFlags.ForwardGroup, extNetInfo.m_forwardExtLaneFlags);
-            Assert.AreEqual(ExtLaneFlags.Outer | ExtLaneFlags.BackwardGroup, extNetInfo.m_backwardExtLaneFlags);
-            Assert.AreEqual(ExtLaneFlags.Outer | ExtLaneFlags.ForwardGroup | ExtLaneFlags.BackwardGroup, extNetInfo.m_extLaneFlags);
+            Assert.AreEqual(ExtLaneFlags.OuterForward, extNetInfo.m_forwardExtLaneFlags);
+            Assert.AreEqual(ExtLaneFlags.OuterBackward, extNetInfo.m_backwardExtLaneFlags);
+            Assert.AreEqual(ExtLaneFlags.OuterForward | ExtLaneFlags.OuterBackward, extNetInfo.m_extLaneFlags);
 
             Assert.AreEqual(2, extNetInfo.m_laneGroups.Length);
-            VerifyGroup(extNetInfo, 0, ExtLaneFlags.Outer | ExtLaneFlags.ForwardGroup, 4, 6);
-            VerifyGroup(extNetInfo, 1, ExtLaneFlags.Outer | ExtLaneFlags.BackwardGroup, 7, 5);
+            VerifyGroup(extNetInfo, 0, ExtLaneFlags.OuterForward, 4, 6);
+            VerifyGroup(extNetInfo, 1, ExtLaneFlags.OuterBackward, 7, 5);
 
             VerifyLane(extNetInfo, 0, ExtLaneFlags.None);
             VerifyLane(extNetInfo, 1, ExtLaneFlags.None);
             VerifyLane(extNetInfo, 2, ExtLaneFlags.None);
             VerifyLane(extNetInfo, 3, ExtLaneFlags.None);
-            VerifyLane(extNetInfo, 4, ExtLaneFlags.Outer | ExtLaneFlags.ForwardGroup);
-            VerifyLane(extNetInfo, 5, ExtLaneFlags.Outer | ExtLaneFlags.BackwardGroup);
-            VerifyLane(extNetInfo, 6, ExtLaneFlags.Outer | ExtLaneFlags.ForwardGroup);
-            VerifyLane(extNetInfo, 7, ExtLaneFlags.Outer | ExtLaneFlags.BackwardGroup);
+            VerifyLane(extNetInfo, 4, ExtLaneFlags.OuterForward);
+            VerifyLane(extNetInfo, 5, ExtLaneFlags.OuterBackward);
+            VerifyLane(extNetInfo, 6, ExtLaneFlags.OuterForward);
+            VerifyLane(extNetInfo, 7, ExtLaneFlags.OuterBackward);
             VerifyLane(extNetInfo, 8, ExtLaneFlags.None);
+        }
+
+        [TestMethod]
+        public void TestCFI() {
+
+            var lanes = new[] {
+                CarLane(0f, true),
+                ThruCarLane(3f, false),
+                ThruCarLane(6f, false),
+                ThruCarLane(9f, true),
+                ThruCarLane(12f, true),
+                CarLane(15f, false),
+                CarLane(18f, false),
+                CarLane(21f, false),
+            };
+
+            var extNetInfo = new ExtNetInfo(lanes);
+
+            Assert.AreEqual(lanes.Length, extNetInfo.m_extLanes.Length);
+            VerifySequence(extNetInfo.m_sortedLanes, 0, 1, 2, 3, 4, 5, 6, 7);
+
+            Assert.AreEqual(ExtLaneFlags.OuterForward | ExtLaneFlags.DisplacedInnerForward | ExtLaneFlags.AllowCFI, extNetInfo.m_forwardExtLaneFlags);
+            Assert.AreEqual(ExtLaneFlags.OuterBackward | ExtLaneFlags.DisplacedInnerBackward | ExtLaneFlags.AllowCFI, extNetInfo.m_backwardExtLaneFlags);
+            Assert.AreEqual(ExtLaneFlags.Outer | ExtLaneFlags.DisplacedInner | ExtLaneFlags.AllowCFI | ExtLaneFlags.ForwardGroup | ExtLaneFlags.BackwardGroup, extNetInfo.m_extLaneFlags);
+
+            Assert.AreEqual(4, extNetInfo.m_laneGroups.Length);
+            VerifyGroup(extNetInfo, 0, ExtLaneFlags.OuterBackward, 0);
+            VerifyGroup(extNetInfo, 1, ExtLaneFlags.DisplacedInnerForward | ExtLaneFlags.AllowCFI, 1, 2);
+            VerifyGroup(extNetInfo, 2, ExtLaneFlags.DisplacedInnerBackward | ExtLaneFlags.AllowCFI, 3, 4);
+            VerifyGroup(extNetInfo, 3, ExtLaneFlags.OuterForward, 5, 6, 7);
+
+            VerifyLane(extNetInfo, 0, ExtLaneFlags.OuterBackward);
+            VerifyLane(extNetInfo, 1, ExtLaneFlags.DisplacedInnerForward | ExtLaneFlags.AllowCFI);
+            VerifyLane(extNetInfo, 2, ExtLaneFlags.DisplacedInnerForward | ExtLaneFlags.AllowCFI);
+            VerifyLane(extNetInfo, 3, ExtLaneFlags.DisplacedInnerBackward | ExtLaneFlags.AllowCFI);
+            VerifyLane(extNetInfo, 4, ExtLaneFlags.DisplacedInnerBackward | ExtLaneFlags.AllowCFI);
+            VerifyLane(extNetInfo, 5, ExtLaneFlags.OuterForward);
+            VerifyLane(extNetInfo, 6, ExtLaneFlags.OuterForward);
+            VerifyLane(extNetInfo, 7, ExtLaneFlags.OuterForward);
+        }
+
+        [TestMethod]
+        public void TestUncontrolledDisplaced() {
+
+            var lanes = new[] {
+                CarLane(0f, true),
+                CarLane(3f, false),
+                CarLane(6f, true),
+                CarLane(9f, false),
+            };
+
+            var extNetInfo = new ExtNetInfo(lanes);
+
+            Assert.AreEqual(lanes.Length, extNetInfo.m_extLanes.Length);
+            VerifySequence(extNetInfo.m_sortedLanes, 0, 1, 2, 3);
+
+            Assert.AreEqual(ExtLaneFlags.OuterForward | ExtLaneFlags.DisplacedInnerForward | ExtLaneFlags.ForbidControlledLanes, extNetInfo.m_forwardExtLaneFlags);
+            Assert.AreEqual(ExtLaneFlags.OuterBackward | ExtLaneFlags.DisplacedInnerBackward | ExtLaneFlags.ForbidControlledLanes, extNetInfo.m_backwardExtLaneFlags);
+            Assert.AreEqual(ExtLaneFlags.Outer | ExtLaneFlags.DisplacedInner | ExtLaneFlags.ForbidControlledLanes | ExtLaneFlags.ForwardGroup | ExtLaneFlags.BackwardGroup, extNetInfo.m_extLaneFlags);
+
+            Assert.AreEqual(4, extNetInfo.m_laneGroups.Length);
+            VerifyGroup(extNetInfo, 0, ExtLaneFlags.OuterBackward, 0);
+            VerifyGroup(extNetInfo, 1, ExtLaneFlags.DisplacedInnerForward | ExtLaneFlags.ForbidControlledLanes, 1);
+            VerifyGroup(extNetInfo, 2, ExtLaneFlags.DisplacedInnerBackward | ExtLaneFlags.ForbidControlledLanes, 2);
+            VerifyGroup(extNetInfo, 3, ExtLaneFlags.OuterForward, 3);
+
+            VerifyLane(extNetInfo, 0, ExtLaneFlags.OuterBackward);
+            VerifyLane(extNetInfo, 1, ExtLaneFlags.DisplacedInnerForward | ExtLaneFlags.ForbidControlledLanes);
+            VerifyLane(extNetInfo, 2, ExtLaneFlags.DisplacedInnerBackward | ExtLaneFlags.ForbidControlledLanes);
+            VerifyLane(extNetInfo, 3, ExtLaneFlags.OuterForward);
+        }
+
+        [TestMethod]
+        public void TestForwardTurnaround() {
+
+            var lanes = new[] {
+                CarLane(0f, false),
+                CarLane(3f, true),
+                CarLane(6f, true),
+                CarLane(9f, false),
+                CarLane(12f, false),
+            };
+
+            var extNetInfo = new ExtNetInfo(lanes);
+
+            Assert.AreEqual(lanes.Length, extNetInfo.m_extLanes.Length);
+            VerifySequence(extNetInfo.m_sortedLanes, 0, 1, 2, 3, 4);
+
+            Assert.AreEqual(ExtLaneFlags.OuterForward | ExtLaneFlags.DisplacedOuterForward, extNetInfo.m_forwardExtLaneFlags);
+            Assert.AreEqual(ExtLaneFlags.OuterBackward, extNetInfo.m_backwardExtLaneFlags);
+            Assert.AreEqual(ExtLaneFlags.OuterForward | ExtLaneFlags.DisplacedOuterForward | ExtLaneFlags.OuterBackward | ExtLaneFlags.DisplacedOuterBackward, extNetInfo.m_extLaneFlags);
+
+            Assert.AreEqual(3, extNetInfo.m_laneGroups.Length);
+            VerifyGroup(extNetInfo, 0, ExtLaneFlags.DisplacedOuterForward, 0);
+            VerifyGroup(extNetInfo, 1, ExtLaneFlags.OuterBackward, 1, 2);
+            VerifyGroup(extNetInfo, 2, ExtLaneFlags.OuterForward, 3, 4);
+
+            VerifyLane(extNetInfo, 0, ExtLaneFlags.DisplacedOuterForward);
+            VerifyLane(extNetInfo, 1, ExtLaneFlags.OuterBackward);
+            VerifyLane(extNetInfo, 2, ExtLaneFlags.OuterBackward);
+            VerifyLane(extNetInfo, 3, ExtLaneFlags.OuterForward);
+            VerifyLane(extNetInfo, 4, ExtLaneFlags.OuterForward);
+        }
+
+        [TestMethod]
+        public void TestBackwardTurnaround() {
+
+            var lanes = new[] {
+                CarLane(0f, true),
+                CarLane(3f, true),
+                CarLane(6f, false),
+                CarLane(9f, false),
+                CarLane(12f, true),
+            };
+
+            var extNetInfo = new ExtNetInfo(lanes);
+
+            Assert.AreEqual(lanes.Length, extNetInfo.m_extLanes.Length);
+            VerifySequence(extNetInfo.m_sortedLanes, 0, 1, 2, 3, 4);
+
+            Assert.AreEqual(ExtLaneFlags.OuterForward, extNetInfo.m_forwardExtLaneFlags);
+            Assert.AreEqual(ExtLaneFlags.OuterBackward | ExtLaneFlags.DisplacedOuterBackward, extNetInfo.m_backwardExtLaneFlags);
+            Assert.AreEqual(ExtLaneFlags.OuterForward | ExtLaneFlags.DisplacedOuterForward | ExtLaneFlags.OuterBackward | ExtLaneFlags.DisplacedOuterBackward, extNetInfo.m_extLaneFlags);
+
+            Assert.AreEqual(3, extNetInfo.m_laneGroups.Length);
+            VerifyGroup(extNetInfo, 0, ExtLaneFlags.OuterBackward, 0, 1);
+            VerifyGroup(extNetInfo, 1, ExtLaneFlags.OuterForward, 2, 3);
+            VerifyGroup(extNetInfo, 2, ExtLaneFlags.DisplacedOuterBackward, 4);
+
+            VerifyLane(extNetInfo, 0, ExtLaneFlags.OuterBackward);
+            VerifyLane(extNetInfo, 1, ExtLaneFlags.OuterBackward);
+            VerifyLane(extNetInfo, 2, ExtLaneFlags.OuterForward);
+            VerifyLane(extNetInfo, 3, ExtLaneFlags.OuterForward);
+            VerifyLane(extNetInfo, 4, ExtLaneFlags.DisplacedOuterBackward);
+        }
+
+        [TestMethod]
+        public void TestDualTurnaround() {
+
+            var lanes = new[] {
+                CarLane(0f, false),
+                CarLane(3f, true),
+                CarLane(6f, true),
+                CarLane(9f, false),
+                CarLane(12f, false),
+                CarLane(15f, true),
+            };
+
+            var extNetInfo = new ExtNetInfo(lanes);
+
+            Assert.AreEqual(lanes.Length, extNetInfo.m_extLanes.Length);
+            VerifySequence(extNetInfo.m_sortedLanes, 0, 1, 2, 3, 4, 5);
+
+            Assert.AreEqual(ExtLaneFlags.OuterForward | ExtLaneFlags.DisplacedOuterForward, extNetInfo.m_forwardExtLaneFlags);
+            Assert.AreEqual(ExtLaneFlags.OuterBackward | ExtLaneFlags.DisplacedOuterBackward, extNetInfo.m_backwardExtLaneFlags);
+            Assert.AreEqual(ExtLaneFlags.OuterForward | ExtLaneFlags.DisplacedOuterForward | ExtLaneFlags.OuterBackward | ExtLaneFlags.DisplacedOuterBackward, extNetInfo.m_extLaneFlags);
+
+            Assert.AreEqual(4, extNetInfo.m_laneGroups.Length);
+            VerifyGroup(extNetInfo, 0, ExtLaneFlags.DisplacedOuterForward, 0);
+            VerifyGroup(extNetInfo, 1, ExtLaneFlags.OuterBackward, 1, 2);
+            VerifyGroup(extNetInfo, 2, ExtLaneFlags.OuterForward, 3, 4);
+            VerifyGroup(extNetInfo, 3, ExtLaneFlags.DisplacedOuterBackward, 5);
+
+            VerifyLane(extNetInfo, 0, ExtLaneFlags.DisplacedOuterForward);
+            VerifyLane(extNetInfo, 1, ExtLaneFlags.OuterBackward);
+            VerifyLane(extNetInfo, 2, ExtLaneFlags.OuterBackward);
+            VerifyLane(extNetInfo, 3, ExtLaneFlags.OuterForward);
+            VerifyLane(extNetInfo, 4, ExtLaneFlags.OuterForward);
+            VerifyLane(extNetInfo, 5, ExtLaneFlags.DisplacedOuterBackward);
+        }
+
+        [TestMethod]
+        public void TestInnerDisplacedBusLanes() {
+
+            var lanes = new[] {
+                CarLane(0f, true),
+                CarLane(3f, true),
+                ThruBusLane(6f, false),
+                ThruBusLane(9f, false),
+                PedestrianLane(13.5f, 6f),
+                ThruBusLane(18f, true),
+                ThruBusLane(21f, true),
+                CarLane(24f, false),
+                CarLane(27f, false),
+            };
+
+            var extNetInfo = new ExtNetInfo(lanes);
+
+            Assert.AreEqual(lanes.Length, extNetInfo.m_extLanes.Length);
+            VerifySequence(extNetInfo.m_sortedLanes, 0, 1, 2, 3, 4, 5, 6, 7, 8);
+
+            Assert.AreEqual(ExtLaneFlags.OuterForward | ExtLaneFlags.DisplacedInnerForward, extNetInfo.m_forwardExtLaneFlags);
+            Assert.AreEqual(ExtLaneFlags.OuterBackward | ExtLaneFlags.DisplacedInnerBackward, extNetInfo.m_backwardExtLaneFlags);
+            Assert.AreEqual(ExtLaneFlags.OuterForward | ExtLaneFlags.DisplacedInnerForward | ExtLaneFlags.OuterBackward | ExtLaneFlags.DisplacedInnerBackward, extNetInfo.m_extLaneFlags);
+
+            Assert.AreEqual(4, extNetInfo.m_laneGroups.Length);
+            VerifyGroup(extNetInfo, 0, ExtLaneFlags.OuterBackward, 0, 1);
+            VerifyGroup(extNetInfo, 1, ExtLaneFlags.DisplacedInnerForward, 2, 3);
+            VerifyGroup(extNetInfo, 2, ExtLaneFlags.DisplacedInnerBackward, 5, 6);
+            VerifyGroup(extNetInfo, 3, ExtLaneFlags.OuterForward, 7, 8);
+
+            VerifyLane(extNetInfo, 0, ExtLaneFlags.OuterBackward);
+            VerifyLane(extNetInfo, 1, ExtLaneFlags.OuterBackward);
+            VerifyLane(extNetInfo, 2, ExtLaneFlags.DisplacedInnerForward);
+            VerifyLane(extNetInfo, 3, ExtLaneFlags.DisplacedInnerForward);
+            VerifyLane(extNetInfo, 4, ExtLaneFlags.None);
+            VerifyLane(extNetInfo, 5, ExtLaneFlags.DisplacedInnerBackward);
+            VerifyLane(extNetInfo, 6, ExtLaneFlags.DisplacedInnerBackward);
+            VerifyLane(extNetInfo, 7, ExtLaneFlags.OuterForward);
+            VerifyLane(extNetInfo, 8, ExtLaneFlags.OuterForward);
+        }
+
+        [TestMethod]
+        public void TestFourCarriageway() {
+
+            var lanes = new[] {
+                PedestrianLane(0f, 3f),
+                ParkingLane(3f, true, 3f),
+                CarLane(6f, true),
+                PedestrianLane(9f, 3f),
+                ThruCarLane(12f, true),
+                ThruCarLane(15f, true),
+                RaisedMedianLane(18f),
+                ThruCarLane(21f, false),
+                ThruCarLane(24f, false),
+                PedestrianLane(27f, 3f),
+                CarLane(30f, false),
+                ParkingLane(33f, false, 3f),
+                PedestrianLane(36f, 3f),
+            };
+
+            var extNetInfo = new ExtNetInfo(lanes);
+
+            Assert.AreEqual(lanes.Length, extNetInfo.m_extLanes.Length);
+            VerifySequence(extNetInfo.m_sortedLanes, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12);
+
+            Assert.AreEqual(ExtLaneFlags.OuterForward | ExtLaneFlags.InnerForward | ExtLaneFlags.AllowServiceLane | ExtLaneFlags.AllowExpressLane, extNetInfo.m_forwardExtLaneFlags);
+            Assert.AreEqual(ExtLaneFlags.OuterBackward | ExtLaneFlags.InnerBackward | ExtLaneFlags.AllowServiceLane | ExtLaneFlags.AllowExpressLane, extNetInfo.m_backwardExtLaneFlags);
+            Assert.AreEqual(ExtLaneFlags.Outer | ExtLaneFlags.Inner | ExtLaneFlags.AllowServiceLane | ExtLaneFlags.AllowExpressLane | ExtLaneFlags.ForwardGroup | ExtLaneFlags.BackwardGroup, extNetInfo.m_extLaneFlags);
+
+            Assert.AreEqual(4, extNetInfo.m_laneGroups.Length);
+            VerifyGroup(extNetInfo, 0, ExtLaneFlags.OuterBackward | ExtLaneFlags.AllowServiceLane, 2);
+            VerifyGroup(extNetInfo, 1, ExtLaneFlags.InnerBackward | ExtLaneFlags.AllowExpressLane, 4, 5);
+            VerifyGroup(extNetInfo, 2, ExtLaneFlags.InnerForward | ExtLaneFlags.AllowExpressLane, 7, 8);
+            VerifyGroup(extNetInfo, 3, ExtLaneFlags.OuterForward | ExtLaneFlags.AllowServiceLane, 10);
+
+            VerifyLane(extNetInfo, 0, ExtLaneFlags.None);
+            VerifyLane(extNetInfo, 1, ExtLaneFlags.None);
+            VerifyLane(extNetInfo, 2, ExtLaneFlags.OuterBackward | ExtLaneFlags.AllowServiceLane);
+            VerifyLane(extNetInfo, 3, ExtLaneFlags.None);
+            VerifyLane(extNetInfo, 4, ExtLaneFlags.InnerBackward | ExtLaneFlags.AllowExpressLane);
+            VerifyLane(extNetInfo, 5, ExtLaneFlags.InnerBackward | ExtLaneFlags.AllowExpressLane);
+            VerifyLane(extNetInfo, 6, ExtLaneFlags.None);
+            VerifyLane(extNetInfo, 7, ExtLaneFlags.InnerForward | ExtLaneFlags.AllowExpressLane);
+            VerifyLane(extNetInfo, 8, ExtLaneFlags.InnerForward | ExtLaneFlags.AllowExpressLane);
+            VerifyLane(extNetInfo, 9, ExtLaneFlags.None);
+            VerifyLane(extNetInfo, 10, ExtLaneFlags.OuterForward | ExtLaneFlags.AllowServiceLane);
+            VerifyLane(extNetInfo, 11, ExtLaneFlags.None);
+            VerifyLane(extNetInfo, 12, ExtLaneFlags.None);
+        }
+
+        [TestMethod]
+        public void TestThreeCarriageway() {
+
+            var lanes = new[] {
+                PedestrianLane(0f, 3f),
+                ParkingLane(3f, true, 3f),
+                CarLane(6f, true),
+                PedestrianLane(9f, 3f),
+                ThruCarLane(12f, true),
+                ThruCarLane(15f, true),
+                ThruCarLane(18f, false),
+                ThruCarLane(21f, false),
+                PedestrianLane(24f, 3f),
+                CarLane(27f, false),
+                ParkingLane(30f, false, 3f),
+                PedestrianLane(33f, 3f),
+            };
+
+            var extNetInfo = new ExtNetInfo(lanes);
+
+            Assert.AreEqual(lanes.Length, extNetInfo.m_extLanes.Length);
+            VerifySequence(extNetInfo.m_sortedLanes, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11);
+
+            Assert.AreEqual(ExtLaneFlags.OuterForward | ExtLaneFlags.InnerForward | ExtLaneFlags.AllowServiceLane | ExtLaneFlags.AllowExpressLane, extNetInfo.m_forwardExtLaneFlags);
+            Assert.AreEqual(ExtLaneFlags.OuterBackward | ExtLaneFlags.InnerBackward | ExtLaneFlags.AllowServiceLane | ExtLaneFlags.AllowExpressLane, extNetInfo.m_backwardExtLaneFlags);
+            Assert.AreEqual(ExtLaneFlags.Outer | ExtLaneFlags.Inner | ExtLaneFlags.AllowServiceLane | ExtLaneFlags.AllowExpressLane | ExtLaneFlags.ForwardGroup | ExtLaneFlags.BackwardGroup, extNetInfo.m_extLaneFlags);
+
+            Assert.AreEqual(4, extNetInfo.m_laneGroups.Length);
+            VerifyGroup(extNetInfo, 0, ExtLaneFlags.OuterBackward | ExtLaneFlags.AllowServiceLane, 2);
+            VerifyGroup(extNetInfo, 1, ExtLaneFlags.InnerBackward | ExtLaneFlags.AllowExpressLane, 4, 5);
+            VerifyGroup(extNetInfo, 2, ExtLaneFlags.InnerForward | ExtLaneFlags.AllowExpressLane, 6, 7);
+            VerifyGroup(extNetInfo, 3, ExtLaneFlags.OuterForward | ExtLaneFlags.AllowServiceLane, 9);
+
+            VerifyLane(extNetInfo, 0, ExtLaneFlags.None);
+            VerifyLane(extNetInfo, 1, ExtLaneFlags.None);
+            VerifyLane(extNetInfo, 2, ExtLaneFlags.OuterBackward | ExtLaneFlags.AllowServiceLane);
+            VerifyLane(extNetInfo, 3, ExtLaneFlags.None);
+            VerifyLane(extNetInfo, 4, ExtLaneFlags.InnerBackward | ExtLaneFlags.AllowExpressLane);
+            VerifyLane(extNetInfo, 5, ExtLaneFlags.InnerBackward | ExtLaneFlags.AllowExpressLane);
+            VerifyLane(extNetInfo, 6, ExtLaneFlags.InnerForward | ExtLaneFlags.AllowExpressLane);
+            VerifyLane(extNetInfo, 7, ExtLaneFlags.InnerForward | ExtLaneFlags.AllowExpressLane);
+            VerifyLane(extNetInfo, 8, ExtLaneFlags.None);
+            VerifyLane(extNetInfo, 9, ExtLaneFlags.OuterForward | ExtLaneFlags.AllowServiceLane);
+            VerifyLane(extNetInfo, 10, ExtLaneFlags.None);
+            VerifyLane(extNetInfo, 11, ExtLaneFlags.None);
+        }
+
+        [TestMethod]
+        public void TestSixCarriageway() {
+
+            var lanes = new[] {
+                CarLane(0f, true),
+                CarLane(3f, true),
+                RaisedMedianLane(6f),
+                ThruCarLane(9f, true),
+                ThruCarLane(12f, true),
+                ThruBusLane(15f, false),
+                ThruBusLane(18f, false),
+                PedestrianLane(22.5f, 6f),
+                ThruBusLane(27f, true),
+                ThruBusLane(30f, true),
+                ThruCarLane(33f, false),
+                ThruCarLane(36f, false),
+                RaisedMedianLane(39f),
+                CarLane(42f, false),
+                CarLane(45f, false),
+            };
+
+            var extNetInfo = new ExtNetInfo(lanes);
+
+            Assert.AreEqual(lanes.Length, extNetInfo.m_extLanes.Length);
+            VerifySequence(extNetInfo.m_sortedLanes, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14);
+
+            Assert.AreEqual(ExtLaneFlags.OuterForward | ExtLaneFlags.InnerForward | ExtLaneFlags.DisplacedInner | ExtLaneFlags.AllowServiceLane | ExtLaneFlags.AllowExpressLane, extNetInfo.m_forwardExtLaneFlags);
+            Assert.AreEqual(ExtLaneFlags.OuterBackward | ExtLaneFlags.InnerBackward | ExtLaneFlags.DisplacedInner | ExtLaneFlags.AllowServiceLane | ExtLaneFlags.AllowExpressLane, extNetInfo.m_backwardExtLaneFlags);
+            Assert.AreEqual(ExtLaneFlags.Outer | ExtLaneFlags.Inner | ExtLaneFlags.DisplacedInner | ExtLaneFlags.AllowServiceLane | ExtLaneFlags.AllowExpressLane | ExtLaneFlags.ForwardGroup | ExtLaneFlags.BackwardGroup, extNetInfo.m_extLaneFlags);
+
+            Assert.AreEqual(6, extNetInfo.m_laneGroups.Length);
+            VerifyGroup(extNetInfo, 0, ExtLaneFlags.OuterBackward | ExtLaneFlags.AllowServiceLane, 0, 1);
+            VerifyGroup(extNetInfo, 1, ExtLaneFlags.InnerBackward | ExtLaneFlags.AllowExpressLane, 3, 4);
+            VerifyGroup(extNetInfo, 2, ExtLaneFlags.DisplacedInnerForward, 5, 6);
+            VerifyGroup(extNetInfo, 3, ExtLaneFlags.DisplacedInnerBackward, 8, 9);
+            VerifyGroup(extNetInfo, 4, ExtLaneFlags.InnerForward | ExtLaneFlags.AllowExpressLane, 10, 11);
+            VerifyGroup(extNetInfo, 5, ExtLaneFlags.OuterForward | ExtLaneFlags.AllowServiceLane, 13, 14);
+
+            VerifyLane(extNetInfo, 0, ExtLaneFlags.OuterBackward | ExtLaneFlags.AllowServiceLane);
+            VerifyLane(extNetInfo, 1, ExtLaneFlags.OuterBackward | ExtLaneFlags.AllowServiceLane);
+            VerifyLane(extNetInfo, 2, ExtLaneFlags.None);
+            VerifyLane(extNetInfo, 3, ExtLaneFlags.InnerBackward | ExtLaneFlags.AllowExpressLane);
+            VerifyLane(extNetInfo, 4, ExtLaneFlags.InnerBackward | ExtLaneFlags.AllowExpressLane);
+            VerifyLane(extNetInfo, 5, ExtLaneFlags.DisplacedInnerForward);
+            VerifyLane(extNetInfo, 6, ExtLaneFlags.DisplacedInnerForward);
+            VerifyLane(extNetInfo, 7, ExtLaneFlags.None);
+            VerifyLane(extNetInfo, 8, ExtLaneFlags.DisplacedInnerBackward);
+            VerifyLane(extNetInfo, 9, ExtLaneFlags.DisplacedInnerBackward);
+            VerifyLane(extNetInfo, 11, ExtLaneFlags.InnerForward | ExtLaneFlags.AllowExpressLane);
+            VerifyLane(extNetInfo, 10, ExtLaneFlags.InnerForward | ExtLaneFlags.AllowExpressLane);
+            VerifyLane(extNetInfo, 12, ExtLaneFlags.None);
+            VerifyLane(extNetInfo, 13, ExtLaneFlags.OuterForward | ExtLaneFlags.AllowServiceLane);
+            VerifyLane(extNetInfo, 14, ExtLaneFlags.OuterForward | ExtLaneFlags.AllowServiceLane);
+        }
+
+        [TestMethod]
+        public void TestLargeCargoRoad() {
+
+            var lanes = new[] {
+                FlushMedianLane(-16.4f),  // 0
+                FlushMedianLane(16.4f),   // 1
+                FlushMedianLane(5.5f),    // 2
+                PedestrianLane(-27f, 2f), // 3
+                FlushMedianLane(-5.5f),   // 4
+                PedestrianLane(27f, 2f),  // 5
+                CarLane(-11.1f, true),    // 6
+                CarLane(11.1f, false),    // 7
+                CarLane(-22.5f, true),    // 8
+                CarLane(22.5f, false),    // 9
+                CarLane(8.1f, true),      // 10
+                CarLane(-8.1f, false),    // 11
+            };
+
+            var extNetInfo = new ExtNetInfo(lanes);
+
+            Assert.AreEqual(lanes.Length, extNetInfo.m_extLanes.Length);
+            VerifySequence(extNetInfo.m_sortedLanes, 3, 8, 0, 6, 11, 4, 2, 10, 7, 1, 9, 5);
+
+            Assert.AreEqual(ExtLaneFlags.OuterForward | ExtLaneFlags.InnerForward | ExtLaneFlags.DisplacedInner | ExtLaneFlags.AllowServiceLane | ExtLaneFlags.ForbidControlledLanes, extNetInfo.m_forwardExtLaneFlags);
+            Assert.AreEqual(ExtLaneFlags.OuterBackward | ExtLaneFlags.InnerBackward | ExtLaneFlags.DisplacedInner | ExtLaneFlags.AllowServiceLane | ExtLaneFlags.ForbidControlledLanes, extNetInfo.m_backwardExtLaneFlags);
+            Assert.AreEqual(ExtLaneFlags.Outer | ExtLaneFlags.Inner | ExtLaneFlags.DisplacedInner | ExtLaneFlags.AllowServiceLane | ExtLaneFlags.ForbidControlledLanes | ExtLaneFlags.ForwardGroup | ExtLaneFlags.BackwardGroup, extNetInfo.m_extLaneFlags);
+
+            Assert.AreEqual(6, extNetInfo.m_laneGroups.Length);
+            VerifyGroup(extNetInfo, 0, ExtLaneFlags.OuterBackward | ExtLaneFlags.AllowServiceLane, 8);
+            VerifyGroup(extNetInfo, 1, ExtLaneFlags.InnerBackward | ExtLaneFlags.ForbidControlledLanes, 6);
+            VerifyGroup(extNetInfo, 2, ExtLaneFlags.DisplacedInnerForward | ExtLaneFlags.ForbidControlledLanes, 11);
+            VerifyGroup(extNetInfo, 3, ExtLaneFlags.DisplacedInnerBackward | ExtLaneFlags.ForbidControlledLanes, 10);
+            VerifyGroup(extNetInfo, 4, ExtLaneFlags.InnerForward | ExtLaneFlags.ForbidControlledLanes, 7);
+            VerifyGroup(extNetInfo, 5, ExtLaneFlags.OuterForward | ExtLaneFlags.AllowServiceLane, 9);
+
+            VerifyLane(extNetInfo, 0, ExtLaneFlags.None);
+            VerifyLane(extNetInfo, 1, ExtLaneFlags.None);
+            VerifyLane(extNetInfo, 2, ExtLaneFlags.None);
+            VerifyLane(extNetInfo, 3, ExtLaneFlags.None);
+            VerifyLane(extNetInfo, 4, ExtLaneFlags.None);
+            VerifyLane(extNetInfo, 5, ExtLaneFlags.None);
+            VerifyLane(extNetInfo, 6, ExtLaneFlags.InnerBackward | ExtLaneFlags.ForbidControlledLanes);
+            VerifyLane(extNetInfo, 7, ExtLaneFlags.InnerForward | ExtLaneFlags.ForbidControlledLanes);
+            VerifyLane(extNetInfo, 8, ExtLaneFlags.OuterBackward | ExtLaneFlags.AllowServiceLane);
+            VerifyLane(extNetInfo, 9, ExtLaneFlags.OuterForward | ExtLaneFlags.AllowServiceLane);
+            VerifyLane(extNetInfo, 10, ExtLaneFlags.DisplacedInnerBackward | ExtLaneFlags.ForbidControlledLanes);
+            VerifyLane(extNetInfo, 11, ExtLaneFlags.DisplacedInnerForward | ExtLaneFlags.ForbidControlledLanes);
         }
 
         private void VerifyGroup(ExtNetInfo extNetInfo, int groupIndex, ExtLaneFlags laneFlags, params int[] sortedLanes) {
@@ -381,10 +581,10 @@ namespace TMUnitTest.ExtPrefabs {
                 m_direction = NetInfo.Direction.Both,
             };
 
-        private NetInfo.Lane ParkingLane(float position, bool backward) =>
+        private NetInfo.Lane ParkingLane(float position, bool backward, float width = 2f) =>
             new NetInfo.Lane {
                 m_position = position,
-                m_width = 2f,
+                m_width = width,
                 m_verticalOffset = -.3f,
                 m_laneType = NetInfo.LaneType.Parking,
                 m_vehicleType = VehicleInfo.VehicleType.Car,
@@ -440,6 +640,15 @@ namespace TMUnitTest.ExtPrefabs {
                 m_position = position,
                 m_width = width,
                 m_verticalOffset = 0f,
+                m_direction = NetInfo.Direction.Both,
+            };
+
+        private NetInfo.Lane FlushMedianLane(float position, float width = 0f) =>
+            new NetInfo.Lane {
+                m_position = position,
+                m_width = width,
+                m_verticalOffset = -.3f,
+                m_direction = NetInfo.Direction.Both,
             };
     }
 }

--- a/TLM/TMPE.UnitTest/ExtPrefabs/ExtNetInfoTest.cs
+++ b/TLM/TMPE.UnitTest/ExtPrefabs/ExtNetInfoTest.cs
@@ -1,0 +1,445 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using TrafficManager.ExtPrefabs;
+using static TrafficManager.ExtPrefabs.ExtNetInfo;
+
+namespace TMUnitTest.ExtPrefabs {
+    [TestClass]
+    public class ExtNetInfoTest {
+
+        [TestMethod]
+        public void TestTwoLane() {
+
+            var lanes = new[] {
+                PedestrianLane(-6.5f, 3f),
+                PedestrianLane(6.5f, 3f),
+                ParkingLane(-4f, true),
+                ParkingLane(4f, false),
+                CarLane(-1.5f, true),
+                CarLane(1.5f, false),
+            };
+
+            var extNetInfo = new ExtNetInfo(lanes);
+
+            Assert.AreEqual(lanes.Length, extNetInfo.m_extLanes.Length);
+            VerifySequence(extNetInfo.m_sortedLanes, 0, 2, 4, 5, 3, 1);
+
+            Assert.AreEqual(ExtLaneFlags.Outer | ExtLaneFlags.ForwardGroup, extNetInfo.m_forwardExtLaneFlags);
+            Assert.AreEqual(ExtLaneFlags.Outer | ExtLaneFlags.BackwardGroup, extNetInfo.m_backwardExtLaneFlags);
+            Assert.AreEqual(ExtLaneFlags.Outer | ExtLaneFlags.ForwardGroup | ExtLaneFlags.BackwardGroup, extNetInfo.m_extLaneFlags);
+
+            Assert.AreEqual(2, extNetInfo.m_laneGroups.Length);
+            VerifyGroup(extNetInfo, 0, ExtLaneFlags.Outer | ExtLaneFlags.BackwardGroup, 4);
+            VerifyGroup(extNetInfo, 1, ExtLaneFlags.Outer | ExtLaneFlags.ForwardGroup, 5);
+
+            VerifyLane(extNetInfo, 0, ExtLaneFlags.None);
+            VerifyLane(extNetInfo, 1, ExtLaneFlags.None);
+            VerifyLane(extNetInfo, 2, ExtLaneFlags.None);
+            VerifyLane(extNetInfo, 3, ExtLaneFlags.None);
+            VerifyLane(extNetInfo, 4, ExtLaneFlags.Outer | ExtLaneFlags.BackwardGroup);
+            VerifyLane(extNetInfo, 5, ExtLaneFlags.Outer | ExtLaneFlags.ForwardGroup);
+        }
+
+        [TestMethod]
+        public void TestTwoLaneOneWay() {
+
+            var lanes = new[] {
+                PedestrianLane(-6.5f, 3f),
+                PedestrianLane(6.5f, 3f),
+                ParkingLane(-4f, false),
+                ParkingLane(4f, false),
+                CarLane(-1.5f, false),
+                CarLane(1.5f, false),
+            };
+
+            var extNetInfo = new ExtNetInfo(lanes);
+
+            Assert.AreEqual(lanes.Length, extNetInfo.m_extLanes.Length);
+            VerifySequence(extNetInfo.m_sortedLanes, 0, 2, 4, 5, 3, 1);
+
+            Assert.AreEqual(ExtLaneFlags.Outer | ExtLaneFlags.ForwardGroup, extNetInfo.m_forwardExtLaneFlags);
+            Assert.AreEqual(ExtLaneFlags.Outer | ExtLaneFlags.ForwardGroup, extNetInfo.m_extLaneFlags);
+
+            Assert.AreEqual(1, extNetInfo.m_laneGroups.Length);
+            VerifyGroup(extNetInfo, 0, ExtLaneFlags.Outer | ExtLaneFlags.ForwardGroup, 4, 5);
+
+            VerifyLane(extNetInfo, 0, ExtLaneFlags.None);
+            VerifyLane(extNetInfo, 1, ExtLaneFlags.None);
+            VerifyLane(extNetInfo, 2, ExtLaneFlags.None);
+            VerifyLane(extNetInfo, 3, ExtLaneFlags.None);
+            VerifyLane(extNetInfo, 4, ExtLaneFlags.Outer | ExtLaneFlags.ForwardGroup);
+            VerifyLane(extNetInfo, 5, ExtLaneFlags.Outer | ExtLaneFlags.ForwardGroup);
+        }
+
+        [TestMethod]
+        public void TestFourLane() {
+
+            var lanes = new[] {
+                PedestrianLane(-13.5f, 5f),
+                PedestrianLane(13.5f, 5f),
+                ParkingLane(-10f, true),
+                ParkingLane(10f, false),
+                CarLane(-7.5f, true),
+                CarLane(7.5f, false),
+                CarLane(-4.5f, true),
+                CarLane(4.5f, false),
+                RaisedMedianLane(0f),
+            };
+
+            var extNetInfo = new ExtNetInfo(lanes);
+
+            Assert.AreEqual(lanes.Length, extNetInfo.m_extLanes.Length);
+            VerifySequence(extNetInfo.m_sortedLanes, 0, 2, 4, 6, 8, 7, 5, 3, 1);
+
+            Assert.AreEqual(ExtLaneFlags.Outer | ExtLaneFlags.ForwardGroup, extNetInfo.m_forwardExtLaneFlags);
+            Assert.AreEqual(ExtLaneFlags.Outer | ExtLaneFlags.BackwardGroup, extNetInfo.m_backwardExtLaneFlags);
+            Assert.AreEqual(ExtLaneFlags.Outer | ExtLaneFlags.ForwardGroup | ExtLaneFlags.BackwardGroup, extNetInfo.m_extLaneFlags);
+
+            Assert.AreEqual(2, extNetInfo.m_laneGroups.Length);
+            VerifyGroup(extNetInfo, 0, ExtLaneFlags.Outer | ExtLaneFlags.BackwardGroup, 4, 6);
+            VerifyGroup(extNetInfo, 1, ExtLaneFlags.Outer | ExtLaneFlags.ForwardGroup, 7, 5);
+
+            VerifyLane(extNetInfo, 0, ExtLaneFlags.None);
+            VerifyLane(extNetInfo, 1, ExtLaneFlags.None);
+            VerifyLane(extNetInfo, 2, ExtLaneFlags.None);
+            VerifyLane(extNetInfo, 3, ExtLaneFlags.None);
+            VerifyLane(extNetInfo, 4, ExtLaneFlags.Outer | ExtLaneFlags.BackwardGroup);
+            VerifyLane(extNetInfo, 5, ExtLaneFlags.Outer | ExtLaneFlags.ForwardGroup);
+            VerifyLane(extNetInfo, 6, ExtLaneFlags.Outer | ExtLaneFlags.BackwardGroup);
+            VerifyLane(extNetInfo, 7, ExtLaneFlags.Outer | ExtLaneFlags.ForwardGroup);
+            VerifyLane(extNetInfo, 8, ExtLaneFlags.None);
+        }
+
+        [TestMethod]
+        public void TestCFI() {
+
+            var lanes = new[] {
+                CarLane(0f, true),
+                ThruCarLane(3f, false),
+                ThruCarLane(6f, false),
+                ThruCarLane(9f, true),
+                ThruCarLane(12f, true),
+                CarLane(15f, false),
+                CarLane(18f, false),
+                CarLane(21f, false),
+            };
+
+            var extNetInfo = new ExtNetInfo(lanes);
+
+            Assert.AreEqual(lanes.Length, extNetInfo.m_extLanes.Length);
+            VerifySequence(extNetInfo.m_sortedLanes, 0, 1, 2, 3, 4, 5, 6, 7);
+
+            Assert.AreEqual(ExtLaneFlags.Outer | ExtLaneFlags.DisplacedInner | ExtLaneFlags.AllowCFI | ExtLaneFlags.ForwardGroup, extNetInfo.m_forwardExtLaneFlags);
+            Assert.AreEqual(ExtLaneFlags.Outer | ExtLaneFlags.DisplacedInner | ExtLaneFlags.AllowCFI | ExtLaneFlags.BackwardGroup, extNetInfo.m_backwardExtLaneFlags);
+            Assert.AreEqual(ExtLaneFlags.Outer | ExtLaneFlags.DisplacedInner | ExtLaneFlags.AllowCFI | ExtLaneFlags.ForwardGroup | ExtLaneFlags.BackwardGroup, extNetInfo.m_extLaneFlags);
+
+            Assert.AreEqual(4, extNetInfo.m_laneGroups.Length);
+            VerifyGroup(extNetInfo, 0, ExtLaneFlags.Outer | ExtLaneFlags.BackwardGroup, 0);
+            VerifyGroup(extNetInfo, 1, ExtLaneFlags.DisplacedInner | ExtLaneFlags.AllowCFI | ExtLaneFlags.ForwardGroup, 1, 2);
+            VerifyGroup(extNetInfo, 2, ExtLaneFlags.DisplacedInner | ExtLaneFlags.AllowCFI | ExtLaneFlags.BackwardGroup, 3, 4);
+            VerifyGroup(extNetInfo, 3, ExtLaneFlags.Outer | ExtLaneFlags.ForwardGroup, 5, 6, 7);
+
+            VerifyLane(extNetInfo, 0, ExtLaneFlags.Outer | ExtLaneFlags.BackwardGroup);
+            VerifyLane(extNetInfo, 1, ExtLaneFlags.DisplacedInner | ExtLaneFlags.AllowCFI | ExtLaneFlags.ForwardGroup);
+            VerifyLane(extNetInfo, 2, ExtLaneFlags.DisplacedInner | ExtLaneFlags.AllowCFI | ExtLaneFlags.ForwardGroup);
+            VerifyLane(extNetInfo, 3, ExtLaneFlags.DisplacedInner | ExtLaneFlags.AllowCFI | ExtLaneFlags.BackwardGroup);
+            VerifyLane(extNetInfo, 4, ExtLaneFlags.DisplacedInner | ExtLaneFlags.AllowCFI | ExtLaneFlags.BackwardGroup);
+            VerifyLane(extNetInfo, 5, ExtLaneFlags.Outer | ExtLaneFlags.ForwardGroup);
+            VerifyLane(extNetInfo, 6, ExtLaneFlags.Outer | ExtLaneFlags.ForwardGroup);
+            VerifyLane(extNetInfo, 7, ExtLaneFlags.Outer | ExtLaneFlags.ForwardGroup);
+        }
+
+        [TestMethod]
+        public void TestUncontrolledDisplaced() {
+
+            var lanes = new[] {
+                CarLane(0f, true),
+                CarLane(3f, false),
+                CarLane(6f, true),
+                CarLane(9f, false),
+            };
+
+            var extNetInfo = new ExtNetInfo(lanes);
+
+            Assert.AreEqual(lanes.Length, extNetInfo.m_extLanes.Length);
+            VerifySequence(extNetInfo.m_sortedLanes, 0, 1, 2, 3);
+
+            Assert.AreEqual(ExtLaneFlags.Outer | ExtLaneFlags.DisplacedInner | ExtLaneFlags.ForbidControlledLanes | ExtLaneFlags.ForwardGroup, extNetInfo.m_forwardExtLaneFlags);
+            Assert.AreEqual(ExtLaneFlags.Outer | ExtLaneFlags.DisplacedInner | ExtLaneFlags.ForbidControlledLanes | ExtLaneFlags.BackwardGroup, extNetInfo.m_backwardExtLaneFlags);
+            Assert.AreEqual(ExtLaneFlags.Outer | ExtLaneFlags.DisplacedInner | ExtLaneFlags.ForbidControlledLanes | ExtLaneFlags.ForwardGroup | ExtLaneFlags.BackwardGroup, extNetInfo.m_extLaneFlags);
+
+            Assert.AreEqual(4, extNetInfo.m_laneGroups.Length);
+            VerifyGroup(extNetInfo, 0, ExtLaneFlags.Outer | ExtLaneFlags.BackwardGroup, 0);
+            VerifyGroup(extNetInfo, 1, ExtLaneFlags.DisplacedInner | ExtLaneFlags.ForbidControlledLanes | ExtLaneFlags.ForwardGroup, 1);
+            VerifyGroup(extNetInfo, 2, ExtLaneFlags.DisplacedInner | ExtLaneFlags.ForbidControlledLanes | ExtLaneFlags.BackwardGroup, 2);
+            VerifyGroup(extNetInfo, 3, ExtLaneFlags.Outer | ExtLaneFlags.ForwardGroup, 3);
+
+            VerifyLane(extNetInfo, 0, ExtLaneFlags.Outer | ExtLaneFlags.BackwardGroup);
+            VerifyLane(extNetInfo, 1, ExtLaneFlags.DisplacedInner | ExtLaneFlags.ForbidControlledLanes | ExtLaneFlags.ForwardGroup);
+            VerifyLane(extNetInfo, 2, ExtLaneFlags.DisplacedInner | ExtLaneFlags.ForbidControlledLanes | ExtLaneFlags.BackwardGroup);
+            VerifyLane(extNetInfo, 3, ExtLaneFlags.Outer | ExtLaneFlags.ForwardGroup);
+        }
+
+        [TestMethod]
+        public void TestForwardTurnaround() {
+
+            var lanes = new[] {
+                CarLane(0f, false),
+                CarLane(3f, true),
+                CarLane(6f, true),
+                CarLane(9f, false),
+                CarLane(12f, false),
+            };
+
+            var extNetInfo = new ExtNetInfo(lanes);
+
+            Assert.AreEqual(lanes.Length, extNetInfo.m_extLanes.Length);
+            VerifySequence(extNetInfo.m_sortedLanes, 0, 1, 2, 3, 4);
+
+            Assert.AreEqual(ExtLaneFlags.Outer | ExtLaneFlags.DisplacedOuter | ExtLaneFlags.ForwardGroup, extNetInfo.m_forwardExtLaneFlags);
+            Assert.AreEqual(ExtLaneFlags.Outer | ExtLaneFlags.BackwardGroup, extNetInfo.m_backwardExtLaneFlags);
+            Assert.AreEqual(ExtLaneFlags.Outer | ExtLaneFlags.DisplacedOuter | ExtLaneFlags.ForwardGroup | ExtLaneFlags.BackwardGroup, extNetInfo.m_extLaneFlags);
+
+            Assert.AreEqual(3, extNetInfo.m_laneGroups.Length);
+            VerifyGroup(extNetInfo, 0, ExtLaneFlags.DisplacedOuter | ExtLaneFlags.ForwardGroup, 0);
+            VerifyGroup(extNetInfo, 1, ExtLaneFlags.Outer | ExtLaneFlags.BackwardGroup, 1, 2);
+            VerifyGroup(extNetInfo, 2, ExtLaneFlags.Outer | ExtLaneFlags.ForwardGroup, 3, 4);
+
+            VerifyLane(extNetInfo, 0, ExtLaneFlags.DisplacedOuter | ExtLaneFlags.ForwardGroup);
+            VerifyLane(extNetInfo, 1, ExtLaneFlags.Outer | ExtLaneFlags.BackwardGroup);
+            VerifyLane(extNetInfo, 2, ExtLaneFlags.Outer | ExtLaneFlags.BackwardGroup);
+            VerifyLane(extNetInfo, 3, ExtLaneFlags.Outer | ExtLaneFlags.ForwardGroup);
+            VerifyLane(extNetInfo, 4, ExtLaneFlags.Outer | ExtLaneFlags.ForwardGroup);
+        }
+
+        [TestMethod]
+        public void TestBackwardTurnaround() {
+
+            var lanes = new[] {
+                CarLane(0f, true),
+                CarLane(3f, true),
+                CarLane(6f, false),
+                CarLane(9f, false),
+                CarLane(12f, true),
+            };
+
+            var extNetInfo = new ExtNetInfo(lanes);
+
+            Assert.AreEqual(lanes.Length, extNetInfo.m_extLanes.Length);
+            VerifySequence(extNetInfo.m_sortedLanes, 0, 1, 2, 3, 4);
+
+            Assert.AreEqual(ExtLaneFlags.Outer | ExtLaneFlags.ForwardGroup, extNetInfo.m_forwardExtLaneFlags);
+            Assert.AreEqual(ExtLaneFlags.Outer | ExtLaneFlags.DisplacedOuter | ExtLaneFlags.BackwardGroup, extNetInfo.m_backwardExtLaneFlags);
+            Assert.AreEqual(ExtLaneFlags.Outer | ExtLaneFlags.DisplacedOuter | ExtLaneFlags.ForwardGroup | ExtLaneFlags.BackwardGroup, extNetInfo.m_extLaneFlags);
+
+            Assert.AreEqual(3, extNetInfo.m_laneGroups.Length);
+            VerifyGroup(extNetInfo, 0, ExtLaneFlags.Outer | ExtLaneFlags.BackwardGroup, 0, 1);
+            VerifyGroup(extNetInfo, 1, ExtLaneFlags.Outer | ExtLaneFlags.ForwardGroup, 2, 3);
+            VerifyGroup(extNetInfo, 2, ExtLaneFlags.DisplacedOuter | ExtLaneFlags.BackwardGroup, 4);
+
+            VerifyLane(extNetInfo, 0, ExtLaneFlags.Outer | ExtLaneFlags.BackwardGroup);
+            VerifyLane(extNetInfo, 1, ExtLaneFlags.Outer | ExtLaneFlags.BackwardGroup);
+            VerifyLane(extNetInfo, 2, ExtLaneFlags.Outer | ExtLaneFlags.ForwardGroup);
+            VerifyLane(extNetInfo, 3, ExtLaneFlags.Outer | ExtLaneFlags.ForwardGroup);
+            VerifyLane(extNetInfo, 4, ExtLaneFlags.DisplacedOuter | ExtLaneFlags.BackwardGroup);
+        }
+
+        [TestMethod]
+        public void TestDualTurnaround() {
+
+            var lanes = new[] {
+                CarLane(0f, false),
+                CarLane(3f, true),
+                CarLane(6f, true),
+                CarLane(9f, false),
+                CarLane(12f, false),
+                CarLane(15f, true),
+            };
+
+            var extNetInfo = new ExtNetInfo(lanes);
+
+            Assert.AreEqual(lanes.Length, extNetInfo.m_extLanes.Length);
+            VerifySequence(extNetInfo.m_sortedLanes, 0, 1, 2, 3, 4, 5);
+
+            Assert.AreEqual(ExtLaneFlags.Outer | ExtLaneFlags.DisplacedOuter | ExtLaneFlags.ForwardGroup, extNetInfo.m_forwardExtLaneFlags);
+            Assert.AreEqual(ExtLaneFlags.Outer | ExtLaneFlags.DisplacedOuter | ExtLaneFlags.BackwardGroup, extNetInfo.m_backwardExtLaneFlags);
+            Assert.AreEqual(ExtLaneFlags.Outer | ExtLaneFlags.DisplacedOuter | ExtLaneFlags.ForwardGroup | ExtLaneFlags.BackwardGroup, extNetInfo.m_extLaneFlags);
+
+            Assert.AreEqual(4, extNetInfo.m_laneGroups.Length);
+            VerifyGroup(extNetInfo, 0, ExtLaneFlags.DisplacedOuter | ExtLaneFlags.ForwardGroup, 0);
+            VerifyGroup(extNetInfo, 1, ExtLaneFlags.Outer | ExtLaneFlags.BackwardGroup, 1, 2);
+            VerifyGroup(extNetInfo, 2, ExtLaneFlags.Outer | ExtLaneFlags.ForwardGroup, 3, 4);
+            VerifyGroup(extNetInfo, 3, ExtLaneFlags.DisplacedOuter | ExtLaneFlags.BackwardGroup, 5);
+
+            VerifyLane(extNetInfo, 0, ExtLaneFlags.DisplacedOuter | ExtLaneFlags.ForwardGroup);
+            VerifyLane(extNetInfo, 1, ExtLaneFlags.Outer | ExtLaneFlags.BackwardGroup);
+            VerifyLane(extNetInfo, 2, ExtLaneFlags.Outer | ExtLaneFlags.BackwardGroup);
+            VerifyLane(extNetInfo, 3, ExtLaneFlags.Outer | ExtLaneFlags.ForwardGroup);
+            VerifyLane(extNetInfo, 4, ExtLaneFlags.Outer | ExtLaneFlags.ForwardGroup);
+            VerifyLane(extNetInfo, 5, ExtLaneFlags.DisplacedOuter | ExtLaneFlags.BackwardGroup);
+        }
+
+        [TestMethod]
+        public void TestInnerDisplacedBusLanes() {
+
+            var lanes = new[] {
+                CarLane(0f, true),
+                CarLane(3f, true),
+                ThruBusLane(6f, false),
+                ThruBusLane(9f, false),
+                PedestrianLane(13.5f, 6f),
+                ThruBusLane(18f, true),
+                ThruBusLane(21f, true),
+                CarLane(24f, false),
+                CarLane(27f, false),
+            };
+
+            var extNetInfo = new ExtNetInfo(lanes);
+
+            Assert.AreEqual(lanes.Length, extNetInfo.m_extLanes.Length);
+            VerifySequence(extNetInfo.m_sortedLanes, 0, 1, 2, 3, 4, 5, 6, 7, 8);
+
+            Assert.AreEqual(ExtLaneFlags.Outer | ExtLaneFlags.DisplacedInner | ExtLaneFlags.ForwardGroup, extNetInfo.m_forwardExtLaneFlags);
+            Assert.AreEqual(ExtLaneFlags.Outer | ExtLaneFlags.DisplacedInner | ExtLaneFlags.BackwardGroup, extNetInfo.m_backwardExtLaneFlags);
+            Assert.AreEqual(ExtLaneFlags.Outer | ExtLaneFlags.DisplacedInner | ExtLaneFlags.ForwardGroup | ExtLaneFlags.BackwardGroup, extNetInfo.m_extLaneFlags);
+
+            Assert.AreEqual(4, extNetInfo.m_laneGroups.Length);
+            VerifyGroup(extNetInfo, 0, ExtLaneFlags.Outer | ExtLaneFlags.BackwardGroup, 0, 1);
+            VerifyGroup(extNetInfo, 1, ExtLaneFlags.DisplacedInner | ExtLaneFlags.ForwardGroup, 2, 3);
+            VerifyGroup(extNetInfo, 2, ExtLaneFlags.DisplacedInner | ExtLaneFlags.BackwardGroup, 5, 6);
+            VerifyGroup(extNetInfo, 3, ExtLaneFlags.Outer | ExtLaneFlags.ForwardGroup, 7, 8);
+
+            VerifyLane(extNetInfo, 0, ExtLaneFlags.Outer | ExtLaneFlags.BackwardGroup);
+            VerifyLane(extNetInfo, 1, ExtLaneFlags.Outer | ExtLaneFlags.BackwardGroup);
+            VerifyLane(extNetInfo, 2, ExtLaneFlags.DisplacedInner | ExtLaneFlags.ForwardGroup);
+            VerifyLane(extNetInfo, 3, ExtLaneFlags.DisplacedInner | ExtLaneFlags.ForwardGroup);
+            VerifyLane(extNetInfo, 4, ExtLaneFlags.None);
+            VerifyLane(extNetInfo, 5, ExtLaneFlags.DisplacedInner | ExtLaneFlags.BackwardGroup);
+            VerifyLane(extNetInfo, 6, ExtLaneFlags.DisplacedInner | ExtLaneFlags.BackwardGroup);
+            VerifyLane(extNetInfo, 7, ExtLaneFlags.Outer | ExtLaneFlags.ForwardGroup);
+            VerifyLane(extNetInfo, 8, ExtLaneFlags.Outer | ExtLaneFlags.ForwardGroup);
+        }
+
+        [TestMethod]
+        public void TestFourLaneInverted() {
+
+            var lanes = new[] {
+                PedestrianLane(-13.5f, 5f),
+                PedestrianLane(13.5f, 5f),
+                ParkingLane(-10f, false),
+                ParkingLane(10f, true),
+                CarLane(-7.5f, false),
+                CarLane(7.5f, true),
+                CarLane(-4.5f, false),
+                CarLane(4.5f, true),
+                RaisedMedianLane(0f),
+            };
+
+            var extNetInfo = new ExtNetInfo(lanes);
+
+            Assert.AreEqual(lanes.Length, extNetInfo.m_extLanes.Length);
+            VerifySequence(extNetInfo.m_sortedLanes, 0, 2, 4, 6, 8, 7, 5, 3, 1);
+
+            Assert.AreEqual(ExtLaneFlags.Outer | ExtLaneFlags.ForwardGroup, extNetInfo.m_forwardExtLaneFlags);
+            Assert.AreEqual(ExtLaneFlags.Outer | ExtLaneFlags.BackwardGroup, extNetInfo.m_backwardExtLaneFlags);
+            Assert.AreEqual(ExtLaneFlags.Outer | ExtLaneFlags.ForwardGroup | ExtLaneFlags.BackwardGroup, extNetInfo.m_extLaneFlags);
+
+            Assert.AreEqual(2, extNetInfo.m_laneGroups.Length);
+            VerifyGroup(extNetInfo, 0, ExtLaneFlags.Outer | ExtLaneFlags.ForwardGroup, 4, 6);
+            VerifyGroup(extNetInfo, 1, ExtLaneFlags.Outer | ExtLaneFlags.BackwardGroup, 7, 5);
+
+            VerifyLane(extNetInfo, 0, ExtLaneFlags.None);
+            VerifyLane(extNetInfo, 1, ExtLaneFlags.None);
+            VerifyLane(extNetInfo, 2, ExtLaneFlags.None);
+            VerifyLane(extNetInfo, 3, ExtLaneFlags.None);
+            VerifyLane(extNetInfo, 4, ExtLaneFlags.Outer | ExtLaneFlags.ForwardGroup);
+            VerifyLane(extNetInfo, 5, ExtLaneFlags.Outer | ExtLaneFlags.BackwardGroup);
+            VerifyLane(extNetInfo, 6, ExtLaneFlags.Outer | ExtLaneFlags.ForwardGroup);
+            VerifyLane(extNetInfo, 7, ExtLaneFlags.Outer | ExtLaneFlags.BackwardGroup);
+            VerifyLane(extNetInfo, 8, ExtLaneFlags.None);
+        }
+
+        private void VerifyGroup(ExtNetInfo extNetInfo, int groupIndex, ExtLaneFlags laneFlags, params int[] sortedLanes) {
+            Assert.AreEqual(laneFlags, extNetInfo.m_laneGroups[groupIndex].m_extLaneFlags);
+            VerifySequence(extNetInfo.m_laneGroups[groupIndex].m_sortedLanes, sortedLanes);
+        }
+
+        private void VerifyLane(ExtNetInfo extNetInfo, int laneIndex, ExtLaneFlags flags) {
+            Assert.AreEqual(flags, extNetInfo.m_extLanes[laneIndex].m_extFlags);
+        }
+
+        private void VerifySequence(int[] actual, params int[] expected) {
+            CollectionAssert.AreEqual(expected, actual);
+        }
+
+        private NetInfo.Lane PedestrianLane(float position, float width) =>
+            new NetInfo.Lane {
+                m_position = position,
+                m_width = width,
+                m_verticalOffset = 0f,
+                m_laneType = NetInfo.LaneType.Pedestrian,
+                m_direction = NetInfo.Direction.Both,
+            };
+
+        private NetInfo.Lane ParkingLane(float position, bool backward) =>
+            new NetInfo.Lane {
+                m_position = position,
+                m_width = 2f,
+                m_verticalOffset = -.3f,
+                m_laneType = NetInfo.LaneType.Parking,
+                m_vehicleType = VehicleInfo.VehicleType.Car,
+                m_direction = backward ? NetInfo.Direction.Backward : NetInfo.Direction.Forward,
+            };
+
+        private NetInfo.Lane CarLane(float position, bool backward) =>
+            new NetInfo.Lane {
+                m_position = position,
+                m_width = 3f,
+                m_verticalOffset = -.3f,
+                m_laneType = NetInfo.LaneType.Vehicle,
+                m_vehicleType = VehicleInfo.VehicleType.Car,
+                m_direction = backward ? NetInfo.Direction.Backward : NetInfo.Direction.Forward,
+                m_allowConnect = true,
+            };
+
+        private NetInfo.Lane ThruCarLane(float position, bool backward) =>
+            new NetInfo.Lane {
+                m_position = position,
+                m_width = 3f,
+                m_verticalOffset = -.3f,
+                m_laneType = NetInfo.LaneType.Vehicle,
+                m_vehicleType = VehicleInfo.VehicleType.Car,
+                m_direction = backward ? NetInfo.Direction.Backward : NetInfo.Direction.Forward,
+                m_allowConnect = false,
+            };
+
+        private NetInfo.Lane BusLane(float position, bool backward) =>
+            new NetInfo.Lane {
+                m_position = position,
+                m_width = 3f,
+                m_verticalOffset = -.3f,
+                m_laneType = NetInfo.LaneType.TransportVehicle,
+                m_vehicleType = VehicleInfo.VehicleType.Car,
+                m_direction = backward ? NetInfo.Direction.Backward : NetInfo.Direction.Forward,
+                m_allowConnect = true,
+            };
+
+        private NetInfo.Lane ThruBusLane(float position, bool backward) =>
+            new NetInfo.Lane {
+                m_position = position,
+                m_width = 3f,
+                m_verticalOffset = -.3f,
+                m_laneType = NetInfo.LaneType.TransportVehicle,
+                m_vehicleType = VehicleInfo.VehicleType.Car,
+                m_direction = backward ? NetInfo.Direction.Backward : NetInfo.Direction.Forward,
+                m_allowConnect = false,
+            };
+
+        private NetInfo.Lane RaisedMedianLane(float position, float width = 0f) =>
+            new NetInfo.Lane {
+                m_position = position,
+                m_width = width,
+                m_verticalOffset = 0f,
+            };
+    }
+}

--- a/TLM/TMPE.UnitTest/TMPE.UnitTest.csproj
+++ b/TLM/TMPE.UnitTest/TMPE.UnitTest.csproj
@@ -92,6 +92,7 @@
     </Otherwise>
   </Choose>
   <ItemGroup>
+    <Compile Include="ExtPrefabs\ExtNetInfoTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Translation\CsvParser.cs" />
     <Compile Include="Util\DynamicKeybindReplaceTest.cs" />
@@ -133,9 +134,7 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
-  <ItemGroup>
-    <Folder Include="ExtPrefabs\" />
-  </ItemGroup>
+  <ItemGroup />
   <Choose>
     <When Condition="'$(VisualStudioVersion)' == '10.0' And '$(IsCodedUITest)' == 'True'">
       <ItemGroup>

--- a/TLM/TMPE.UnitTest/TMPE.UnitTest.csproj
+++ b/TLM/TMPE.UnitTest/TMPE.UnitTest.csproj
@@ -133,6 +133,9 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
+  <ItemGroup>
+    <Folder Include="ExtPrefabs\" />
+  </ItemGroup>
   <Choose>
     <When Condition="'$(VisualStudioVersion)' == '10.0' And '$(IsCodedUITest)' == 'True'">
       <ItemGroup>


### PR DESCRIPTION
Resolves #1589 

This code analyzes NetInfo objects and groups lanes according to directionality and detected medians. It will be the foundation for new routing logic that is more median-aware.

This is all new code, not yet wired up to any existing features. I am submitting this work in stages.