### PR TITLE
Fix incorrect target method for harmony patches

### DIFF
--- a/TLM/TLM/Patch/_RoadBaseAI/TrafficLightSimulationStepPatch.cs
+++ b/TLM/TLM/Patch/_RoadBaseAI/TrafficLightSimulationStepPatch.cs
@@ -4,7 +4,7 @@ namespace TrafficManager.Patch._RoadBaseAI {
     using TrafficManager.Manager.Impl;
     using TrafficManager.State;
 
-    [HarmonyPatch(typeof(TrainTrackBaseAI), nameof(TrainTrackBaseAI.LevelCrossingSimulationStep))]
+    [HarmonyPatch(typeof(RoadBaseAI), nameof(RoadBaseAI.TrafficLightSimulationStep))]
     public class TrafficLightSimulationStepPatch {
         /// <summary>
         /// Decides whether the stock simulation step for traffic lights should run.

--- a/TLM/TLM/Patch/_RoadBaseAI/TrafficLightSimulationStepPatch.cs
+++ b/TLM/TLM/Patch/_RoadBaseAI/TrafficLightSimulationStepPatch.cs
@@ -10,7 +10,7 @@ namespace TrafficManager.Patch._RoadBaseAI {
         /// Decides whether the stock simulation step for traffic lights should run.
         /// </summary>
         [UsedImplicitly]
-        public static bool Prefix(RoadBaseAI __instance, ushort nodeID, ref NetNode data) {
+        public static bool Prefix(ushort nodeID) {
             return !Options.timedLightsEnabled
                    || !TrafficLightSimulationManager
                                 .Instance

--- a/TLM/TLM/Patch/_TrainTrackBaseAI/LevelCrossingSimulationStepPatch.cs
+++ b/TLM/TLM/Patch/_TrainTrackBaseAI/LevelCrossingSimulationStepPatch.cs
@@ -1,10 +1,10 @@
-namespace TrafficManager.Patch._TrainTrackBase {
+namespace TrafficManager.Patch._TrainTrackBaseAI {
     using HarmonyLib;
     using JetBrains.Annotations;
     using TrafficManager.Manager.Impl;
     using TrafficManager.State;
 
-    [HarmonyPatch(typeof(RoadBaseAI), nameof(RoadBaseAI.TrafficLightSimulationStep))]
+    [HarmonyPatch(typeof(TrainTrackBaseAI), nameof(TrainTrackBaseAI.LevelCrossingSimulationStep))]
     public class LevelCrossingSimulationStepPatch {
         /// <summary>
         /// Decides whether the stock simulation step for traffic lights should run.

--- a/TLM/TLM/Patch/_TrainTrackBaseAI/LevelCrossingSimulationStepPatch.cs
+++ b/TLM/TLM/Patch/_TrainTrackBaseAI/LevelCrossingSimulationStepPatch.cs
@@ -10,7 +10,7 @@ namespace TrafficManager.Patch._TrainTrackBaseAI {
         /// Decides whether the stock simulation step for traffic lights should run.
         /// </summary>
         [UsedImplicitly]
-        public static bool Prefix(TrainTrackBaseAI __instance, ushort nodeID, ref NetNode data) {
+        public static bool Prefix(ushort nodeID) {
             return !Options.timedLightsEnabled
                    || !TrafficLightSimulationManager
                                 .Instance


### PR DESCRIPTION

This bug was not spotted before probably because we don't use `__instance` parameter (it'd be null because of invalid cast)