### PR TITLE
Lane connector incorrectly renders connection lines

### DIFF
--- a/TLM/TLM/UI/SubTools/LaneConnectorTool.cs
+++ b/TLM/TLM/UI/SubTools/LaneConnectorTool.cs
@@ -1291,7 +1291,7 @@ namespace TrafficManager.UI.SubTools {
                 uint laneId = netSegment.m_lanes;
                 // CSUR transition segments (2->3, 3->2 etc.) have "0" m_averageLength,
                 // set 10% of lane length as a connector marker offset
-                float offsetT = FloatUtil.IsZero(netSegment.m_averageLength) ? 0.1f : offset / netSegment.m_averageLength;
+                float offsetT = netSegment.m_averageLength <= 1f ? 0.1f : Mathf.Clamp01(offset / netSegment.m_averageLength);
 
                 for (byte laneIndex = 0; (laneIndex < lanes.Length) && (laneId != 0); laneIndex++) {
                     ref NetLane netLane = ref laneId.ToLane();


### PR DESCRIPTION
Resolves #1604 

Incorrect offset on bezier - should not be outside of 0...1f range

Build [zip](https://ci.appveyor.com/api/projects/krzychu124/tmpe/artifacts/TMPE.zip?branch=bugfix/1604-lane-connector-weird-lines)