### PR TITLE
clear all node rules

### DIFF
--- a/TLM/TLM/Manager/Impl/JunctionRestrictionsManager.cs
+++ b/TLM/TLM/Manager/Impl/JunctionRestrictionsManager.cs
@@ -855,6 +855,19 @@ namespace TrafficManager.Manager.Impl {
             return ret;
         }
 
+        public bool ClearNode(ushort nodeId) {
+            bool ret = false;
+            ref NetNode node = ref nodeId.ToNode();
+            for (int segmentIndex = 0; segmentIndex < Constants.MAX_SEGMENTS_OF_NODE; ++segmentIndex) {
+                ushort segmentId = node.GetSegment(segmentIndex);
+                if (segmentId != 0) {
+                    bool startNode = segmentId.ToSegment().IsStartNode(nodeId);
+                    ret |= ClearSegmentEnd(segmentId, startNode);
+                }
+            }
+            return ret;
+        }
+
         private void SetSegmentJunctionRestrictions(ushort segmentId, bool startNode, JunctionRestrictions restrictions) {
             if (restrictions.HasValue(JunctionRestrictionFlags.AllowUTurn)) {
                 SetUturnAllowed(segmentId, startNode, restrictions.GetValueOrDefault(JunctionRestrictionFlags.AllowUTurn));

--- a/TLM/TLM/Manager/Impl/TrafficLightManager.cs
+++ b/TLM/TLM/Manager/Impl/TrafficLightManager.cs
@@ -159,17 +159,6 @@ namespace TrafficManager.Manager.Impl {
                 : null;
         }
 
-        public bool GetDefaultTrafficLight(ushort nodeId) {
-            NetNode.Flags flags = nodeId.ToNode().m_flags;
-            if (flags.IsFlagSet(NetNode.Flags.CustomTrafficLights)) {
-                NetNode node2 = nodeId.ToNode(); // copy
-                node2.m_flags &= ~NetNode.Flags.CustomTrafficLights;
-                node2.Info?.m_netAI?.UpdateNodeFlags(nodeId, ref node2);
-                flags = node2.m_flags;
-            }
-            return flags.IsFlagSet(NetNode.Flags.TrafficLights);
-        }
-
         bool ITrafficLightManager.CanToggleTrafficLight(ushort nodeId) {
             ref NetNode netNode = ref nodeId.ToNode();
             return netNode.IsValid() &&

--- a/TLM/TLM/UI/MainMenu/OSD/OnscreenDisplay.cs
+++ b/TLM/TLM/UI/MainMenu/OSD/OnscreenDisplay.cs
@@ -27,6 +27,13 @@ namespace TrafficManager.UI.MainMenu.OSD {
             var items = new List<OsdItem>();
             items.Add(new MainMenu.OSD.Label(
                           localizedText: Translation.Menu.Get("Onscreen.Idle:Choose a tool")));
+            items.Add(new MainMenu.OSD.HardcodedMouseShortcut(
+                button: ColossalFramework.UI.UIMouseButton.Left,
+                shift: false,
+                ctrl: false,
+                alt: true,
+                localizedText: "Select a node"));
+
             Display(items);
         }
 

--- a/TLM/TLM/UI/MainMenu/OSD/OnscreenDisplay.cs
+++ b/TLM/TLM/UI/MainMenu/OSD/OnscreenDisplay.cs
@@ -22,21 +22,6 @@ namespace TrafficManager.UI.MainMenu.OSD {
             }
         }
 
-        /// <summary>Clear the OSD panel and display the idle hint.</summary>
-        public static void DisplayIdle() {
-            var items = new List<OsdItem>();
-            items.Add(new MainMenu.OSD.Label(
-                          localizedText: Translation.Menu.Get("Onscreen.Idle:Choose a tool")));
-            items.Add(new MainMenu.OSD.HardcodedMouseShortcut(
-                button: ColossalFramework.UI.UIMouseButton.Left,
-                shift: false,
-                ctrl: false,
-                alt: true,
-                localizedText: "Select a node"));
-
-            Display(items);
-        }
-
         /// <summary>
         /// On Screen Display feature:
         /// Clear, and hide the keybind panel.

--- a/TLM/TLM/UI/RoadSelectionPanels.cs
+++ b/TLM/TLM/UI/RoadSelectionPanels.cs
@@ -185,7 +185,7 @@ namespace TrafficManager.UI {
             if (tool && tool.GetToolMode() == ToolMode.None) {
                 if (!UI.SubTools.PrioritySigns.MassEditOverlay.IsActive) {
                     if (ShouldShowMassEditOverlay()) {
-                        ShowMassEditOverlay();
+                        RoadSelectionUtil.ShowMassEditOverlay();
                     }
                 } else {
                     if (!ShouldShowMassEditOverlay()) {
@@ -234,21 +234,6 @@ namespace TrafficManager.UI {
             roadSelectLabel.isVisible = false;
             roadSelectLegend.isVisible = false;
             roadSelectSprite.isVisible = false;
-        }
-
-        /// <summary>
-        /// Enables and refreshes overlay for various traffic rules influenced by road selection panel.
-        /// </summary>
-        private void ShowMassEditOverlay() {
-            var tmTool = ModUI.GetTrafficManagerTool();
-            if (tmTool == null) {
-                Log.Error("ModUI.GetTrafficManagerTool() returned null");
-                return;
-            }
-            UI.SubTools.PrioritySigns.MassEditOverlay.Show = true;
-            tmTool.SetToolMode(ToolMode.None);
-            tmTool.InitializeSubTools();
-            Log._Debug("Mass edit overlay enabled");
         }
 
         private void HideMassEditOverlay() {
@@ -452,11 +437,11 @@ namespace TrafficManager.UI {
                     if (!IsActive()) {
                         Root.Function = this.Function;
                         Root.Record = Do();
-                        Root.EnqueueAction(Root.ShowMassEditOverlay);
+                        Root.EnqueueAction(RoadSelectionUtil.ShowMassEditOverlay);
                     } else {
                         Root.Function = FunctionModes.None;
                         Undo();
-                        Root.EnqueueAction(Root.ShowMassEditOverlay);
+                        Root.EnqueueAction(RoadSelectionUtil.ShowMassEditOverlay);
                     }
                 }
                 #endregion

--- a/TLM/TLM/UI/SubTools/JunctionRestrictionsTool.cs
+++ b/TLM/TLM/UI/SubTools/JunctionRestrictionsTool.cs
@@ -34,17 +34,9 @@ namespace TrafficManager.UI.SubTools {
 
         public override void OnToolGUI(Event e) {
             // handle delete
+            // TODO: #568 provide unified delete key for all managers.
             if (KeybindSettingsBase.RestoreDefaultsKey.KeyDown(e)) {
-                ref NetNode node = ref SelectedNodeId.ToNode();
-
-                for (int segmentIndex = 0; segmentIndex < Constants.MAX_SEGMENTS_OF_NODE; ++segmentIndex) {
-                    ushort segmentId = node.GetSegment(segmentIndex);
-                    if (segmentId != 0) {
-                        // TODO: #568 provide unified delete key for all managers.
-                        bool startNode = segmentId.ToSegment().IsStartNode(SelectedNodeId);
-                        JunctionRestrictionsManager.Instance.ClearSegmentEnd(segmentId, startNode);
-                    }
-                }
+                JunctionRestrictionsManager.Instance.ClearNode(SelectedNodeId);
             }
         }
 

--- a/TLM/TLM/UI/TrafficManagerTool.cs
+++ b/TLM/TLM/UI/TrafficManagerTool.cs
@@ -1645,31 +1645,31 @@ namespace TrafficManager.UI {
                 shift: false,
                 ctrl: false,
                 alt: false,
-                localizedText: "Onscreen.Default:Select a segment"));
+                localizedText: "Onscreen.Default:Select a road")); // select a road to set as main road.
             items.Add(new MainMenu.OSD.HardcodedMouseShortcut(
                 button: ColossalFramework.UI.UIMouseButton.Left,
                 shift: false,
                 ctrl: false,
                 alt: true,
-                localizedText: "Onscreen.Default:Select a node"));
+                localizedText: "Onscreen.Default:Select a node")); // select a node to erase all traffic rules.
 
-            if(SelectedNodeId != 0) {
+            if (SelectedNodeId != 0) {
                 items.Add(new MainMenu.OSD.Shortcut(
                     keybindSetting: KeybindSettingsBase.RestoreDefaultsKey,
-                    localizedText: "Onscreen.Default:Reset all traffic rules for selected node"));
+                    localizedText: "Onscreen.Default:Erase")); // Erase all traffic rules from selected node.
                 items.Add(new MainMenu.OSD.HardcodedMouseShortcut(
                     button: ColossalFramework.UI.UIMouseButton.Right,
                     shift: false,
                     ctrl: false,
                     alt: false,
-                    localizedText: "Onscreen.Default:Deselect a node"));
+                    localizedText: "Onscreen.Default:Deselect node"));
             }
 
