### PR TITLE
Train Vehicle Restrictions disabled

### DIFF
--- a/TLM/TLM/Util/Extensions/VehicleExtensions.cs
+++ b/TLM/TLM/Util/Extensions/VehicleExtensions.cs
@@ -92,6 +92,9 @@ namespace TrafficManager.Util.Extensions {
             if ((category & VehicleInfo.VehicleCategory.Emergency) != 0) {
                 type |= ExtVehicleType.Emergency;
             }
+            if ((category & VehicleInfo.VehicleCategory.Trains) != 0) {
+                type |= ExtVehicleType.RailVehicle;
+            }
             return type;
         }
 


### PR DESCRIPTION
Fixes #1644 

- add missing vehicle category used in Vehicle Restrictions UI/Overlay