### PR TITLE
What's new update for 11.6.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,14 @@ This changelog includes all versions and major variants of the mod going all the
 
 > Date format: dd/mm/yyyy
 
+#### TM:PE V11.6.6.2 TEST, 04/08/2022
+
+- [Meta] This update contains important bug fixes before release to Stable
+- [Fixed] After loading savegame settings are not loaded immediately #1624 #1625 (krzychu124)
+- [Fixed] NullReferenceException after exit to the main menu or reloading the savegame #1625 (krzychu124)
+- [Updated] UnifiedUI library update to the latest version (krzychu124)
+- [Steam] [TM:PE v11 TEST](https://steamcommunity.com/sharedfiles/filedetails/?id=2489276785)
+
 #### TM:PE V11.6.6.1 TEST, 31/07/2022
 
 - [Meta] This update contains important bug fixes before release to Stable

--- a/TLM/TLM/Resources/whats_new.txt
+++ b/TLM/TLM/Resources/whats_new.txt
@@ -1,3 +1,11 @@
+[Version] 11.6.6.2
+[Released] Aug 4th 2022
+[Link] tmpe-v11662-test-04082022
+[Fixed] After loading savegame settings are not loaded immediately #1624 #1625 (krzychu124)
+[Fixed] NullReferenceException after exit to the main menu or reloading the savegame #1625 (krzychu124)
+[Updated] UnifiedUI library update to the latest version (krzychu124)
+[/Version]
+
 [Version] 11.6.6.1
 [Released] Jul 31st 2022
 [Link] tmpe-v11661-test-31072022

--- a/TLM/TLM/UI/WhatsNew/WhatsNew.cs
+++ b/TLM/TLM/UI/WhatsNew/WhatsNew.cs
@@ -11,7 +11,7 @@ namespace TrafficManager.UI.WhatsNew {
 
     public class WhatsNew {
         // bump and update what's new changelogs when new features added
-        public static readonly Version CurrentVersion = new Version(11,6,6,1);
+        public static readonly Version CurrentVersion = new Version(11,6,6,2);
 
         private const string WHATS_NEW_FILE = "whats_new.txt";
         private const string RESOURCES_PREFIX = "TrafficManager.Resources.";


### PR DESCRIPTION
- [Fixed] After loading savegame settings are not loaded immediately #1625
- [Fixed] `NullReferenceException` after exit to the main menu or reloading the savegame e25b679f7da7684da16157aa6aaf861d421585f9
- [Updated] UnifiedUI library update to the latest version 4b0164d7cd0e09bd69df5044e085c9c09feca290