-            OnscreenDisplay.Display(items);
-        }
-
-        public static void OnscreenDisplayNodeSlectionMode() {
-            var items = new List<OsdItem>();
+            items.Add(new MainMenu.OSD.HoldModifier(
+                shift: false,
+                ctrl: true,
+                alt: false,
+                localizedText: "Onscreen.Default:Show traffic rules")); // show traffic rules for high priority roads
 
             OnscreenDisplay.Display(items);
         }

--- a/TLM/TLM/UI/TrafficManagerTool.cs
+++ b/TLM/TLM/UI/TrafficManagerTool.cs
@@ -730,7 +730,10 @@ namespace TrafficManager.UI {
                 }
             } else if (SelectedNodeId != 0 && KeybindSettingsBase.RestoreDefaultsKey.KeyDown(e)) {
                 ushort nodeId = SelectedNodeId;
-                SimulationManager.instance.AddAction(() => PriorityRoad.EraseAllTrafficRoadsForNode(nodeId));
+                SimulationManager.instance.m_ThreadingWrapper.QueueSimulationThread(() => {
+                    PriorityRoad.EraseAllTrafficRoadsForNode(nodeId);
+                    SimulationManager.instance.m_ThreadingWrapper.QueueMainThread(RoadSelectionUtil.ShowMassEditOverlay);
+                });
             }
         }
 

