### PR TITLE
Maintenance: Remove all lane connections

### DIFF
--- a/TLM/TLM/Manager/Impl/LaneConnection/ConnectionDataBase.cs
+++ b/TLM/TLM/Manager/Impl/LaneConnection/ConnectionDataBase.cs
@@ -128,17 +128,17 @@ namespace TrafficManager.Manager.Impl.LaneConnection {
 
             return ret;
         }
-        
+
         /// <summary>
         /// removes all connections from and to the given lane.
         /// </summary>
         internal void RemoveConnections(uint laneId) {
             var laneStart = new LaneEnd(laneId, true);
             var laneEnd = new LaneEnd(laneId, false);
-            if(this.TryGetValue(laneStart,out var startConnections)) { 
+            if(this.TryGetValue(laneStart,out var startConnections)) {
                 foreach (var connection in startConnections) {
                     uint laneId2 = connection.LaneId;
-                    ushort nodeId = laneId.ToLane().GetNodeId(true /* StartConnections */); 
+                    ushort nodeId = laneId.ToLane().GetNodeId(true /* StartConnections */);
                     RemoveConnection(laneId2, laneId, nodeId);
                 }
                 this.Remove(laneStart);
@@ -152,6 +152,10 @@ namespace TrafficManager.Manager.Impl.LaneConnection {
                 }
                 this.Remove(laneEnd);
             }
+        }
+
+        internal void ResetConnectionsDatabase() {
+            this.Clear();
         }
 
         [Conditional("DEBUG")]

--- a/TLM/TLM/Manager/Impl/LaneConnection/LaneConnectionManager.cs
+++ b/TLM/TLM/Manager/Impl/LaneConnection/LaneConnectionManager.cs
@@ -263,6 +263,13 @@ namespace TrafficManager.Manager.Impl.LaneConnection {
             return null;
         }
 
+        internal void RemoveAllLaneConnections() {
+            Log.Info("LaneConnectionManager(): Removing all lane connections...");
+            Road.ResetLaneConnections();
+            Track.ResetLaneConnections();
+            Log.Info("LaneConnectionManager(): All lane connections have been removed!");
+        }
+
         public bool LoadData(List<Configuration.LaneConnection> data) {
             bool success;
             Log.Info($"Loading {data.Count} lane connections");

--- a/TLM/TLM/Manager/Impl/LaneConnection/LaneConnectionSubManager.cs
+++ b/TLM/TLM/Manager/Impl/LaneConnection/LaneConnectionSubManager.cs
@@ -657,6 +657,11 @@ namespace TrafficManager.Manager.Impl.LaneConnection {
             LaneArrowManager.Instance.SetLaneArrows(laneId, arrows, true);
         }
 
+        internal void ResetLaneConnections() {
+            Log.Info($"Resetting lane connections of group: {Group}");
+            connectionDataBase_.ResetConnectionsDatabase();
+        }
+
         public bool LoadData(List<Configuration.LaneConnection> data) {
             bool success = true;
             Log.Info($"Loading {data.Count} lane connections");

--- a/TLM/TLM/State/OptionsTabs/MaintenanceTab_ToolsGroup.cs
+++ b/TLM/TLM/State/OptionsTabs/MaintenanceTab_ToolsGroup.cs
@@ -3,6 +3,7 @@ namespace TrafficManager.State {
     using ICities;
     using TrafficManager.Lifecycle;
     using TrafficManager.Manager.Impl;
+    using TrafficManager.Manager.Impl.LaneConnection;
     using TrafficManager.UI;
     using TrafficManager.UI.Helpers;
 
@@ -20,6 +21,10 @@ namespace TrafficManager.State {
             Label = "Maintenance.Button:Reset custom speed limits",
             Handler = OnResetSpeedLimitsClicked,
         };
+        public static ActionButton RemoveLaneConnections = new() {
+            Label = "Maintenance.Button:Remove all lane connections",
+            Handler = OnResetLaneConnectionsClicked,
+        };
 
         internal static void AddUI(UIHelperBase tab) {
             if (!TMPELifecycle.InGameOrEditor())
@@ -29,6 +34,7 @@ namespace TrafficManager.State {
 
             ResetStuckEntities.AddUI(group);
             RemoveTrafficLights.AddUI(group);
+            RemoveLaneConnections.AddUI(group);
 #if DEBUG
             ResetSpeedLimits.AddUI(group);
 #endif
@@ -55,5 +61,20 @@ namespace TrafficManager.State {
 
         private static void OnResetSpeedLimitsClicked()
             => SpeedLimitManager.Instance.ResetSpeedLimits();
+
+        private static void OnResetLaneConnectionsClicked() {
+            ConfirmPanel.ShowModal(
+                T("Maintenance.Dialog.Title:Remove all lane connections"),
+                T("Maintenance.Dialog.Text:Remove all lane connections, Confirmation"),
+                (_, result) => {
+                    if (result == 1) {
+                        SimulationManager.instance.AddAction(
+                            () => {
+                                LaneConnectionManager.Instance.RemoveAllLaneConnections();
+                                OptionsManager.UpdateRoutingManager();
+                            });
+                    }
+                });
+        }
     }
 }


### PR DESCRIPTION
Resolves #1646 

Simple maintenance tool for removing all lane connections. More info in #1637 
@kianzarrin I'm pretty sure that resetting connection database and requesting full routing recalculation should be enough to make it work correctly. Please double-check.