### PR TITLE
Some Vehicle Restrictions are ignored even with `Strict` Vehicle Aggression setting 

### DIFF
--- a/TLM/TLM/Custom/PathFinding/CustomPathManager.cs
+++ b/TLM/TLM/Custom/PathFinding/CustomPathManager.cs
@@ -376,7 +376,7 @@ namespace TrafficManager.Custom.PathFinding {
 
             PathCreationArgs args = new PathCreationArgs {
                 extPathType = ExtPathType.None,
-                extVehicleType = ExtVehicleManager.ConvertToExtVehicleType(vehicleType),
+                extVehicleType = ExtVehicleManager.ConvertToExtVehicleType(vehicleType, vehicleCategory),
                 vehicleId = 0,
                 spawned = true,
                 buildIndex = Singleton<SimulationManager>.instance.m_currentBuildIndex,

--- a/TLM/TLM/Manager/Impl/ExtVehicleManager.cs
+++ b/TLM/TLM/Manager/Impl/ExtVehicleManager.cs
@@ -1050,11 +1050,12 @@ namespace TrafficManager.Manager.Impl {
         /// Converts game VehicleInfo.VehicleType to closest TMPE.API.Traffic.Enums.ExtVehicleType
         /// </summary>
         /// <param name="vehicleType"></param>
+        /// <param name="vehicleCategory"></param>
         /// <returns></returns>
-        public static ExtVehicleType ConvertToExtVehicleType(VehicleInfo.VehicleType vehicleType) {
+        public static ExtVehicleType ConvertToExtVehicleType(VehicleInfo.VehicleType vehicleType, VehicleInfo.VehicleCategory vehicleCategory) {
             ExtVehicleType extVehicleType = ExtVehicleType.None;
             if ((vehicleType & VehicleInfo.VehicleType.Car) != VehicleInfo.VehicleType.None) {
-                extVehicleType = ExtVehicleType.Bus;
+                extVehicleType = vehicleCategory.MapCarVehicleCategoryToExtVehicle();
             } else if ((vehicleType & (VehicleInfo.VehicleType.Train | VehicleInfo.VehicleType.Metro |
                                 VehicleInfo.VehicleType.Monorail)) !=
                 VehicleInfo.VehicleType.None) {

--- a/TLM/TLM/Manager/Impl/VehicleRestrictionsManager.cs
+++ b/TLM/TLM/Manager/Impl/VehicleRestrictionsManager.cs
@@ -261,7 +261,7 @@ namespace TrafficManager.Manager.Impl {
                                | ExtVehicleType.Emergency;
                     } else if ((laneInfo.m_vehicleType & VehicleInfo.VehicleType.Car) !=
                              VehicleInfo.VehicleType.None) {
-                        ret |= laneInfo.vehicleCategory.MapToExtVehicleTypeRestrictions();
+                        ret |= laneInfo.vehicleCategory.MapToExtVehicleTypeRestrictions(checkTrains: false);
                     }
 
                     break;
@@ -270,7 +270,7 @@ namespace TrafficManager.Manager.Impl {
                 default: {
                     if ((laneInfo.m_vehicleType & VehicleInfo.VehicleType.Car) !=
                         VehicleInfo.VehicleType.None) {
-                        ret |= laneInfo.vehicleCategory.MapToExtVehicleTypeRestrictions();
+                        ret |= laneInfo.vehicleCategory.MapToExtVehicleTypeRestrictions(checkTrains: false);
                     }
 
                     break;
@@ -779,7 +779,7 @@ namespace TrafficManager.Manager.Impl {
         }
 
         public ExtVehicleType GetConfigurableVehicleTypes(NetInfo segmentInfo, NetInfo.Lane laneInfo) {
-            return laneInfo.vehicleCategory.MapToExtVehicleTypeRestrictions();
+            return laneInfo.vehicleCategory.MapToExtVehicleTypeRestrictions(checkTrains: (laneInfo.m_vehicleType & VehicleInfo.VehicleType.Car) == VehicleInfo.VehicleType.None);
         }
 
         internal void ClearCache(ushort segmentId) {

--- a/TLM/TLM/Patch/_PathManager/CreatePathPatch.cs
+++ b/TLM/TLM/Patch/_PathManager/CreatePathPatch.cs
@@ -58,9 +58,9 @@ namespace TrafficManager.Patch._PathManager {
                     args.skipQueue = false;
 
             } else {
-                // CreatePath called for vanilla AI
+                // CreatePath called for vanilla or custom not supported AI
                 // determine vehicle type
-                args.extVehicleType = ExtVehicleManager.ConvertToExtVehicleType(vehicleTypes);
+                args.extVehicleType = ExtVehicleManager.ConvertToExtVehicleType(vehicleTypes, vehicleCategories);
                 args.skipQueue = skipQueue;
             }
 

--- a/TLM/TLM/Util/Extensions/VehicleExtensions.cs
+++ b/TLM/TLM/Util/Extensions/VehicleExtensions.cs
@@ -117,6 +117,7 @@ namespace TrafficManager.Util.Extensions {
                                     VehicleInfo.VehicleCategory.Hearse |
                                     VehicleInfo.VehicleCategory.MaintenanceTruck |
                                     VehicleInfo.VehicleCategory.ParkTruck |
+                                    VehicleInfo.VehicleCategory.PostTruck |
                                     VehicleInfo.VehicleCategory.SnowTruck)) != 0) {
                 return ExtVehicleType.Service;
             } else if ((category & VehicleInfo.VehicleCategory.Bus) != 0) {

--- a/TLM/TLM/Util/Extensions/VehicleExtensions.cs
+++ b/TLM/TLM/Util/Extensions/VehicleExtensions.cs
@@ -63,7 +63,7 @@ namespace TrafficManager.Util.Extensions {
         public static ExtVehicleType ToExtVehicleType(this uint vehicleId)
             => ExtVehicleManager.Instance.ExtVehicles[vehicleId].vehicleType;
 
-        public static ExtVehicleType MapToExtVehicleTypeRestrictions(this VehicleInfo.VehicleCategory category) {
+        public static ExtVehicleType MapToExtVehicleTypeRestrictions(this VehicleInfo.VehicleCategory category, bool checkTrains) {
             if (category == VehicleInfo.VehicleCategory.None) {
                 return ExtVehicleType.None;
             }
@@ -92,10 +92,47 @@ namespace TrafficManager.Util.Extensions {
             if ((category & VehicleInfo.VehicleCategory.Emergency) != 0) {
                 type |= ExtVehicleType.Emergency;
             }
-            if ((category & VehicleInfo.VehicleCategory.Trains) != 0) {
-                type |= ExtVehicleType.RailVehicle;
+            if (checkTrains) {
+                if ((category & VehicleInfo.VehicleCategory.Trains) != 0) {
+                    type |= ExtVehicleType.RailVehicle;
+                }
             }
             return type;
+        }
+
+        /// <summary>
+        /// Maps VehicleCategory to ExtVehicleType - works correctly only for VehicleType.Car or shared with Car (Car | Tram)
+        /// Useful as a fallback in case of CreatePath request for not explicitly supported AIs (including custom)
+        /// </summary>
+        /// <param name="category"></param>
+        /// <returns></returns>
+        public static ExtVehicleType MapCarVehicleCategoryToExtVehicle(this VehicleInfo.VehicleCategory category) {
+            if ((category & (VehicleInfo.VehicleCategory.Ambulance |
+                             VehicleInfo.VehicleCategory.FireTruck |
+                             VehicleInfo.VehicleCategory.Police |
+                             VehicleInfo.VehicleCategory.Disaster |
+                             VehicleInfo.VehicleCategory.VacuumTruck)) != 0) {
+                return ExtVehicleType.Emergency;
+            } else if ((category & (VehicleInfo.VehicleCategory.GarbageTruck |
+                                    VehicleInfo.VehicleCategory.Hearse |
+                                    VehicleInfo.VehicleCategory.MaintenanceTruck |
+                                    VehicleInfo.VehicleCategory.ParkTruck |
+                                    VehicleInfo.VehicleCategory.SnowTruck)) != 0) {
+                return ExtVehicleType.Service;
+            } else if ((category & VehicleInfo.VehicleCategory.Bus) != 0) {
+                return ExtVehicleType.Bus;
+            } else if ((category & VehicleInfo.VehicleCategory.Trolleybus) != 0) {
+                return ExtVehicleType.Trolleybus;
+            } else if ((category & VehicleInfo.VehicleCategory.CargoTruck) != 0) {
+                return ExtVehicleType.CargoTruck;
+            } else if ((category & VehicleInfo.VehicleCategory.PassengerCar) != 0) {
+                return ExtVehicleType.PassengerCar;
+            } else if ((category & VehicleInfo.VehicleCategory.Taxi) != 0) {
+                return ExtVehicleType.Taxi;
+            } else if ((category & VehicleInfo.VehicleCategory.Tram) != 0) {
+                return ExtVehicleType.Tram;
+            }
+            return ExtVehicleType.None;
         }
 
         /// <summary>


### PR DESCRIPTION
Improved `ExtVehicleType` detection for vehicle restrictions and unsupported AIs

Depends on network configuration (how long the path will be) Pathfinding could test `CargoTruck` and include `CargoVehicle` in restriction calculations and since vehicle category mapper was including `RailVehicle` into default restrictions allowed (which was a bug), it could allow using lane restricted for `CargoTruck` (`RailVehicle` is not `CargoTruck` but still in `CargoVehicle` group)

I've also added improved `ExtVehicleType` in case other mod add new AI so will be detected correctly by AI VehicleCategory. 

Build [ZIP](https://ci.appveyor.com/api/projects/krzychu124/tmpe/artifacts/TMPE.zip?branch=bugfix/imprecise-vehicle-category-mapping)