--- a/TLM/TLM/UI/TrafficManagerTool.cs
+++ b/TLM/TLM/UI/TrafficManagerTool.cs
@@ -348,7 +348,7 @@ namespace TrafficManager.UI {
                 toolMode_ = ToolMode.None;
 
                 Log._Debug($"SetToolMode: reset because toolmode not found {newToolMode}");
-                OnscreenDisplay.DisplayIdle();
+                ScreenDisplay();
                 ModUI.Instance?.MainMenu?.UpdateButtons();
                 return;
             }
@@ -728,11 +728,9 @@ namespace TrafficManager.UI {
                             HitPos);
                     });
                 }
-            } else if (e.type == EventType.keyDown && (e.keyCode is KeyCode.Backspace or KeyCode.Delete)) {
-                if (SelectedNodeId != 0) {
-                    ushort nodeId = SelectedNodeId;
-                    SimulationManager.instance.AddAction(() => PriorityRoad.EraseAllTrafficRoadsForNode(nodeId));
-                }
+            } else if (SelectedNodeId != 0 && KeybindSettingsBase.RestoreDefaultsKey.KeyDown(e)) {
+                ushort nodeId = SelectedNodeId;
+                SimulationManager.instance.AddAction(() => PriorityRoad.EraseAllTrafficRoadsForNode(nodeId));
             }
         }
 
