### PR TITLE
`InvalidOperationException` saving lane connection data

### DIFF
--- a/TLM/TLM/Manager/Impl/LaneConnection/LaneConnectionSubManager.cs
+++ b/TLM/TLM/Manager/Impl/LaneConnection/LaneConnectionSubManager.cs
@@ -735,7 +735,8 @@ namespace TrafficManager.Manager.Impl.LaneConnection {
                 try {
                     var targets = pair.Value;
                     foreach (var target in pair.Value) {
-                        if (!ValidateLane(target.LaneId)) {
+                        // skip invalid connections. Modifying database while iterating will throw InvalidOperationException!!!
+                        if (!target.LaneId.ToLane().IsValidWithSegment()) {
                             continue;
                         }
 #if DEBUGSAVE


### PR DESCRIPTION

Other places where `ValidateLane` is used are ok.

<details>
<summary>Stacktrace</summary>

```cs
Info 6,142.5260298: Saving Mod Data.
Error 6,142.5392794: Error occurred while saving data: System.InvalidOperationException: out of sync
  at System.Collections.Generic.Dictionary`2+Enumerator[TrafficManager.Manager.Impl.LaneConnection.LaneEnd,TrafficManager.Manager.Impl.LaneConnection.LaneConnectionData[]].VerifyState () [0x00000] in <filename unknown>:0 
  at System.Collections.Generic.Dictionary`2+Enumerator[TrafficManager.Manager.Impl.LaneConnection.LaneEnd,TrafficManager.Manager.Impl.LaneConnection.LaneConnectionData[]].MoveNext () [0x00000] in <filename unknown>:0 
  at TrafficManager.Manager.Impl.LaneConnection.LaneConnectionSubManager.SaveData (System.Boolean& success) [0x00000] in <filename unknown>:0 
  at TrafficManager.Manager.Impl.LaneConnection.LaneConnectionManager.SaveData (System.Boolean& success) [0x00000] in <filename unknown>:0 
  at TrafficManager.Lifecycle.SerializableDataExtension.Save () [0x00000] in <filename unknown>:0 
   at CSUtil.Commons.Log.LogToFile(System.String log, LogLevel level)
   at CSUtil.Commons.Log.Error(System.String s)
   at TrafficManager.Lifecycle.SerializableDataExtension.Save()
   at TrafficManager.Lifecycle.SerializableDataExtension.OnSaveData()
   at SerializableDataWrapper.OnSaveData()
   at SimulationManager+Data.Serialize(ColossalFramework.IO.DataSerializer s)
   at ColossalFramework.IO.DataSerializer.Serialize(System.IO.Stream stream, Mode mode, UInt32 version, IDataContainer data)
   at LoadingManager+<SaveSimulationData>c__IteratorC.MoveNext()
   at AsyncTask.Execute()
   at SimulationManager.SimulationStep()
   at SimulationManager.SimulationThread()
   ```
   
</details>
