### PR TITLE
Get Segment End API

### DIFF
--- a/TLM/TLM/Manager/Impl/ExtSegmentEndManager.cs
+++ b/TLM/TLM/Manager/Impl/ExtSegmentEndManager.cs
@@ -94,12 +94,13 @@ namespace TrafficManager.Manager.Impl {
             extSegmentEnd.firstVehicleId = 0;
         }
 
+        public ref ExtSegmentEnd GetEnd(ushort segmentId, bool startNode) => ref ExtSegmentEnds[GetIndex(segmentId, startNode)];
+
+        public ref ExtSegmentEnd GetEnd(ushort segmentId, ushort nodeId) => ref ExtSegmentEnds[GetIndex(segmentId, nodeId)];
+
         public int GetIndex(ushort segmentId, bool startNode) {
             return (segmentId * 2) + (startNode ? 0 : 1);
         }
-
-        public ref ExtSegmentEnd GetEnd(ushort segmentId, bool startNode) => ref ExtSegmentEnds[GetIndex(segmentId, startNode)];
-        public ref ExtSegmentEnd GetEnd(ushort segmentId, ushort nodeId) => ref ExtSegmentEnds[GetIndex(segmentId, nodeId)];
 
         public int GetIndex(ushort segmentId, ushort nodeId) {
             bool found = false;

--- a/TLM/TLM/Manager/Impl/ExtSegmentEndManager.cs
+++ b/TLM/TLM/Manager/Impl/ExtSegmentEndManager.cs
@@ -99,7 +99,7 @@ namespace TrafficManager.Manager.Impl {
         }
 
         public ref ExtSegmentEnd GetEnd(ushort segmentId, bool startNode) => ref ExtSegmentEnds[GetIndex(segmentId, startNode)];
-        public ref ExtSegmentEnd GetEnd(ushort segmentId, ushort nodeID) => ref ExtSegmentEnds[GetIndex(segmentId, nodeID)];
+        public ref ExtSegmentEnd GetEnd(ushort segmentId, ushort nodeId) => ref ExtSegmentEnds[GetIndex(segmentId, nodeId)];
 
         public int GetIndex(ushort segmentId, ushort nodeId) {
             bool found = false;

--- a/TLM/TLM/Manager/Impl/ExtSegmentEndManager.cs
+++ b/TLM/TLM/Manager/Impl/ExtSegmentEndManager.cs
@@ -98,6 +98,9 @@ namespace TrafficManager.Manager.Impl {
             return (segmentId * 2) + (startNode ? 0 : 1);
         }
 
+        public ref ExtSegmentEnd GetEnd(ushort segmentId, bool startNode) => ref ExtSegmentEnds[GetIndex(segmentId, startNode)];
+        public ref ExtSegmentEnd GetEnd(ushort segmentId, ushort nodeID) => ref ExtSegmentEnds[GetIndex(segmentId, nodeID)];
+
         public int GetIndex(ushort segmentId, ushort nodeId) {
             bool found = false;
             bool startNode = false;

--- a/TLM/TMPE.API/Manager/IExtSegmentEndManager.cs
+++ b/TLM/TMPE.API/Manager/IExtSegmentEndManager.cs
@@ -8,6 +8,10 @@ namespace TrafficManager.API.Manager {
         /// </summary>
         ExtSegmentEnd[] ExtSegmentEnds { get; }
 
+        ref ExtSegmentEnd GetEnd(ushort segmentId, bool startNode);
+
+        ref ExtSegmentEnd GetEnd(ushort segmentId, ushort nodeID);
+
         /// <summary>
         /// Resets both segment ends of the given segment.
         /// </summary>

--- a/TLM/TMPE.API/Manager/IExtSegmentEndManager.cs
+++ b/TLM/TMPE.API/Manager/IExtSegmentEndManager.cs
@@ -8,15 +8,15 @@ namespace TrafficManager.API.Manager {
         /// </summary>
         ExtSegmentEnd[] ExtSegmentEnds { get; }
 
-        ref ExtSegmentEnd GetEnd(ushort segmentId, bool startNode);
-
-        ref ExtSegmentEnd GetEnd(ushort segmentId, ushort nodeID);
-
         /// <summary>
         /// Resets both segment ends of the given segment.
         /// </summary>
         /// <param name="segmentId">segment id</param>
         void Reset(ushort segmentId);
+
+        ref ExtSegmentEnd GetEnd(ushort segmentId, bool startNode);
+
+        ref ExtSegmentEnd GetEnd(ushort segmentId, ushort nodeID);
 
         /// <summary>
         /// Determines the index of the segment end.


### PR DESCRIPTION
I think `ExtSegmentEndManager` is exposing too much detail. instead of exposing `GetIndex()` and `ExtSegmentEnds` array its to introduce an API method that hides this complexity from user.
Code is self explanatory and is unused from inside TMPE.
