### PR TITLE
Incorrect segment id for direction calculations

### DIFF
--- a/TLM/TLM/Manager/Impl/ExtSegmentEndManager.cs
+++ b/TLM/TLM/Manager/Impl/ExtSegmentEndManager.cs
@@ -170,7 +170,7 @@ namespace TrafficManager.Manager.Impl {
 
         public ArrowDirection GetDirection(ushort segmentId0, ushort segmentId1, ushort nodeId = 0) {
             if (nodeId == 0) {
-                ref NetSegment netSegment = ref ((ushort)0).ToSegment();
+                ref NetSegment netSegment = ref segmentId0.ToSegment();
                 nodeId = netSegment.GetSharedNode(segmentId1);
                 if (nodeId == 0) {
                     return ArrowDirection.None;


### PR DESCRIPTION
Fixed the code since it does not make any sense when node id was not passed as argument - it suppose to calculate the id by taking shared node - **ID 0 is always reserved and used as "Empty/Invalid"**.

That method is currently used in two places in both cases we pass node Id so this change doesn't really improve anything but will prevent bugs if someone try to use it without explicitly passing the node id.