### PR TITLE
Refresh tooltip

### DIFF
--- a/TLM/TLM/UI/Helpers/SliderOption.cs
+++ b/TLM/TLM/UI/Helpers/SliderOption.cs
@@ -98,22 +98,12 @@ namespace TrafficManager.UI.Helpers {
         protected override void UpdateLabel() {
             if (!HasUI) return;
 
-            _sliderLabel.text = Translate(Label);
+            string tooltip = IsInScope ? $"{Value}{_tooltip}" : Translate(INGAME_ONLY_SETTING);
+            string label = Translate(Label);
+            _sliderLabel.text = label + " " + tooltip;
         }
 
-        protected override void UpdateTooltip() {
-            if (!HasUI) return;
-
-            //UISlider parent(UIPanel) handles tooltip
-            UIComponent parent = _ui.parent;
-            parent.tooltip = IsInScope
-                ? $"{Value}{_tooltip}"
-                : Translate(INGAME_ONLY_SETTING);
-
-            if (parent.isVisible) {
-                parent.RefreshTooltip();
-            }
-        }
+        protected override void UpdateTooltip() => UpdateLabel();
 
         protected override void UpdateReadOnly() {
             if (!HasUI) return;

--- a/TLM/TLM/UI/Helpers/SliderOption.cs
+++ b/TLM/TLM/UI/Helpers/SliderOption.cs
@@ -1,3 +1,4 @@
+#pragma warning disable
 namespace TrafficManager.UI.Helpers {
     using ICities;
     using ColossalFramework.UI;
@@ -104,13 +105,13 @@ namespace TrafficManager.UI.Helpers {
             if (!HasUI) return;
 
             //UISlider parent(UIPanel) handles tooltip
-            _ui.parent.tooltip = IsInScope
+            UIComponent parent = _ui.parent;
+            parent.tooltip = IsInScope
                 ? $"{Value}{_tooltip}"
                 : Translate(INGAME_ONLY_SETTING);
 
-            if (_ui.thumbObject.hasFocus) {
-                try { _ui.RefreshTooltip(); }
-                catch (Exception _) { }
+            if (parent.isVisible) {
+                parent.RefreshTooltip();
             }
         }
 

--- a/TLM/TLM/UI/Helpers/SliderOption.cs
+++ b/TLM/TLM/UI/Helpers/SliderOption.cs
@@ -100,7 +100,7 @@ namespace TrafficManager.UI.Helpers {
 
             string tooltip = IsInScope ? $"{Value}{_tooltip}" : Translate(INGAME_ONLY_SETTING);
             string label = Translate(Label);
-            _sliderLabel.text = label + " " + tooltip;
+            _sliderLabel.text = label + ": " + tooltip;
         }
 
         protected override void UpdateTooltip() => UpdateLabel();


### PR DESCRIPTION
Tooltip box is annoying and hard to notice specially on a black background. I think its better to show value as part of the label text like this
![image](https://user-images.githubusercontent.com/26344691/192761932-afd6885b-8e6d-4727-976e-4faddea1b286.png)

[TMPE.zip](https://ci.appveyor.com/api/projects/krzychu124/tmpe/artifacts/TMPE.zip?branch=refresh-tooltip)

Note
----
in the prev PR tooltip would cause exception when CS is loading because things are not initialized. It can't even tell if it is visible or not. guarding the code like this would avoid the exception:
```cs
if (parent.containsMouse)
  parent.RefreshTooltip();
```
But still the tooltip is hard to notice.