### PR TITLE
Skip `Old Town` pathfinding penalties for buses and taxi (optional)

### DIFF
--- a/TLM/TLM/Custom/PathFinding/CustomPathFind.cs
+++ b/TLM/TLM/Custom/PathFinding/CustomPathFind.cs
@@ -2510,15 +2510,26 @@ namespace TrafficManager.Custom.PathFinding {
                 NetInfo.LaneType.None &&
                 (prevVehicleType & vehicleTypes_) == VehicleInfo.VehicleType.Car &&
                 (prevSegment.m_flags & carBanMask_) != NetSegment.Flags.None) {
-                offsetLength *= 7.5f;
 
-                if (isLogEnabled) {
+                // is vehicle type Car, in the district with Old Town Policy, skip penalty if bus or taxi when allowed
+                if ((!globalConf_.PathFinding.AllowTaxiInOldTownDistricts || (queueItem_.vehicleType & ExtVehicleType.Taxi) == 0) &&
+                    (!globalConf_.PathFinding.AllowBusInOldTownDistricts || (queueItem_.vehicleType & ExtVehicleType.Bus) == 0)) {
+                    offsetLength *= 7.5f;
+
+                    if (isLogEnabled) {
+                        DebugLog(
+                            unitId,
+                            item,
+                            nextSegmentId,
+                            $"ProcessItemCosts: Applied stock car ban cost factor\n" +
+                            $"\toffsetLength={offsetLength}");
+                    }
+                } else if (isLogEnabled) {
                     DebugLog(
                         unitId,
                         item,
                         nextSegmentId,
-                        $"ProcessItemCosts: Applied stock car ban cost factor\n" +
-                        $"\toffsetLength={offsetLength}");
+                        $"ProcessItemCosts: Skipped car ban, vehicle {queueItem_.vehicleType}");
                 }
             }
 

--- a/TLM/TLM/State/ConfigData/PathFinding.cs
+++ b/TLM/TLM/State/ConfigData/PathFinding.cs
@@ -44,5 +44,15 @@
         /// Maximum penalty for entering public transport vehicles
         /// </summary>
         public float PublicTransportTransitionMaxPenalty = 100f;
+
+        /// <summary>
+        /// Allows Buses to drive through districts with Old Town policy (AfterDark DLC)
+        /// </summary>
+        public bool AllowBusInOldTownDistricts = false;
+
+        /// <summary>
+        /// Allows Taxis to drive through districts with Old Town policy (AfterDark DLC)
+        /// </summary>
+        public bool AllowTaxiInOldTownDistricts = false;
     }
 }

--- a/TLM/TLM/State/OptionsTabs/GameplayTab_AIGroups.cs
+++ b/TLM/TLM/State/OptionsTabs/GameplayTab_AIGroups.cs
@@ -2,6 +2,7 @@ namespace TrafficManager.State {
     using ICities;
     using TrafficManager.Lifecycle;
     using TrafficManager.Manager.Impl;
+    using TrafficManager.State.ConfigData;
     using TrafficManager.UI;
     using TrafficManager.UI.Helpers;
 
@@ -39,6 +40,20 @@ namespace TrafficManager.State {
                 Label = "Gameplay.Checkbox:No excessive transfers",
             };
 
+        public static CheckboxOption AllowBusInOldTown =
+            new(nameof(GlobalConfig.Instance.PathFinding.AllowBusInOldTownDistricts), Options.PersistTo.Global) {
+                Label = "Gameplay.Checkbox:Allow Buses in Old Town districts",
+                Handler = OnAllowBusInOldTownChanged,
+                Validator = AfterDarkDlcValidator,
+            };
+
+        public static CheckboxOption AllowTaxiInOldTown =
+            new(nameof(GlobalConfig.Instance.PathFinding.AllowTaxiInOldTownDistricts), Options.PersistTo.Global) {
+                Label = "Gameplay.Checkbox:Allow Taxis in Old Town districts",
+                Handler = OnAllowTaxiInOldTownChanged,
+                Validator = AfterDarkDlcValidator,
+            };
+
         internal static void AddUI(UIHelperBase tab) {
             UIHelperBase group;
 
@@ -56,9 +71,17 @@ namespace TrafficManager.State {
             group = tab.AddGroup(T("Gameplay.Group:Public transport"));
 
             RealisticPublicTransport.AddUI(group);
+
+            if (HasAfterDarkDLC) {
+                AllowBusInOldTown.AddUI(group);
+                AllowTaxiInOldTown.AddUI(group);
+            }
         }
 
         private static string T(string key) => Translation.Options.Get(key);
+
+        private static bool HasAfterDarkDLC
+            => SteamHelper.IsDLCOwned(SteamHelper.DLC.AfterDarkDLC);
 
         private static void OnAdvancedAIChanged(bool _) {
             if (TMPELifecycle.Instance.Deserializing) return;
@@ -84,6 +107,31 @@ namespace TrafficManager.State {
             } else {
                 AdvancedParkingManager.Instance.OnDisableFeature();
             }
+        }
+
+        private static void OnAllowBusInOldTownChanged(bool value) {
+            if (TMPELifecycle.Instance.Deserializing) return;
+
+            PathFinding config = GlobalConfig.Instance.PathFinding;
+            if (config.AllowBusInOldTownDistricts != value) {
+                config.AllowBusInOldTownDistricts = value;
+                GlobalConfig.WriteConfig();
+            }
+        }
+
+        private static void OnAllowTaxiInOldTownChanged(bool value) {
+            if (TMPELifecycle.Instance.Deserializing) return;
+
+            PathFinding config = GlobalConfig.Instance.PathFinding;
+            if (config.AllowTaxiInOldTownDistricts != value) {
+                config.AllowTaxiInOldTownDistricts = value;
+                GlobalConfig.WriteConfig();
+            }
+        }
+
+        private static bool AfterDarkDlcValidator(bool desired, out bool result) {
+            result = HasAfterDarkDLC && desired;
+            return true;
         }
     }
 }


### PR DESCRIPTION
`After Dark DLC required`

Optional pathfinding penalty skip for buses and taxi for segments in area with **Old Town** policy enabled.

_This enhancement could be more accurate and eliminate cases where vehicles would use **Old Town** districts as a shortcut but determining district ID based only on segment is quite costly so I abandoned the idea. Still, better than nothing, might be improved later when we collect some more feedback how it actually works outside of simple testing scenarios._

---

This enhancement is pretty easy to test. Vanilla applies ~7x cost penalty so the key is to add bus stops outside of the district but making the road layout provoking vehicles to use **Old Town** as shortcut (they won't if not allowed).

Worth noting is the fact that bus line overlay may show incorrect path with the feature **disabled** where vehicle will go through **Old Town** but they actually won't follow restricted part of the path, unless you put bus stop **in the district** which obviously force them to enter it (less likely to overflow path penalty score on short paths between stops), so enhancement settings in that particular case won't make any difference.

---

Settings stored in `GlobalConfig`, both `disabled` by default (vanilla)

Closes #371 , closes #361 

Test build [zip](https://ci.appveyor.com/api/projects/krzychu124/tmpe/artifacts/TMPE.zip?branch=enhancment/371-old-town-policy)