### PR TITLE
TMPE settings not applied immediately after loading the savegame

### DIFF
--- a/TLM/TLM/Lifecycle/SerializableDataExtension.cs
+++ b/TLM/TLM/Lifecycle/SerializableDataExtension.cs
@@ -121,6 +121,8 @@ namespace TrafficManager.Lifecycle {
                                                 new Exception($"OnAfterLoadData: Error while initializing {manager.GetType().Name}:\n{e}")));
                 }
             }
+
+            Patcher.Install();
         }
 
         private static void DeserializeVersionData(byte[] data) {

--- a/TLM/TLM/Lifecycle/TMPELifecycle.cs
+++ b/TLM/TLM/Lifecycle/TMPELifecycle.cs
@@ -305,8 +305,6 @@ namespace TrafficManager.Lifecycle {
                     uiView.gameObject.AddComponent<RoadSelectionPanels>();
                 }
 
-                Patcher.Install();
-
                 Log.Info("Notifying managers...");
                 foreach (ICustomManager manager in RegisteredManagers) {
                     Log.Info($"OnLevelLoading: {manager.GetType().Name}");

--- a/TLM/TLM/TLM.csproj
+++ b/TLM/TLM/TLM.csproj
@@ -113,8 +113,8 @@
     </Reference>
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Xml" />
-    <Reference Include="UnifiedUILib, Version=2.2.1.1037, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\UnifiedUILib.2.2.1\lib\net35\UnifiedUILib.dll</HintPath>
+    <Reference Include="UnifiedUILib, Version=2.2.12.31246, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\UnifiedUILib.2.2.12\lib\net35\UnifiedUILib.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine">
       <HintPath>$(MangedDLLPath)\UnityEngine.dll</HintPath>

--- a/TLM/TLM/UI/TrafficManagerTool.cs
+++ b/TLM/TLM/UI/TrafficManagerTool.cs
@@ -1660,7 +1660,9 @@ namespace TrafficManager.UI {
         }
 
         public void RemoveUUIButton() {
-            Destroy(UUIButton?.gameObject);
+            if (UUIButton) {
+                Destroy(UUIButton.gameObject);
+            }
             UUIButton = null;
         }
     }

--- a/TLM/TLM/packages.config
+++ b/TLM/TLM/packages.config
@@ -5,5 +5,5 @@
   <package id="Microsoft.Unity.Analyzers" version="1.13.0" targetFramework="net35" developmentDependency="true" />
   <package id="ReflectionIT.Analyzer.Structs" version="0.1.0" targetFramework="net35" />
   <package id="StyleCop.Analyzers" version="1.1.118" targetFramework="net35" developmentDependency="true" />
-  <package id="UnifiedUILib" version="2.2.1" targetFramework="net35" />
+  <package id="UnifiedUILib" version="2.2.12" targetFramework="net35" />
 </packages>


### PR DESCRIPTION
#1624 

- moved Harmony patches installation to earlier step of loading process to prevent network update desync and make it mod load order independent
- the change does not break hot-reload - in both situations mod initialization process goes in the same order

#### Other
- fixed `NullReferenceException` on exit to the Main menu or when user try to reload savegame

Build [zip](https://ci.appveyor.com/api/projects/krzychu124/tmpe/artifacts/TMPE.zip?branch=bugfix/1624-network-not-reflecting-mod-settings)