### PR TITLE
Lane connections not removed when segment has been released

### DIFF
--- a/TLM/TLM/Manager/Impl/LaneConnection/LaneConnectionSubManager.cs
+++ b/TLM/TLM/Manager/Impl/LaneConnection/LaneConnectionSubManager.cs
@@ -39,6 +39,7 @@ namespace TrafficManager.Manager.Impl.LaneConnection {
                 laneTypes_ |= TrackUtils.TRACK_LANE_TYPES;
                 vehicleTypes_ |= TrackUtils.TRACK_VEHICLE_TYPES;
             }
+            NetManagerEvents.Instance.ReleasingSegment += ReleasingSegment;
         }
 
         public NetInfo.LaneType LaneTypes => laneTypes_;
@@ -51,10 +52,6 @@ namespace TrafficManager.Manager.Impl.LaneConnection {
         public bool Supports(LaneEndTransitionGroup group) => (group & Group) != 0;
 
         public bool Supports(NetInfo.Lane laneInfo) => laneInfo.Matches(laneTypes_, vehicleTypes_);
-
-        private LaneConnectionSubManager() {
-            NetManagerEvents.Instance.ReleasingSegment += ReleasingSegment;
-        }
 
         public override void OnBeforeLoadData() {
             base.OnBeforeLoadData();


### PR DESCRIPTION
Not much to add. 
Listener was in the unused `LaneConnectionSubManager` constructor which resulted in missing actions after segment release (upgrade, collapse etc.) preventing `Routing Manager` from generating default lane transitions - connected lanes are not processed. 
All that resulted in completely detached segments if all lanes were connected before the upgrade/collapse.

Build [**zip**](https://ci.appveyor.com/api/projects/krzychu124/tmpe/artifacts/TMPE.zip?branch=bugfix/lane-connection-not-released-after-ugrading-segment)