### PR TITLE
no lane arrows => no lane routings.

### DIFF
--- a/TLM/TLM/Manager/Impl/RoutingManager.cs
+++ b/TLM/TLM/Manager/Impl/RoutingManager.cs
@@ -821,10 +821,11 @@ namespace TrafficManager.Manager.Impl {
                                             LaneArrowManager.Instance.GetFinalLaneArrows(nextLaneId);
                                         bool hasLeftArrow = (nextLaneArrows & LaneArrows.Left) != LaneArrows.None;
                                         bool hasRightArrow = (nextLaneArrows & LaneArrows.Right) != LaneArrows.None;
-                                        bool hasForwardArrow =
-                                            (nextLaneArrows & LaneArrows.Forward) != LaneArrows.None ||
-                                            (nextLaneArrows & LaneArrows.LeftForwardRight) ==
-                                            LaneArrows.None;
+                                        bool hasForwardArrow = (nextLaneArrows & LaneArrows.Forward) != LaneArrows.None;
+                                        if (!nodeIsJunction) {
+                                            // on junctions: no arrows means dead end
+                                            hasForwardArrow |= (nextLaneArrows & LaneArrows.LeftForwardRight) == LaneArrows.None;
+                                        }
 
                                         extendedLog?.Invoke(new { _ = "start lane arrow check for ",
                                             nextLaneId, nextLaneIndex, hasLeftArrow, hasForwardArrow, hasRightArrow });


### PR DESCRIPTION
phase 1 of #1213

At junctions if lane has no arrows, it will have no lane transitions (except for relaxed transitions for SOS vehicles). 

applies to JUNCTIONS ONLY!!!!

in the next phase I use the lane connector tool so that we can remove lane transitions from track lanes too.