### PR TITLE
bugfix: dead end connection becomes disabled when removed.

### DIFF
--- a/TLM/TLM/Manager/Impl/LaneConnection/ConnectionDataBase.cs
+++ b/TLM/TLM/Manager/Impl/LaneConnection/ConnectionDataBase.cs
@@ -65,6 +65,11 @@ namespace TrafficManager.Manager.Impl.LaneConnection {
 
         /// <summary>removes the connection from source to target lane at the given node</summary>
         internal bool Disconnect(uint sourceLaneId, uint targetLaneId, ushort nodeId) {
+            if(sourceLaneId == targetLaneId) {
+                RemoveConnection(sourceLaneId, targetLaneId, nodeId);
+                return RemoveConnection(sourceLaneId, targetLaneId, nodeId);
+            }
+
             // if backward connection exists (uni-directional) then just disable the connection.
             // otherwise delete both connections.
             bool backward = IsConnectedTo(targetLaneId, sourceLaneId, nodeId);

--- a/TLM/TLM/Manager/Impl/LaneConnection/ConnectionDataBase.cs
+++ b/TLM/TLM/Manager/Impl/LaneConnection/ConnectionDataBase.cs
@@ -66,7 +66,6 @@ namespace TrafficManager.Manager.Impl.LaneConnection {
         /// <summary>removes the connection from source to target lane at the given node</summary>
         internal bool Disconnect(uint sourceLaneId, uint targetLaneId, ushort nodeId) {
             if(sourceLaneId == targetLaneId) {
-                RemoveConnection(sourceLaneId, targetLaneId, nodeId);
                 return RemoveConnection(sourceLaneId, targetLaneId, nodeId);
             }
 

--- a/TLM/TLM/Manager/Impl/LaneConnection/LaneConnectionSubManager.cs
+++ b/TLM/TLM/Manager/Impl/LaneConnection/LaneConnectionSubManager.cs
@@ -457,13 +457,22 @@ namespace TrafficManager.Manager.Impl.LaneConnection {
         }
 
         private void AssertLane(uint laneId, bool startNode) {
-            Assert(laneId.ToLane().IsValidWithSegment(), $"IsValidWithSegment() failed for laneId:{laneId}");
-            var connections = GetLaneConnections(laneId, startNode);
-            if (connections != null && connections.Contains(laneId)) {
-                // dead end should only have one connection to itself.
-                ushort nodeId = laneId.ToLane().GetNodeId(startNode);
-                Assert(connections.Length == 1, $"connections for lane:{laneId} at node:{nodeId} = " + connections.ToSTR());
-            } 
+            try {
+                Assert(laneId.ToLane().IsValidWithSegment(), $"IsValidWithSegment() failed for laneId:{laneId}");
+                if (connectionDataBase_.TryGetValue(new LaneEnd(laneId, startNode), out var connections) &&
+                    connections.Any(item => item.LaneId == laneId)) {
+                    ushort nodeId = laneId.ToLane().GetNodeId(startNode);
+                    Assert(connections.Length == 1,
+                        $"dead end should only have one connection to itself. " +
+                        $"connections for lane:{laneId} at node:{nodeId} = " + connections.ToSTR());
+
+                    Assert(connections[0].Enabled,
+                        $"disabled dead should be deleted. " +
+                        $"connection data for lane:{laneId} at node:{nodeId} = " + connections[0]);
+                }
+            } catch(Exception ex) {
+                ex.LogException();
+            }
         }
 
         private void ReleasingSegment(ushort segmentId, ref NetSegment segment) {


### PR DESCRIPTION
fixes #1678
code is simple and self explanatory.

changes:
- added extra condition to handle removal of special case of dead end.
- improved lane assertion to check for disabled dead end.

[TMPE.zip](https://ci.appveyor.com/api/projects/krzychu124/tmpe/artifacts/TMPE.zip?branch=dead-end-fix)

I Tested the code like this:
- make and remove dead end connection
- then make and remove connection to another track
- then make connection to the other track and remove it by making a dead end connection.
- then make a dead end connection and remove it by making connection to the other track
expected result: 
 - tracks are connected and disconnected as expected
 - no assertion/exception/error in the log.