@@ -1633,18 +1631,46 @@ namespace TrafficManager.UI {
 
             if (activeOsd == null && activeLegacyOsd == null) {
                 // No tool hint support was available means we have to show the default
-                if (SelectedNodeId != 0) {
-                    OnscreenDisplayNodeSlectionMode();
-                } else {
-                    OnscreenDisplay.DisplayIdle();
-                }
+                ScreenDisplay();
             }
+        }
+
+        /// <summary>Clear the OSD panel and display the idle hint.</summary>
+        public void ScreenDisplay() {
+            var items = new List<OsdItem>();
+            items.Add(new MainMenu.OSD.Label(
+                          localizedText: Translation.Menu.Get("Onscreen.Idle:Choose a tool")));
+            items.Add(new MainMenu.OSD.HardcodedMouseShortcut(
+                button: ColossalFramework.UI.UIMouseButton.Left,
+                shift: false,
+                ctrl: false,
+                alt: false,
+                localizedText: "Onscreen.Default:Select a segment"));
+            items.Add(new MainMenu.OSD.HardcodedMouseShortcut(
+                button: ColossalFramework.UI.UIMouseButton.Left,
+                shift: false,
+                ctrl: false,
+                alt: true,
+                localizedText: "Onscreen.Default:Select a node"));
+
+            if(SelectedNodeId != 0) {
+                items.Add(new MainMenu.OSD.Shortcut(
+                    keybindSetting: KeybindSettingsBase.RestoreDefaultsKey,
+                    localizedText: "Onscreen.Default:Reset all traffic rules for selected node"));
+                items.Add(new MainMenu.OSD.HardcodedMouseShortcut(
+                    button: ColossalFramework.UI.UIMouseButton.Right,
+                    shift: false,
+                    ctrl: false,
+                    alt: false,
+                    localizedText: "Onscreen.Default:Deselect a node"));
+            }
+
+            OnscreenDisplay.Display(items);
         }
 
         public static void OnscreenDisplayNodeSlectionMode() {
             var items = new List<OsdItem>();
-            items.Add(new MainMenu.OSD.Label(localizedText: "Delete/backspace: reset all traffic rules for selected node"));
-            items.Add(new MainMenu.OSD.Label(localizedText: "right-click: deselect node"));
+
             OnscreenDisplay.Display(items);
         }
 

--- a/TLM/TLM/Util/PriorityRoad.cs
+++ b/TLM/TLM/Util/PriorityRoad.cs
@@ -674,5 +674,16 @@ namespace TrafficManager.Util {
             record.Record();
             return record;
         }
+
+        public static void EraseAllTrafficRoadsForNode(ushort nodeId) {
+            try {
+                TrafficLightManager.Instance.ResetTrafficLightAndPrioritySignsFromNode(nodeId);
+                LaneConnectionManager.Instance.RemoveLaneConnectionsFromNode(nodeId);
+                LaneArrowManager.Instance.ResetNodeLaneArrows(nodeId);
+                JunctionRestrictionsManager.Instance.ClearNode(nodeId);
+            } catch (Exception ex) {
+                ex.LogException();
+            }
+        }
     } //end class
 }

--- a/TLM/TLM/Util/RoadSelectionUtil.cs
+++ b/TLM/TLM/Util/RoadSelectionUtil.cs
@@ -5,9 +5,7 @@ namespace TrafficManager.Util {
     using ColossalFramework;
     using ICities;
     using CSUtil.Commons;
-    using static TrafficManager.Util.Shortcuts;
-    using static NetAdjust;
-    using static SegmentTraverser;
+    using TrafficManager.UI;
 
     public class RoadSelectionUtil {
         public RoadSelectionUtil() : base() {
@@ -16,6 +14,21 @@ namespace TrafficManager.Util {
 
         // instance of singleton
         public static RoadSelectionUtil Instance { get; private set; }
+
+        /// <summary>
+        /// Enables and refreshes overlay for various traffic rules influenced by road selection panel.
+        /// </summary>
+        public static void ShowMassEditOverlay() {
+            var tmTool = ModUI.GetTrafficManagerTool();
+            if (tmTool == null) {
+                Log.Error("ModUI.GetTrafficManagerTool() returned null");
+                return;
+            }
+            UI.SubTools.PrioritySigns.MassEditOverlay.Show = true;
+            tmTool.SetToolMode(ToolMode.None);
+            tmTool.InitializeSubTools();
+            Log._Debug("Mass edit overlay enabled");
+        }
 
         public static void Release() {
             if (Instance != null) {
@@ -164,7 +177,7 @@ namespace TrafficManager.Util {
                         RoadSelectionUtil.Instance.OnChanged?.Invoke();
                     }
                     prev_segmentID = segmentID;
-                }catch(Exception e) {
+                } catch(Exception e) {
                     Log.Error(e.Message);
                 }
             }


### PR DESCRIPTION
fixes: #692
when no subtool is selected alt-click on a node and then press delete to clear all node rules (except TTL).

[TMPE.zip](https://ci.appveyor.com/api/projects/krzychu124/tmpe/artifacts/TMPE.zip?branch=clear-node)