### PR TITLE
TTL wait=0 bug

### DIFF
--- a/TLM/TLM/TrafficLight/Impl/TimedTrafficLightsStep.cs
+++ b/TLM/TLM/TrafficLight/Impl/TimedTrafficLightsStep.cs
@@ -677,10 +677,6 @@ namespace TrafficManager.TrafficLight.Impl {
             float newFlow = CurrentFlow;
             float newWait = CurrentWait;
 
-#if DEBUG
-            newFlow = flow;
-            newWait = wait;
-#else
             if (ChangeMetric != StepChangeMetric.Default || Single.IsNaN(newFlow)) {
                 newFlow = flow;
             } else {
@@ -689,7 +685,7 @@ namespace TrafficManager.TrafficLight.Impl {
                           flow; // some smoothing
             }
 
-            if (Single.IsNaN(newWait)) {
+            if (Single.IsNaN(newWait) && ChangeMetric != StepChangeMetric.NoWait) {
                 newWait = 0;
             } else if (ChangeMetric != StepChangeMetric.Default) {
                 newWait = wait;
@@ -698,7 +694,6 @@ namespace TrafficManager.TrafficLight.Impl {
                           (1f - GlobalConfig.Instance.TimedTrafficLights.SmoothingFactor) *
                           wait; // some smoothing
             }
-#endif
 
             // if more cars are waiting than flowing, we change the step
             bool done = ShouldGoToNextStep(newFlow, newWait, out float _);

--- a/TLM/TLM/UI/SubTools/TTL/TimedTrafficLightsTool.cs
+++ b/TLM/TLM/UI/SubTools/TTL/TimedTrafficLightsTool.cs
@@ -950,9 +950,9 @@ namespace TrafficManager.UI.SubTools.TTL {
                 }
 
                 if (GUILayout.Toggle(
-                        _stepMetric == StepChangeMetric.NoFlow,
-                        GetStepChangeMetricDescription(StepChangeMetric.NoFlow),
-                        EmptyOptionsArray)) {
+                    _stepMetric == StepChangeMetric.NoFlow,
+                    GetStepChangeMetricDescription(StepChangeMetric.NoFlow),
+                    EmptyOptionsArray)) {
                     _stepMetric = StepChangeMetric.NoFlow;
                 }
 

--- a/TLM/TLM/UI/SubTools/TTL/TimedTrafficLightsTool.cs
+++ b/TLM/TLM/UI/SubTools/TTL/TimedTrafficLightsTool.cs
@@ -22,6 +22,11 @@ namespace TrafficManager.UI.SubTools.TTL {
     public class TimedTrafficLightsTool
         : LegacySubTool,
           UI.MainMenu.IOnscreenDisplayProvider {
+        private static float minSensitivity_ = 0.001f;
+        private static float maxSensitivity_ = 10;
+        private static float logMinSensitivity_ = Mathf.Log10(minSensitivity_);
+        private static float logMaxSensitivity_ = Mathf.Log10(maxSensitivity_);
+
         private readonly GUI.WindowFunction _guiTimedControlPanelDelegate;
         private readonly GUI.WindowFunction _guiTimedTrafficLightsNodeWindowDelegate;
         private readonly GUI.WindowFunction _guiTimedTrafficLightsPasteWindowDelegate;
@@ -945,10 +950,10 @@ namespace TrafficManager.UI.SubTools.TTL {
                 }
 
                 if (GUILayout.Toggle(
-                    _stepMetric == StepChangeMetric.FirstFlow,
-                    GetStepChangeMetricDescription(StepChangeMetric.FirstFlow),
-                    EmptyOptionsArray)) {
-                    _stepMetric = StepChangeMetric.FirstFlow;
+                        _stepMetric == StepChangeMetric.NoFlow,
+                        GetStepChangeMetricDescription(StepChangeMetric.NoFlow),
+                        EmptyOptionsArray)) {
+                    _stepMetric = StepChangeMetric.NoFlow;
                 }
 
                 if (GUILayout.Toggle(
@@ -959,10 +964,10 @@ namespace TrafficManager.UI.SubTools.TTL {
                 }
 
                 if (GUILayout.Toggle(
-                    _stepMetric == StepChangeMetric.NoFlow,
-                    GetStepChangeMetricDescription(StepChangeMetric.NoFlow),
+                    _stepMetric == StepChangeMetric.FirstFlow,
+                    GetStepChangeMetricDescription(StepChangeMetric.FirstFlow),
                     EmptyOptionsArray)) {
-                    _stepMetric = StepChangeMetric.NoFlow;
+                    _stepMetric = StepChangeMetric.FirstFlow;
                 }
 
                 if (GUILayout.Toggle(
@@ -982,13 +987,17 @@ namespace TrafficManager.UI.SubTools.TTL {
         }
 
         private void BuildFlowPolicyDisplay(bool editable) {
-            string formatStr;
+            if(_stepMetric != StepChangeMetric.Default) {
+                return;
+            }
+
+            string flowBalanceText;
             if (_waitFlowBalance < 0.01f) {
-                formatStr = "{0:0.###}";
+                flowBalanceText = $"{_waitFlowBalance:0.###}";
             } else if (_waitFlowBalance < 0.1f) {
-                formatStr = "{0:0.##}";
+                flowBalanceText = $"{_waitFlowBalance:0.##}";
             } else {
-                formatStr = "{0:0.#}";
+                flowBalanceText = $"{_waitFlowBalance:0.#}";
             }
 
             GUILayout.BeginHorizontal(EmptyOptionsArray);
@@ -996,58 +1005,31 @@ namespace TrafficManager.UI.SubTools.TTL {
 
             // TODO: Clarify for the user what this means, more help text, simpler UI
             if (editable) {
-                string flowBalanceText = string.Format(formatStr, _waitFlowBalance);
                 GUILayout.Label(
                     $"{sensText} ({flowBalanceText}, {GetWaitFlowBalanceInfo()}):",
                     EmptyOptionsArray);
-
-                if (_waitFlowBalance <= 0.01f) {
-                    if (_waitFlowBalance >= 0) {
-                        if (GUILayout.Button("-.001", EmptyOptionsArray)) {
-                            _waitFlowBalance -= 0.001f;
-                        }
-                    }
-
-                    if (_waitFlowBalance < 0.01f) {
-                        if (GUILayout.Button("+.001", EmptyOptionsArray)) {
-                            _waitFlowBalance += 0.001f;
-                        }
-                    }
-                } else if (_waitFlowBalance <= 0.1f) {
-                    if (GUILayout.Button("-.01", EmptyOptionsArray)) {
-                        _waitFlowBalance -= 0.01f;
-                    }
-
-                    if (_waitFlowBalance < 0.1f) {
-                        if (GUILayout.Button("+.01", EmptyOptionsArray)) {
-                            _waitFlowBalance += 0.01f;
-                        }
-                    }
-                }
-
-                if (_waitFlowBalance < 0) {
-                    _waitFlowBalance = 0;
-                }
-
-                if (_waitFlowBalance > 10) {
-                    _waitFlowBalance = 10;
-                }
-
                 GUILayout.EndHorizontal();
 
-                _waitFlowBalance = GUILayout.HorizontalSlider(_waitFlowBalance, 0.001f, 10f, EmptyOptionsArray);
 
-                // step snapping
-                if (_waitFlowBalance < 0.001f) {
+                // logarithmic slider
+                float logValue = GUILayout.HorizontalSlider(
+                    value: Mathf.Log10(_waitFlowBalance),
+                    leftValue: logMinSensitivity_,
+                    rightValue: logMaxSensitivity_,
+                    options: EmptyOptionsArray);
+                _waitFlowBalance = Mathf.Pow(10, logValue);
+
+                // clamp + step snapping
+                if (_waitFlowBalance < minSensitivity_) {
                     _waitFlowBalance = 0.001f;
                 } else if (_waitFlowBalance < 0.01f) {
                     _waitFlowBalance = Mathf.Round(_waitFlowBalance * 1000f) * 0.001f;
                 } else if (_waitFlowBalance < 0.1f) {
                     _waitFlowBalance = Mathf.Round(_waitFlowBalance * 100f) * 0.01f;
-                } else if (_waitFlowBalance < 10f) {
+                } else if (_waitFlowBalance < maxSensitivity_) {
                     _waitFlowBalance = Mathf.Round(_waitFlowBalance * 10f) * 0.1f;
                 } else {
-                    _waitFlowBalance = 10f;
+                    _waitFlowBalance = maxSensitivity_;
                 }
 
                 GUILayout.BeginHorizontal(EmptyOptionsArray);
@@ -1065,7 +1047,6 @@ namespace TrafficManager.UI.SubTools.TTL {
                     style,
                     GUILayout.Height(10));
             } else {
-                string flowBalanceText = string.Format(formatStr, _waitFlowBalance);
                 GUILayout.Label($"{sensText}: {flowBalanceText} ({GetWaitFlowBalanceInfo()})", EmptyOptionsArray);
             }
 


### PR DESCRIPTION
[TMPE.zip](https://ci.appveyor.com/api/projects/krzychu124/tmpe/artifacts/TMPE.zip?branch=TTL-wait-bug)
fixes #1497 see issue

Test
--- 
created a setup like this video https://youtu.be/EqkzznhV6hc?t=760
result:  
- prev code: step3 did not wait for pedestrians to pass
- fixed code: step3 properly waits for pedestrian to pass

side effects
--- 
   the fix is guarded by `ChangeMetric != StepChangeMetric.NoWait` so it has not effect on other change metrics.