### PR TITLE
Infinite loop while traversing segments of node

### DIFF
--- a/TLM/TLM/Util/Iterators/GetNodeSegmentIdsEnumerator.cs
+++ b/TLM/TLM/Util/Iterators/GetNodeSegmentIdsEnumerator.cs
@@ -17,7 +17,7 @@ namespace TrafficManager.Util.Iterators {
 
         private bool firstRun;
         private ushort currentSegmentId;
-        private int counter;
+        private int watchdog;
 
         public GetNodeSegmentIdsEnumerator(ushort nodeId, ushort initialSegmentId, ClockDirection clockDirection, NetSegment[] segmentBuffer) {
             this.nodeId = nodeId;
@@ -27,7 +27,7 @@ namespace TrafficManager.Util.Iterators {
 
             this.firstRun = true;
             this.currentSegmentId = default;
-            this.counter = 0;
+            this.watchdog = 0;
         }
 
         public ushort Current => currentSegmentId;
@@ -40,7 +40,7 @@ namespace TrafficManager.Util.Iterators {
             } else if (firstRun && initialSegment != 0) {
                 currentSegmentId = initialSegment;
                 firstRun = false;
-                counter++;
+                watchdog++;
                 return true;
             }
 
@@ -52,7 +52,7 @@ namespace TrafficManager.Util.Iterators {
                 throw new Exception($"Unknown ClockDirection '{nameof(clockDirection)}'");
             }
 
-            if (currentSegmentId == 0 || currentSegmentId == initialSegment || ++counter == 8) {
+            if (currentSegmentId == 0 || currentSegmentId == initialSegment || ++watchdog == Constants.MAX_SEGMENTS_OF_NODE) {
                 return false;
             }
 

--- a/TLM/TLM/Util/Iterators/GetNodeSegmentIdsEnumerator.cs
+++ b/TLM/TLM/Util/Iterators/GetNodeSegmentIdsEnumerator.cs
@@ -17,6 +17,7 @@ namespace TrafficManager.Util.Iterators {
 
         private bool firstRun;
         private ushort currentSegmentId;
+        private int counter = 0;
 
         public GetNodeSegmentIdsEnumerator(ushort nodeId, ushort initialSegmentId, ClockDirection clockDirection, NetSegment[] segmentBuffer) {
             this.nodeId = nodeId;
@@ -38,6 +39,7 @@ namespace TrafficManager.Util.Iterators {
             } else if (firstRun && initialSegment != 0) {
                 currentSegmentId = initialSegment;
                 firstRun = false;
+                counter++;
                 return true;
             }
 
@@ -49,7 +51,7 @@ namespace TrafficManager.Util.Iterators {
                 throw new Exception($"Unknown ClockDirection '{nameof(clockDirection)}'");
             }
 
-            if (currentSegmentId == 0 || currentSegmentId == initialSegment) {
+            if (currentSegmentId == 0 || currentSegmentId == initialSegment || ++counter == 8) {
                 return false;
             }
 

--- a/TLM/TLM/Util/Iterators/GetNodeSegmentIdsEnumerator.cs
+++ b/TLM/TLM/Util/Iterators/GetNodeSegmentIdsEnumerator.cs
@@ -17,7 +17,7 @@ namespace TrafficManager.Util.Iterators {
 
         private bool firstRun;
         private ushort currentSegmentId;
-        private int counter = 0;
+        private int counter;
 
         public GetNodeSegmentIdsEnumerator(ushort nodeId, ushort initialSegmentId, ClockDirection clockDirection, NetSegment[] segmentBuffer) {
             this.nodeId = nodeId;
@@ -27,6 +27,7 @@ namespace TrafficManager.Util.Iterators {
 
             this.firstRun = true;
             this.currentSegmentId = default;
+            this.counter = 0;
         }
 
         public ushort Current => currentSegmentId;


### PR DESCRIPTION

- limit number of iterations - node can be connected to 8 segments only
- fixes possible infinite loop due to network configuration properties - parallel segments iteration e.g.: CSUR merge, diverge segments

Fixes #1612 , fixes #1439

Build [ZIP](https://ci.appveyor.com/api/projects/krzychu124/tmpe/artifacts/TMPE.zip?branch=bugfix/1612-infinite-loop-traversing-node-segments)