### PR TITLE
central default values

### DIFF
--- a/TLM/.editorconfig
+++ b/TLM/.editorconfig
@@ -29,6 +29,7 @@ dotnet_diagnostic.SA1309.severity = silent
 dotnet_diagnostic.SA1310.severity = none
 dotnet_diagnostic.SA1401.severity = none # field should be private
 dotnet_diagnostic.SA1407.severity = none # Arithmetic expressions should declare precedence
+dotnet_diagnostic.SA1402.severity = none # File may only contain a single type
 dotnet_diagnostic.SA1500.severity = silent # BracesForMultiLineStatementsMustNotShareLine
 dotnet_diagnostic.SA1502.severity = none # ElementMustNotBeOnSingleLine
 dotnet_diagnostic.SA1503.severity = suggestion

--- a/TLM/TLM/Manager/Impl/OptionsManager.cs
+++ b/TLM/TLM/Manager/Impl/OptionsManager.cs
@@ -78,47 +78,6 @@ namespace TrafficManager.Manager.Impl {
             => TMPELifecycle.Instance.MayPublishSegmentChanges();
 
         /// <summary>
-        /// Converts value to SimulationAccuracy
-        /// </summary>
-        /// <param name="value">Old value</param>
-        /// <returns>SimulationAccuracy value</returns>
-        private static SimulationAccuracy ConvertToSimulationAccuracy(byte value) {
-            return SimulationAccuracy.MaxValue - value;
-        }
-
-        /// <summary>
-        /// Converts SimulationAccuracy to SimulationAccuracy
-        /// </summary>
-        /// <param name="value">SimulationAccuracy value</param>
-        /// <returns>byte representation of value (backward compatible)</returns>
-        private static byte ConvertFromSimulationAccuracy(SimulationAccuracy value) {
-            return (byte)(SimulationAccuracy.MaxValue - value);
-        }
-
-        private static bool LoadBool([NotNull] byte[] data, uint idx, bool defaultVal = false)
-            => (data.Length > idx) ? data[idx] == 1 : defaultVal;
-
-        private static byte LoadByte([NotNull] byte[] data, uint idx, byte defaultVal = 0)
-            => (data.Length > idx) ? data[idx] : defaultVal;
-
-        /// <summary>Load LegacySerializableOption bool.</summary>
-        private static void ToCheckbox(byte[] data, uint idx, ILegacySerializableOption opt, bool defaultVal = false)
-            => opt.Load((byte)(LoadBool(data, idx, defaultVal) ? 1 : 0));
-
-        /// <summary>Load LegacySerializableOption byte.</summary>
-        private static void ToSlider(byte[] data, uint idx, ILegacySerializableOption opt, byte defaultVal = 0)
-            => opt.Load(LoadByte(data, idx, defaultVal));
-
-        private static void ToDropDown<TEnum>(byte[] data, uint idx, ILegacySerializableOption opt, TEnum defaultVal)
-            where TEnum: struct,Enum,IConvertible {
-            if (idx < data.Length) {
-                opt.Load(data[idx]);
-            } else {
-                opt.Load(defaultVal.ToByte(null));
-            }
-        }
-
-        /// <summary>
         /// Restores the mod options based on supplied <paramref name="data"/>.
         /// </summary>
         /// <param name="data">Byte array obtained from the savegame.</param>
@@ -135,87 +94,87 @@ namespace TrafficManager.Manager.Impl {
 
                 if (dataVersion >= 3 || data.Length == 0) {
                     // new version or default.
-                    ToDropDown(data, idx: 0, GeneralTab_SimulationGroup.SimulationAccuracy, SimulationAccuracy.VeryHigh);
+                    LoadOption(data, idx: 0, GeneralTab_SimulationGroup.SimulationAccuracyOption);
                 } else {
                     // legacy
-                    GeneralTab_SimulationGroup.SimulationAccuracy.Load((byte)(SimulationAccuracy.MaxValue - data[0]));
+                    GeneralTab_SimulationGroup.SimulationAccuracyOption.Load((byte)(SimulationAccuracy.MaxValue - data[0]));
                 }
 
                 // skip Options.setLaneChangingRandomization(options[1]);
-                ToDropDown(data, idx: 2, GameplayTab_VehicleBehaviourGroup.RecklessDrivers, RecklessDrivers.HolyCity);
-                ToCheckbox(data, idx: 3, PoliciesTab_AtJunctionsGroup.RelaxedBusses, true);
-                ToCheckbox(data, idx: 4, OverlaysTab_OverlaysGroup.NodesOverlay, false);
-                ToCheckbox(data, idx: 5, PoliciesTab_AtJunctionsGroup.AllowEnterBlockedJunctions, false);
-                ToCheckbox(data, idx: 6, GameplayTab_AIGroups.AdvancedAI, false);
-                ToCheckbox(data, idx: 7, PoliciesTab_OnHighwaysGroup.HighwayRules, false);
-                ToCheckbox(data, idx: 8, OverlaysTab_OverlaysGroup.PrioritySignsOverlay, false);
-                ToCheckbox(data, idx: 9, OverlaysTab_OverlaysGroup.TimedLightsOverlay, false);
-                ToCheckbox(data, idx: 10, OverlaysTab_OverlaysGroup.SpeedLimitsOverlay, false);
-                ToCheckbox(data, idx: 11, OverlaysTab_OverlaysGroup.VehicleRestrictionsOverlay, false);
-                ToCheckbox(data, idx: 12, GameplayTab_VehicleBehaviourGroup.StrongerRoadConditionEffects, false);
-                ToCheckbox(data, idx: 13, PoliciesTab_AtJunctionsGroup.AllowUTurns, false);
-                ToCheckbox(data, idx: 14, PoliciesTab_AtJunctionsGroup.AllowLaneChangesWhileGoingStraight, false);
+                LoadOption(data, idx: 2, GameplayTab_VehicleBehaviourGroup.RecklessDriversOption);
+                LoadOption(data, idx: 3, PoliciesTab_AtJunctionsGroup.RelaxedBusses);
+                LoadOption(data, idx: 4, OverlaysTab_OverlaysGroup.NodesOverlay);
+                LoadOption(data, idx: 5, PoliciesTab_AtJunctionsGroup.AllowEnterBlockedJunctions);
+                LoadOption(data, idx: 6, GameplayTab_AIGroups.AdvancedAI);
+                LoadOption(data, idx: 7, PoliciesTab_OnHighwaysGroup.HighwayRules);
+                LoadOption(data, idx: 8, OverlaysTab_OverlaysGroup.PrioritySignsOverlay);
+                LoadOption(data, idx: 9, OverlaysTab_OverlaysGroup.TimedLightsOverlay);
+                LoadOption(data, idx: 10, OverlaysTab_OverlaysGroup.SpeedLimitsOverlay);
+                LoadOption(data, idx: 11, OverlaysTab_OverlaysGroup.VehicleRestrictionsOverlay);
+                LoadOption(data, idx: 12, GameplayTab_VehicleBehaviourGroup.StrongerRoadConditionEffects);
+                LoadOption(data, idx: 13, PoliciesTab_AtJunctionsGroup.AllowUTurns);
+                LoadOption(data, idx: 14, PoliciesTab_AtJunctionsGroup.AllowLaneChangesWhileGoingStraight);
 
                 if (dataVersion < 1) {
                     GameplayTab_VehicleBehaviourGroup.DisableDespawning.Value = !LoadBool(data, idx: 15, true); // inverted
                 } else {
-                    ToCheckbox(data, idx: 15, GameplayTab_VehicleBehaviourGroup.DisableDespawning, false); // not inverted
+                    LoadOption(data, idx: 15, GameplayTab_VehicleBehaviourGroup.DisableDespawning); // not inverted
                 }
 
                 // skip Options.setDynamicPathRecalculation(data[16] == (byte)1);
-                ToCheckbox(data, idx: 17, OverlaysTab_OverlaysGroup.ConnectedLanesOverlay, false);
-                ToCheckbox(data, idx: 18, MaintenanceTab_FeaturesGroup.PrioritySignsEnabled, true);
-                ToCheckbox(data, idx: 19, MaintenanceTab_FeaturesGroup.TimedLightsEnabled, true);
-                ToCheckbox(data, idx: 20, MaintenanceTab_FeaturesGroup.CustomSpeedLimitsEnabled, true);
-                ToCheckbox(data, idx: 21, MaintenanceTab_FeaturesGroup.VehicleRestrictionsEnabled, true);
-                ToCheckbox(data, idx: 22, MaintenanceTab_FeaturesGroup.LaneConnectorEnabled, true);
-                ToCheckbox(data, idx: 23, OverlaysTab_OverlaysGroup.JunctionRestrictionsOverlay, false);
-                ToCheckbox(data, idx: 24, MaintenanceTab_FeaturesGroup.JunctionRestrictionsEnabled, true);
-                ToCheckbox(data, idx: 25, GameplayTab_AIGroups.ParkingAI, false);
-                ToCheckbox(data, idx: 26, PoliciesTab_OnHighwaysGroup.PreferOuterLane, false);
-                ToCheckbox(data, idx: 27, GameplayTab_VehicleBehaviourGroup.IndividualDrivingStyle, true);
-                ToCheckbox(data, idx: 28, PoliciesTab_InEmergenciesGroup.EvacBussesMayIgnoreRules, false);
-                // skip ToCheckbox(data, idx: 29, GeneralTab_SimulationGroup.InstantEffects, true);
-                ToCheckbox(data, idx: 30, MaintenanceTab_FeaturesGroup.ParkingRestrictionsEnabled, true);
-                ToCheckbox(data, idx: 31, OverlaysTab_OverlaysGroup.ParkingRestrictionsOverlay, false);
-                ToCheckbox(data, idx: 32, PoliciesTab_OnRoadsGroup.BanRegularTrafficOnBusLanes, false);
-                ToCheckbox(data, idx: 33, OverlaysTab_OverlaysGroup.ShowPathFindStats, VersionUtil.IS_DEBUG);
-                ToSlider(data, idx: 34, GameplayTab_AIGroups.AltLaneSelectionRatio, 0);
+                LoadOption(data, idx: 17, OverlaysTab_OverlaysGroup.ConnectedLanesOverlay);
+                LoadOption(data, idx: 18, MaintenanceTab_FeaturesGroup.PrioritySignsEnabled);
+                LoadOption(data, idx: 19, MaintenanceTab_FeaturesGroup.TimedLightsEnabled);
+                LoadOption(data, idx: 20, MaintenanceTab_FeaturesGroup.CustomSpeedLimitsEnabled);
+                LoadOption(data, idx: 21, MaintenanceTab_FeaturesGroup.VehicleRestrictionsEnabled);
+                LoadOption(data, idx: 22, MaintenanceTab_FeaturesGroup.LaneConnectorEnabled);
+                LoadOption(data, idx: 23, OverlaysTab_OverlaysGroup.JunctionRestrictionsOverlay);
+                LoadOption(data, idx: 24, MaintenanceTab_FeaturesGroup.JunctionRestrictionsEnabled);
+                LoadOption(data, idx: 25, GameplayTab_AIGroups.ParkingAI);
+                LoadOption(data, idx: 26, PoliciesTab_OnHighwaysGroup.PreferOuterLane);
+                LoadOption(data, idx: 27, GameplayTab_VehicleBehaviourGroup.IndividualDrivingStyle);
+                LoadOption(data, idx: 28, PoliciesTab_InEmergenciesGroup.EvacBussesMayIgnoreRules);
+                // skip LoadOption(data, idx: 29, GeneralTab_SimulationGroup.InstantEffects, defaultVal: true);
+                LoadOption(data, idx: 30, MaintenanceTab_FeaturesGroup.ParkingRestrictionsEnabled);
+                LoadOption(data, idx: 31, OverlaysTab_OverlaysGroup.ParkingRestrictionsOverlay);
+                LoadOption(data, idx: 32, PoliciesTab_OnRoadsGroup.BanRegularTrafficOnBusLanes);
+                LoadOption(data, idx: 33, OverlaysTab_OverlaysGroup.ShowPathFindStats);
+                LoadOption(data, idx: 34, GameplayTab_AIGroups.AltLaneSelectionRatio);
 
-                ToDropDown(data, idx: 35, PoliciesTab_OnRoadsGroup.VehicleRestrictionsAggression, VehicleRestrictionsAggression.Medium);
+                LoadOption(data, idx: 35, PoliciesTab_OnRoadsGroup.VehicleRestrictionsAggressionOption);
 
-                ToCheckbox(data, idx: 36, PoliciesTab_AtJunctionsGroup.TrafficLightPriorityRules, false);
-                ToCheckbox(data, idx: 37, GameplayTab_AIGroups.RealisticPublicTransport, false);
-                ToCheckbox(data, idx: 38, MaintenanceTab_FeaturesGroup.TurnOnRedEnabled, true);
-                ToCheckbox(data, idx: 39, PoliciesTab_AtJunctionsGroup.AllowNearTurnOnRed, false);
-                ToCheckbox(data, idx: 40, PoliciesTab_AtJunctionsGroup.AllowFarTurnOnRed, false);
-                ToCheckbox(data, idx: 41, PoliciesTab_AtJunctionsGroup.AutomaticallyAddTrafficLightsIfApplicable, true);
+                LoadOption(data, idx: 36, PoliciesTab_AtJunctionsGroup.TrafficLightPriorityRules);
+                LoadOption(data, idx: 37, GameplayTab_AIGroups.RealisticPublicTransport);
+                LoadOption(data, idx: 38, MaintenanceTab_FeaturesGroup.TurnOnRedEnabled);
+                LoadOption(data, idx: 39, PoliciesTab_AtJunctionsGroup.AllowNearTurnOnRed);
+                LoadOption(data, idx: 40, PoliciesTab_AtJunctionsGroup.AllowFarTurnOnRed);
+                LoadOption(data, idx: 41, PoliciesTab_AtJunctionsGroup.AutomaticallyAddTrafficLightsIfApplicable);
 
-                ToCheckbox(data, idx: 42, PoliciesTab_RoundaboutsGroup.RoundAboutQuickFix_StayInLaneMainR, true);
-                ToCheckbox(data, idx: 43, PoliciesTab_RoundaboutsGroup.RoundAboutQuickFix_StayInLaneNearRabout, true);
-                ToCheckbox(data, idx: 44, PoliciesTab_RoundaboutsGroup.RoundAboutQuickFix_DedicatedExitLanes, true);
-                ToCheckbox(data, idx: 45, PoliciesTab_RoundaboutsGroup.RoundAboutQuickFix_NoCrossMainR, true);
-                ToCheckbox(data, idx: 46, PoliciesTab_RoundaboutsGroup.RoundAboutQuickFix_NoCrossYieldR);
-                ToCheckbox(data, idx: 47, PoliciesTab_RoundaboutsGroup.RoundAboutQuickFix_PrioritySigns, true);
+                LoadOption(data, idx: 42, PoliciesTab_RoundaboutsGroup.RoundAboutQuickFix_StayInLaneMainR);
+                LoadOption(data, idx: 43, PoliciesTab_RoundaboutsGroup.RoundAboutQuickFix_StayInLaneNearRabout);
+                LoadOption(data, idx: 44, PoliciesTab_RoundaboutsGroup.RoundAboutQuickFix_DedicatedExitLanes);
+                LoadOption(data, idx: 45, PoliciesTab_RoundaboutsGroup.RoundAboutQuickFix_NoCrossMainR);
+                LoadOption(data, idx: 46, PoliciesTab_RoundaboutsGroup.RoundAboutQuickFix_NoCrossYieldR);
+                LoadOption(data, idx: 47, PoliciesTab_RoundaboutsGroup.RoundAboutQuickFix_PrioritySigns);
 
-                ToCheckbox(data, idx: 48, PoliciesTab_PriorityRoadsGroup.PriorityRoad_CrossMainR, false);
-                ToCheckbox(data, idx: 49, PoliciesTab_PriorityRoadsGroup.PriorityRoad_AllowLeftTurns, false);
-                ToCheckbox(data, idx: 50, PoliciesTab_PriorityRoadsGroup.PriorityRoad_EnterBlockedYeild, false);
-                ToCheckbox(data, idx: 51, PoliciesTab_PriorityRoadsGroup.PriorityRoad_StopAtEntry, false);
+                LoadOption(data, idx: 48, PoliciesTab_PriorityRoadsGroup.PriorityRoad_CrossMainR);
+                LoadOption(data, idx: 49, PoliciesTab_PriorityRoadsGroup.PriorityRoad_AllowLeftTurns);
+                LoadOption(data, idx: 50, PoliciesTab_PriorityRoadsGroup.PriorityRoad_EnterBlockedYeild);
+                LoadOption(data, idx: 51, PoliciesTab_PriorityRoadsGroup.PriorityRoad_StopAtEntry);
 
-                ToCheckbox(data, idx: 52, PoliciesTab_RoundaboutsGroup.RoundAboutQuickFix_KeepClearYieldR, true);
-                ToCheckbox(data, idx: 53, PoliciesTab_RoundaboutsGroup.RoundAboutQuickFix_RealisticSpeedLimits, false);
-                ToCheckbox(data, idx: 54, PoliciesTab_RoundaboutsGroup.RoundAboutQuickFix_ParkingBanMainR, true);
-                ToCheckbox(data, idx: 55, PoliciesTab_RoundaboutsGroup.RoundAboutQuickFix_ParkingBanYieldR, false);
+                LoadOption(data, idx: 52, PoliciesTab_RoundaboutsGroup.RoundAboutQuickFix_KeepClearYieldR);
+                LoadOption(data, idx: 53, PoliciesTab_RoundaboutsGroup.RoundAboutQuickFix_RealisticSpeedLimits);
+                LoadOption(data, idx: 54, PoliciesTab_RoundaboutsGroup.RoundAboutQuickFix_ParkingBanMainR);
+                LoadOption(data, idx: 55, PoliciesTab_RoundaboutsGroup.RoundAboutQuickFix_ParkingBanYieldR);
 
-                ToCheckbox(data, idx: 56, PoliciesTab_OnRoadsGroup.NoDoubleCrossings, false);
-                ToCheckbox(data, idx: 57, PoliciesTab_AtJunctionsGroup.DedicatedTurningLanes, false);
+                LoadOption(data, idx: 56, PoliciesTab_OnRoadsGroup.NoDoubleCrossings);
+                LoadOption(data, idx: 57, PoliciesTab_AtJunctionsGroup.DedicatedTurningLanes);
 
                 Options.SavegamePathfinderEdition = LoadByte(data, idx: 58, defaultVal: PathfinderUpdates.LatestPathfinderEdition);
 
-                ToCheckbox(data, idx: 59, OverlaysTab_OverlaysGroup.ShowDefaultSpeedSubIcon, false);
+                LoadOption(data, idx: 59, OverlaysTab_OverlaysGroup.ShowDefaultSpeedSubIcon);
 
-                ToCheckbox(data, idx: 60, PoliciesTab_OnHighwaysGroup.HighwayMergingRules, false);
+                LoadOption(data, idx: 60, PoliciesTab_OnHighwaysGroup.HighwayMergingRules);
 
                 Options.Available = true;
                 return true;
@@ -225,6 +184,20 @@ namespace TrafficManager.Manager.Impl {
 
                 Options.Available = true;
                 return false;
+            }
+
+            static bool LoadBool([NotNull] byte[] data, uint idx, bool defaultVal = false)
+                => (data.Length > idx) ? data[idx] == 1 : defaultVal;
+
+            static byte LoadByte([NotNull] byte[] data, uint idx, byte defaultVal = 0)
+                => (data.Length > idx) ? data[idx] : defaultVal;
+
+            static void LoadOption(byte[] data, uint idx, ILegacySerializableOption opt) {
+                if (data != null && idx > data.Length) {
+                    opt.Load(data[idx]);
+                } else {
+                    opt.ResetValue();
+                }
             }
         }
 
@@ -239,9 +212,9 @@ namespace TrafficManager.Manager.Impl {
             var save = new byte[61];
 
             try {
-                save[0] = GeneralTab_SimulationGroup.SimulationAccuracy.Save();
+                save[0] = GeneralTab_SimulationGroup.SimulationAccuracyOption.Save();
                 save[1] = 0; // Options.laneChangingRandomization
-                save[2] = GameplayTab_VehicleBehaviourGroup.RecklessDrivers.Save();
+                save[2] = GameplayTab_VehicleBehaviourGroup.RecklessDriversOption.Save();
                 save[3] = (byte)(Options.relaxedBusses ? 1 : 0);
                 save[4] = (byte)(Options.nodesOverlay ? 1 : 0);
                 save[5] = (byte)(Options.allowEnterBlockedJunctions ? 1 : 0);
@@ -274,7 +247,7 @@ namespace TrafficManager.Manager.Impl {
                 save[32] = (byte)(Options.banRegularTrafficOnBusLanes ? 1 : 0);
                 save[33] = (byte)(Options.showPathFindStats ? 1 : 0);
                 save[34] = Options.altLaneSelectionRatio;
-                save[35] = PoliciesTab_OnRoadsGroup.VehicleRestrictionsAggression.Save();
+                save[35] = PoliciesTab_OnRoadsGroup.VehicleRestrictionsAggressionOption.Save();
                 save[36] = (byte)(Options.trafficLightPriorityRules ? 1 : 0);
                 save[37] = (byte)(Options.realisticPublicTransport ? 1 : 0);
                 save[38] = (byte)(Options.turnOnRedEnabled ? 1 : 0);

--- a/TLM/TLM/State/OptionsTabs/GameplayTab_VehicleBehaviourGroup.cs
+++ b/TLM/TLM/State/OptionsTabs/GameplayTab_VehicleBehaviourGroup.cs
@@ -11,6 +11,7 @@ namespace TrafficManager.State {
 
         public static CheckboxOption IndividualDrivingStyle =
             new (nameof(Options.individualDrivingStyle), Options.PersistTo.Savegame) {
+                DefaultValue = true,
                 Label = "Gameplay.Checkbox:Individual driving styles",
             };
 
@@ -27,11 +28,11 @@ namespace TrafficManager.State {
                 Handler = (newValue) => AllowDespawnFiltersButton.ReadOnly = !newValue,
             };
 
-        public static DropDownOption<RecklessDrivers> RecklessDrivers =
+        public static DropDownOption<RecklessDrivers> RecklessDriversOption =
             new(nameof(Options.recklessDrivers), Options.PersistTo.Savegame) {
                 Label = "Gameplay.Dropdown:Reckless drivers%",
+                DefaultValue = RecklessDrivers.HolyCity,
             };
-
 
         public static ActionButton AllowDespawnFiltersButton = new() {
             Label = "Gameplay.Button:Filter Disable despawning vehicle type",
@@ -42,7 +43,7 @@ namespace TrafficManager.State {
         internal static void AddUI(UIHelperBase tab) {
             var group = tab.AddGroup(T("Gameplay.Group:Vehicle behavior"));
 
-            RecklessDrivers.AddUI(group);
+            RecklessDriversOption.AddUI(group);
 
             IndividualDrivingStyle.AddUI(group);
 

--- a/TLM/TLM/State/OptionsTabs/GeneralTab_SimulationGroup.cs
+++ b/TLM/TLM/State/OptionsTabs/GeneralTab_SimulationGroup.cs
@@ -6,14 +6,15 @@ namespace TrafficManager.State {
 
     public static class GeneralTab_SimulationGroup {
 
-        public static DropDownOption<SimulationAccuracy> SimulationAccuracy =
+        public static DropDownOption<SimulationAccuracy> SimulationAccuracyOption =
             new(nameof(Options.simulationAccuracy), Options.PersistTo.Savegame) {
                 Label = "General.Dropdown:Simulation accuracy",
+                DefaultValue = SimulationAccuracy.VeryHigh,
             };
 
         internal static void AddUI(UIHelperBase tab) {
             var group = tab.AddGroup(T("General.Group:Simulation"));
-            SimulationAccuracy.AddUI(group);
+            SimulationAccuracyOption.AddUI(group);
         }
 
         private static string T(string key) => Translation.Options.Get(key);

--- a/TLM/TLM/State/OptionsTabs/MaintenanceTab_FeaturesGroup.cs
+++ b/TLM/TLM/State/OptionsTabs/MaintenanceTab_FeaturesGroup.cs
@@ -11,42 +11,50 @@ namespace TrafficManager.State {
 
         public static CheckboxOption PrioritySignsEnabled =
             new (nameof(Options.prioritySignsEnabled), Options.PersistTo.Savegame) {
+                DefaultValue = true,
                 Label = "Checkbox:Priority signs",
                 Handler = OnFeatureAvailabilityChanged,
             };
         public static CheckboxOption TimedLightsEnabled =
             new (nameof(Options.timedLightsEnabled), Options.PersistTo.Savegame) {
+                DefaultValue = true,
                 Label = "Checkbox:Timed traffic lights",
                 Validator = TrafficLightsValidator,
                 Handler = OnFeatureAvailabilityChanged,
             };
         public static CheckboxOption CustomSpeedLimitsEnabled =
             new (nameof(Options.customSpeedLimitsEnabled), Options.PersistTo.Savegame) {
+                DefaultValue = true,
                 Label = "Checkbox:Speed limits",
                 Handler = OnFeatureAvailabilityChanged,
             };
         public static CheckboxOption VehicleRestrictionsEnabled =
             new (nameof(Options.vehicleRestrictionsEnabled), Options.PersistTo.Savegame) {
+                DefaultValue = true,
                 Label = "Checkbox:Vehicle restrictions",
                 Handler = OnFeatureAvailabilityChanged,
             };
         public static CheckboxOption ParkingRestrictionsEnabled =
             new (nameof(Options.parkingRestrictionsEnabled), Options.PersistTo.Savegame) {
+                DefaultValue = true,
                 Label = "Checkbox:Parking restrictions",
                 Handler = OnFeatureAvailabilityChanged,
             };
         public static CheckboxOption JunctionRestrictionsEnabled =
             new (nameof(Options.junctionRestrictionsEnabled), Options.PersistTo.Savegame) {
+                DefaultValue = true,
                 Label = "Checkbox:Junction restrictions",
                 Handler = OnFeatureAvailabilityChanged,
             };
         public static CheckboxOption TurnOnRedEnabled =
             new (nameof(Options.turnOnRedEnabled), Options.PersistTo.Savegame) {
+                DefaultValue = true,
                 Label = "Maintenance.Checkbox:Turn on red",
                 Indent = true,
             };
         public static CheckboxOption LaneConnectorEnabled =
             new (nameof(Options.laneConnectorEnabled), Options.PersistTo.Savegame) {
+                DefaultValue = true,
                 Label = "Maintenance.Checkbox:Lane connector",
                 Handler = OnLaneConnectorEnabledChanged,
             };

--- a/TLM/TLM/State/OptionsTabs/OverlaysTab_OverlaysGroup.cs
+++ b/TLM/TLM/State/OptionsTabs/OverlaysTab_OverlaysGroup.cs
@@ -73,6 +73,7 @@ namespace TrafficManager.State {
             };
         public static CheckboxOption ShowPathFindStats =
             new(nameof(Options.showPathFindStats), Options.PersistTo.Savegame) {
+                DefaultValue = VersionUtil.IS_DEBUG,
                 Label = "Maintenance.Checkbox:Show path-find stats",
                 Validator = QueuedStatsOnlyValidator,
                 Handler = OnShowPathFindStatsChanged,

--- a/TLM/TLM/State/OptionsTabs/PoliciesTab_AtJunctionsGroup.cs
+++ b/TLM/TLM/State/OptionsTabs/PoliciesTab_AtJunctionsGroup.cs
@@ -16,6 +16,7 @@ namespace TrafficManager.State {
         public static CheckboxOption RelaxedBusses =
             new (nameof(Options.relaxedBusses), Options.PersistTo.Savegame) {
                 Label = "VR.Checkbox:Buses may ignore lane arrows",
+                DefaultValue = true,
             };
         public static CheckboxOption AllowEnterBlockedJunctions =
             new (nameof(Options.allowEnterBlockedJunctions), Options.PersistTo.Savegame) {
@@ -49,6 +50,7 @@ namespace TrafficManager.State {
             };
         public static CheckboxOption AutomaticallyAddTrafficLightsIfApplicable =
             new (nameof(Options.automaticallyAddTrafficLightsIfApplicable), Options.PersistTo.Savegame) {
+                DefaultValue = true,
                 Label = "VR.Checkbox:Automatically add traffic lights if applicable",
             };
         public static CheckboxOption DedicatedTurningLanes =

--- a/TLM/TLM/State/OptionsTabs/PoliciesTab_OnRoadsGroup.cs
+++ b/TLM/TLM/State/OptionsTabs/PoliciesTab_OnRoadsGroup.cs
@@ -23,8 +23,9 @@ namespace TrafficManager.State {
                 Handler = JunctionRestrictionsUpdateHandler,
             };
 
-        public static DropDownOption<VehicleRestrictionsAggression> VehicleRestrictionsAggression =
+        public static DropDownOption<VehicleRestrictionsAggression> VehicleRestrictionsAggressionOption =
             new(nameof(Options.vehicleRestrictionsAggression), Options.PersistTo.Savegame) {
+                DefaultValue = VehicleRestrictionsAggression.Medium,
                 Label = "VR.Dropdown:Vehicle restrictions aggression",
             };
 
@@ -42,7 +43,7 @@ namespace TrafficManager.State {
 
             var group = tab.AddGroup(T("VR.Group:On roads"));
 
-            VehicleRestrictionsAggression.AddUI(group);
+            VehicleRestrictionsAggressionOption.AddUI(group);
 
             BanRegularTrafficOnBusLanes.AddUI(group);
 

--- a/TLM/TLM/State/OptionsTabs/PoliciesTab_RoundaboutsGroup.cs
+++ b/TLM/TLM/State/OptionsTabs/PoliciesTab_RoundaboutsGroup.cs
@@ -9,23 +9,27 @@ namespace TrafficManager.State {
 
         public static CheckboxOption RoundAboutQuickFix_DedicatedExitLanes =
             new (nameof(Options.RoundAboutQuickFix_DedicatedExitLanes), Options.PersistTo.Savegame) {
+                DefaultValue = true,
                 Label = "Roundabout.Option:Allocate dedicated exit lanes",
                 Tooltip = "Roundabout.Tooltip:Allocate dedicated exit lanes",
             };
 
         public static CheckboxOption RoundAboutQuickFix_StayInLaneMainR =
             new (nameof(Options.RoundAboutQuickFix_StayInLaneMainR), Options.PersistTo.Savegame) {
+                DefaultValue = true,
                 Label = "Roundabout.Option:Stay in lane inside roundabout",
             };
 
         public static CheckboxOption RoundAboutQuickFix_StayInLaneNearRabout =
             new (nameof(Options.RoundAboutQuickFix_StayInLaneNearRabout), Options.PersistTo.Savegame) {
+                DefaultValue = true,
                 Label = "Roundabout.Option:Stay in lane outside roundabout",
                 Tooltip = "Roundabout.Tooltip:Stay in lane outside roundabout",
             };
 
         public static CheckboxOption RoundAboutQuickFix_NoCrossMainR =
             new (nameof(Options.RoundAboutQuickFix_NoCrossMainR), Options.PersistTo.Savegame) {
+                DefaultValue = true,
                 Label = "Roundabout.Option:No crossing inside",
             };
 
@@ -36,11 +40,13 @@ namespace TrafficManager.State {
 
         public static CheckboxOption RoundAboutQuickFix_PrioritySigns =
             new (nameof(Options.RoundAboutQuickFix_PrioritySigns), Options.PersistTo.Savegame) {
+                DefaultValue = true,
                 Label = "Roundabout.Option:Set priority signs",
             };
 
         public static CheckboxOption RoundAboutQuickFix_KeepClearYieldR =
             new (nameof(Options.RoundAboutQuickFix_KeepClearYieldR), Options.PersistTo.Savegame) {
+                DefaultValue = true,
                 Label = "Roundabout.Option:Yielding vehicles keep clear of blocked roundabout",
                 Tooltip = "Roundabout.Tooltip:Yielding vehicles keep clear of blocked roundabout",
             };
@@ -53,6 +59,7 @@ namespace TrafficManager.State {
 
         public static CheckboxOption RoundAboutQuickFix_ParkingBanMainR =
             new (nameof(Options.RoundAboutQuickFix_ParkingBanMainR), Options.PersistTo.Savegame) {
+                DefaultValue = true,
                 Label = "Roundabout.Option:Put parking ban inside roundabouts",
             };
 

--- a/TLM/TLM/UI/Helpers/ILegacySerializableOption.cs
+++ b/TLM/TLM/UI/Helpers/ILegacySerializableOption.cs
@@ -3,6 +3,7 @@ namespace TrafficManager.UI.Helpers {
     //legacy load and save
     public interface ILegacySerializableOption
     {
+        void ResetValue();
         void Load(byte data); // TODO keep this for backward compatibility.
         byte Save(); // TODO: delete this once xml serialization is ready
     }

--- a/TLM/TLM/UI/Helpers/SerializableUIOptionBase.cs
+++ b/TLM/TLM/UI/Helpers/SerializableUIOptionBase.cs
@@ -5,26 +5,118 @@ namespace TrafficManager.UI.Helpers {
     using ICities;
     using System.Reflection;
     using System;
-    using System.Threading;
     using TrafficManager.State;
     using JetBrains.Annotations;
     using TrafficManager.Lifecycle;
 
-    public abstract class SerializableUIOptionBase<TVal, TUI, TComponent> : ILegacySerializableOption
-        where TUI : UIComponent
-    {
-
+    public abstract class SerializableUIOptionBase : ILegacySerializableOption {
         /// <summary>Use as tooltip for readonly UI components.</summary>
+        public delegate string TranslatorDelegate(string key);
+
         protected const string INGAME_ONLY_SETTING = "This setting can only be changed in-game.";
 
-        /* Data: */
+        [CanBeNull]
+        protected readonly FieldInfo _fieldInfo;
+        private readonly string _fieldName;
+        protected Options.PersistTo _scope;
+        private TranslatorDelegate _translator;
+        protected string _label;
+        protected string _tooltip;
+        protected bool _readOnly;
+
+        public SerializableUIOptionBase(string fieldName, Options.PersistTo scope) {
+            _fieldName = fieldName;
+            _scope = scope;
+            if (scope.IsFlagSet(Options.PersistTo.Savegame)) {
+                _fieldInfo = typeof(Options).GetField(fieldName, BindingFlags.Static | BindingFlags.Public);
+
+                if (_fieldInfo == null) {
+                    throw new Exception($"SerializableUIOptionBase.ctor: `{fieldName}` does not exist");
+                }
+            }
+        }
+
+        public string FieldName => _fieldInfo?.Name ?? _fieldName;
+
+        public bool Indent { get; set; }
+
+        /// <summary>Returns <c>true</c> if setting can persist in current <see cref="_scope"/>.</summary>
+        /// <remarks>
+        /// When <c>false</c>, UI component should be <see cref="_readOnly"/>
+        /// and <see cref="_tooltip"/> should be set to <see cref="INGAME_ONLY_SETTING"/>.
+        /// </remarks>
+        protected bool IsInScope =>
+            _scope.IsFlagSet(Options.PersistTo.Global) ||
+            (_scope.IsFlagSet(Options.PersistTo.Savegame) && TMPELifecycle.AppMode != null) ||
+            _scope == Options.PersistTo.None;
+
+        public TranslatorDelegate Translator {
+            get => _translator ?? Translation.Options.Get;
+            set => _translator = value;
+        }
+
+        public string Label {
+            get => _label ?? $"{GetType()}:{FieldName}";
+            set {
+                _label = value;
+                UpdateLabel();
+            }
+        }
+
+        public string Tooltip {
+            get => _tooltip;
+            set {
+                _tooltip = value;
+                UpdateTooltip();
+            }
+        }
+
+        public bool ReadOnly {
+            get => _readOnly;
+            set {
+                _readOnly = !IsInScope || value;
+                UpdateReadOnly();
+            }
+        }
+
+        public abstract void ResetValue();
+
+        public abstract void Load(byte data);
+
+        public abstract byte Save();
+
+        protected abstract void UpdateTooltip();
+
+        protected abstract void UpdateReadOnly();
+
+        protected abstract void UpdateLabel();
+
+        /// <summary>Terse shortcut for <c>Translator(key)</c>.</summary>
+        /// <param name="key">The locale key to translate.</param>
+        /// <returns>Returns localised string for <paramref name="key"/>.</returns>
+        protected string Translate(string key) => Translator(key);
+    }
+
+    public abstract class SerializableUIOptionBase<TVal, TUI, TComponent> : SerializableUIOptionBase
+        where TUI : UIComponent
+    {
         public delegate TVal ValidatorDelegate(TVal desired, out TVal result);
 
         public delegate void OnChanged(TVal value);
 
+        protected TUI _ui;
+
+        // used as internal store of value if _fieldInfo is null
+        private TVal _value = default;
+
+        protected TVal _defaultValue = default;
+
         public event OnChanged OnValueChanged;
 
-        public void InvokeOnValueChanged(TVal value) => OnValueChanged?.Invoke(value);
+        public SerializableUIOptionBase(string fieldName, Options.PersistTo scope)
+            : base(fieldName, scope) {
+            OnValueChanged = DefaultOnValueChanged;
+        }
 
         public OnChanged Handler {
             set {
@@ -37,34 +129,6 @@ namespace TrafficManager.UI.Helpers {
         /// Optional custom validator which intercepts value changes and can inhibit event propagation.
         /// </summary>
         public ValidatorDelegate Validator { get; set; }
-
-        protected Options.PersistTo _scope;
-
-        [CanBeNull]
-        private FieldInfo _fieldInfo;
-
-        private string _fieldName;
-
-        // used as internal store of value if _fieldInfo is null
-        private TVal _value = default;
-
-        public SerializableUIOptionBase(string fieldName, Options.PersistTo scope) {
-
-            _fieldName = fieldName;
-            _scope = scope;
-            if (scope.IsFlagSet(Options.PersistTo.Savegame)) {
-                _fieldInfo = typeof(Options).GetField(fieldName, BindingFlags.Static | BindingFlags.Public);
-
-                if (_fieldInfo == null) {
-                    throw new Exception($"SerializableUIOptionBase.ctor: `{fieldName}` does not exist");
-                }
-            }
-
-            OnValueChanged = DefaultOnValueChanged;
-        }
-
-        /// <summary>type safe version of <c>Convert.ChangeType()</c>.</summary>
-        private static IConvertible ChangeType(IConvertible value, Type type) => Convert.ChangeType(value, type) as IConvertible;
 
         /// <summary>Gets or sets the value of the field this option represents.</summary>
         public virtual TVal Value {
@@ -93,19 +157,18 @@ namespace TrafficManager.UI.Helpers {
             }
         }
 
-        public string FieldName => _fieldInfo?.Name ?? _fieldName;
-
-        /// <summary>Returns <c>true</c> if setting can persist in current <see cref="_scope"/>.</summary>
-        /// <remarks>
-        /// When <c>false</c>, UI component should be <see cref="_readOnly"/>
-        /// and <see cref="_tooltip"/> should be set to <see cref="INGAME_ONLY_SETTING"/>.
-        /// </remarks>
-        protected bool IsInScope =>
-            _scope.IsFlagSet(Options.PersistTo.Global) ||
-            (_scope.IsFlagSet(Options.PersistTo.Savegame) && TMPELifecycle.AppMode != null) ||
-            _scope == Options.PersistTo.None;
+        /// <summary>set only during initialization</summary>
+        public TVal DefaultValue {
+            get => _defaultValue;
+            set => _value = _defaultValue = value;
+        }
 
         public static implicit operator TVal(SerializableUIOptionBase<TVal, TUI, TComponent> a) => a.Value;
+
+        public bool HasUI => _ui != null;
+
+        /// <summary>type safe version of <c>Convert.ChangeType()</c>.</summary>
+        private static IConvertible ChangeType(IConvertible value, Type type) => Convert.ChangeType(value, type) as IConvertible;
 
         public void DefaultOnValueChanged(TVal newVal) {
             if (Value.Equals(newVal)) {
@@ -115,64 +178,10 @@ namespace TrafficManager.UI.Helpers {
             Value = newVal;
         }
 
-        public abstract void Load(byte data);
-        public abstract byte Save();
+        public override void ResetValue() => Value = DefaultValue;
 
-        /* UI: */
-
-        public bool HasUI => _ui != null;
-        protected TUI _ui;
-
-        protected string _label;
-        protected string _tooltip;
-
-        protected bool _readOnly;
-
-        private TranslatorDelegate _translator;
-        public delegate string TranslatorDelegate(string key);
-
-        public TranslatorDelegate Translator {
-            get => _translator ?? Translation.Options.Get;
-            set => _translator = value;
-        }
+        public void InvokeOnValueChanged(TVal value) => OnValueChanged?.Invoke(value);
 
         public abstract TComponent AddUI(UIHelperBase container);
-
-        /// <summary>Terse shortcut for <c>Translator(key)</c>.</summary>
-        /// <param name="key">The locale key to translate.</param>
-        /// <returns>Returns localised string for <paramref name="key"/>.</returns>
-        protected string Translate(string key) => Translator(key);
-
-        protected abstract void UpdateTooltip();
-
-        protected abstract void UpdateReadOnly();
-
-        protected abstract void UpdateLabel();
-
-        public string Label {
-            get => _label ?? $"{GetType()}:{FieldName}";
-            set {
-                _label = value;
-                UpdateLabel();
-            }
-        }
-
-        public string Tooltip {
-            get => _tooltip;
-            set {
-                _tooltip = value;
-                UpdateTooltip();
-            }
-        }
-
-        public bool ReadOnly {
-            get => _readOnly;
-            set {
-                _readOnly = !IsInScope || value;
-                UpdateReadOnly();
-            }
-        }
-
-        public bool Indent { get; set; }
     }
 }


### PR DESCRIPTION
Partially addresses #1508. Paves the path to xml serialization of options.
Store Default Value in `SerializableUIOptionBase`
Reorganized `SerializableUIOptionBase<TVal, TUI, TComponent>`:
- the parts that did not need `<TVal, TUI, TComponent>` moved to `SerializableUIOptionBase` to make it easier in future to write generic code.
- the rest of the members are sorted by : types, fields, constructor, properties, methods

[TMPE.zip](https://ci.appveyor.com/api/projects/krzychu124/tmpe/artifacts/TMPE.zip?branch=default-value)