### PR TITLE
Compatibility patch for 1.15.1-f4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,24 @@ This changelog includes all versions and major variants of the mod going all the
 
 > Date format: dd/mm/yyyy
 
+#### TM:PE V[11.7.2.0](https://github.com/CitiesSkylinesMods/TMPE/compare/11.7.1.2...11.7.2.0) STABLE, 15/11/2022
+
+- [Meta] Compatibility patch for the game update 1.15.1-f4 (krzychu124)
+- [New] Clear all TM:PE rules from selected node #692, #1668 (kianzarrin)
+- [Fixed] Timed Traffic Lights wait = 0 issues #1497, #1674 (kianzarrin)
+- [Updated] Minor changes to Timed Traffic Lights sensitivity slider #1670 (kianzarrin)
+- [Updated] Pedestrian zone roads have now lower priority when setting up high priority road #1653 (kianzarrin)
+- [Steam] [TM:PE v11 STABLE](https://steamcommunity.com/sharedfiles/filedetails/?id=1637663252)
+
+#### TM:PE V11.7.2.0 TEST, 15/11/2022
+
+- [Meta] Compatibility patch for the game update 1.15.1-f4 (krzychu124)
+- [New] Clear all TM:PE rules from selected node #692, #1668 (kianzarrin)
+- [Fixed] Timed Traffic Lights wait = 0 issues #1497, #1674 (kianzarrin)
+- [Updated] Minor changes to Timed Traffic Lights sensitivity slider #1670 (kianzarrin)
+- [Updated] Pedestrian zone roads have now lower priority when setting up high priority road #1653 (kianzarrin)
+- [Steam] [TM:PE v11 TEST](https://steamcommunity.com/sharedfiles/filedetails/?id=2489276785)
+
 #### TM:PE V[11.7.1.2](https://github.com/CitiesSkylinesMods/TMPE/compare/11.7.1.1...11.7.1.2) STABLE, 11/10/2022
 
 - [Fixed] Game crash on load (krzychu124)

--- a/TLM/SharedAssemblyInfo.cs
+++ b/TLM/SharedAssemblyInfo.cs
@@ -20,4 +20,4 @@ using System.Runtime.InteropServices;
 //      Minor Version
 //      Build Number
 //      Revision
-[assembly: AssemblyVersion("11.7.1.*")]
+[assembly: AssemblyVersion("11.7.2.*")]

--- a/TLM/TLM/Custom/PathFinding/CustomPathFind.cs
+++ b/TLM/TLM/Custom/PathFinding/CustomPathFind.cs
@@ -2630,6 +2630,11 @@ namespace TrafficManager.Custom.PathFinding {
                     $"\toffsetLength={offsetLength}");
             }
 #endif
+            if ((vehicleCategory_ & VehicleInfo.VehicleCategory.PublicTransportRoad) != 0 &&
+                (vehicleCategory_ & ~(VehicleInfo.VehicleCategory.Bus | VehicleInfo.VehicleCategory.Trolleybus | VehicleInfo.VehicleCategory.Taxi)) == 0)
+            {
+                offsetLength *= 0.75f;
+            }
 
             float baseLength = offsetLength / (prevLaneSpeed * maxLength_); // NON-STOCK CODE
             float comparisonValue = item.ComparisonValue; // NON-STOCK CODE
@@ -3113,12 +3118,6 @@ namespace TrafficManager.Custom.PathFinding {
                                 nextItem.ComparisonValue +=
                                     20f / ((prevMaxSpeed + nextMaxSpeed) * 0.5f * maxLength_);
                             }
-                        }
-
-                        if ((nextLaneInfo.vehicleCategory & VehicleInfo.VehicleCategory.PublicTransportRoad) != 0 &&
-                            (nextLaneInfo.vehicleCategory & ~(VehicleInfo.VehicleCategory.Bus | VehicleInfo.VehicleCategory.Trolleybus | VehicleInfo.VehicleCategory.Taxi)) == 0)
-                        {
-                            nextItem.ComparisonValue /= 100f;
                         }
 
                         if (isLogEnabled) {

--- a/TLM/TLM/Patch/_VehicleAI/VehicleAICommons.cs
+++ b/TLM/TLM/Patch/_VehicleAI/VehicleAICommons.cs
@@ -12,7 +12,7 @@ namespace TrafficManager.Patch._VehicleAI {
     using UnityEngine.UI;
 
     public class VehicleAICommons {
-        private static readonly float vanillaSlowDrivingSpeed = 0.16f;
+        private static readonly float vanillaSlowDrivingSpeed = 0.4f;
 
         private static CalculateTargetSpeedDelegate CalculateTargetSpeed = GameConnectionManager.Instance.VehicleAIConnection.CalculateTargetSpeed;
         private static CalculateTargetSpeedByNetInfoDelegate CalculateTargetSpeedByNetInfo = GameConnectionManager.Instance.VehicleAIConnection.CalculateTargetSpeedByNetInfo;

--- a/TLM/TLM/Resources/whats_new.txt
+++ b/TLM/TLM/Resources/whats_new.txt
@@ -1,23 +1,10 @@
-[Version] 11.7.1.2
-[Released] Oct 11th 2022
-[Link] tmpe-v11712-stable-11102022
+[Version] 11.7.2.0
+[Released] Nov 15th 2022
+[Link] tmpe-v11720-stable-15112022
 [Stable]
-[Fixed] Game crash on load (krzychu124)
-[/Version]
-
-[Version] 11.7.1.1
-[Released] Oct 10th 2022
-[Link] tmpe-v11711-stable-10102022
-[Stable]
-[Meta] TM:PE 11.7.1.1 TEST branch released as STABLE - huge thanks to our beta testers!
-[New] Dead-end lane connections #1613, #1213 (kianzarrin)
-[New] Reset lane arrows when the user delete lane connections from selected node #1613 (kianzarrin)
-[Fixed] Cargo Trucks ignoring vehicle restrictions #1661 (krzychu124)
-[Fixed] Parking AI - "thinking about a parking spot" near pedestrian streets #1661, #1655 (krzychu124)
-[Fixed] Parking AI confused in large parking lots #1626, #1394, #924, #423, #352 (krzychu124)
-[Fixed] Internal issues causing desyc when other mod patched Citizen / CitizenUnit size in CitizenManager #1599 (krzychu124)
-[Updated] Slider value moved to label instead of tooltip #1660 (kianzarrin)
-[Updated] Hotreload save - debug improvements #1635 (kianzarrin)
-[Updated] Show DLC icon near the option if the feature requires DLC mechanics to work (previously the option was invisible without DLC) (krzychu124)
-[Updated] Translations update - Chinese Simplified, French, Indonesian, Korean, Slovak, Spanish, Thai
+[Meta] Compatibility patch for the game update 1.15.1-f4 (krzychu124)
+[New] Clear all TM:PE rules from selected node #692, #1668 (kianzarrin)
+[Fixed] Timed Traffic Lights wait = 0 issues #1497, #1674 (kianzarrin)
+[Updated] Minor changes to Timed Traffic Lights sensitivity slider #1670 (kianzarrin)
+[Updated] Pedestrian zone roads have now lower priority when setting up high priority road #1653 (kianzarrin)
 [/Version]

--- a/TLM/TLM/UI/WhatsNew/WhatsNew.cs
+++ b/TLM/TLM/UI/WhatsNew/WhatsNew.cs
@@ -11,7 +11,7 @@ namespace TrafficManager.UI.WhatsNew {
 
     public class WhatsNew {
         // bump and update what's new changelogs when new features added
-        public static readonly Version CurrentVersion = new Version(11,7,1,2);
+        public static readonly Version CurrentVersion = new Version(11,7,2,0);
 
         private const string WHATS_NEW_FILE = "whats_new.txt";
         private const string RESOURCES_PREFIX = "TrafficManager.Resources.";

--- a/TLM/TLM/Util/VersionUtil.cs
+++ b/TLM/TLM/Util/VersionUtil.cs
@@ -35,10 +35,10 @@ namespace TrafficManager.Util {
         // we could alternatively use BuildConfig.APPLICATION_VERSION because const values are evaluated at compile time.
         // but I have decided not to do this because I don't want this to happen automatically with a rebuild if
         // CS updates. these values should be changed manually so as to force us to acknowledge that they have changed.
-        public const uint EXPECTED_GAME_VERSION_U = 197256976U;
+        public const uint EXPECTED_GAME_VERSION_U = 197387280U;
 
         // see comments for EXPECTED_GAME_VERSION_U.
-        public static Version ExpectedGameVersion => new Version(1, 15, 0, 7);
+        public static Version ExpectedGameVersion => new Version(1, 15, 1, 4);
 
         public static string ExpectedGameVersionString => BuildConfig.VersionToString(EXPECTED_GAME_VERSION_U, false);
 


### PR DESCRIPTION
- [Meta] Compatibility path for **1.15.1-f4**
- [New] Clear all TM:PE rules from selected node #692, #1668 
- [Fixed] Timed Traffic Lights wait = 0 issues #1497, #1674
- [Updated] Minor changes to Timed Traffic Lights sensitivity slider #1670
- [Updated] Pedestrian zone roads have now lower priority when setting up high priority road #1653 