### PR TITLE
Cargo truck transfer pathfinding fixes

### DIFF
--- a/TLM/TLM/Custom/PathFinding/CustomPathFind.cs
+++ b/TLM/TLM/Custom/PathFinding/CustomPathFind.cs
@@ -4130,7 +4130,7 @@ namespace TrafficManager.Custom.PathFinding {
                 extVehicleType |= ExtVehicleType.CargoShip;
             }
 
-            return extVehicleType | defaultExtVehicleType
+            return extVehicleType | defaultExtVehicleType;
         }
 
 #endif

--- a/TLM/TLM/Custom/PathFinding/CustomPathFind.cs
+++ b/TLM/TLM/Custom/PathFinding/CustomPathFind.cs
@@ -291,6 +291,8 @@ namespace TrafficManager.Custom.PathFinding {
                 disableMask_ |= NetSegment.Flags.Flooded;
             }
 
+            allowMixedCargoPath_ = false;
+            mixedPathVehicleTypes_ = queueItem_.vehicleType;
             if ((laneTypes_ & NetInfo.LaneType.Vehicle) != NetInfo.LaneType.None) {
                 laneTypes_ |= NetInfo.LaneType.TransportVehicle;
 

--- a/TLM/TLM/Custom/PathFinding/CustomPathFind.cs
+++ b/TLM/TLM/Custom/PathFinding/CustomPathFind.cs
@@ -296,7 +296,7 @@ namespace TrafficManager.Custom.PathFinding {
             if ((laneTypes_ & NetInfo.LaneType.Vehicle) != NetInfo.LaneType.None) {
                 laneTypes_ |= NetInfo.LaneType.TransportVehicle;
 
-                // allowed mixed vehicle path when requeted path is Vehicle + CargoVehicle (at current state CargoTruck and PostVanAI)
+                // allow mixed vehicle path when requested path is Vehicle + CargoVehicle (e.g.: CargoTruck and PostVanAI)
                 allowMixedCargoPath_ = (laneTypes_ & NetInfo.LaneType.CargoVehicle) != NetInfo.LaneType.None;
                 if (allowMixedCargoPath_) {
                     mixedPathVehicleTypes_ = VehicleTypeToMixedCargoExtVehicle(vehicleTypes_, queueItem_.vehicleType);

--- a/TLM/TLM/Custom/PathFinding/CustomPathFind.cs
+++ b/TLM/TLM/Custom/PathFinding/CustomPathFind.cs
@@ -4130,7 +4130,7 @@ namespace TrafficManager.Custom.PathFinding {
                 extVehicleType |= ExtVehicleType.CargoShip;
             }
 
-            return extVehicleType != 0 ? (extVehicleType | defaultExtVehicleType) : defaultExtVehicleType;
+            return extVehicleType | defaultExtVehicleType
         }
 
 #endif

--- a/TLM/TLM/Manager/Impl/RoutingManager.cs
+++ b/TLM/TLM/Manager/Impl/RoutingManager.cs
@@ -27,7 +27,7 @@ namespace TrafficManager.Manager.Impl {
         private RoutingManager() { }
 
         public const NetInfo.LaneType ROUTED_LANE_TYPES =
-            NetInfo.LaneType.Vehicle | NetInfo.LaneType.TransportVehicle;
+            NetInfo.LaneType.Vehicle | NetInfo.LaneType.TransportVehicle | NetInfo.LaneType.CargoVehicle;
 
         public const VehicleInfo.VehicleType ROUTED_VEHICLE_TYPES =
             VehicleInfo.VehicleType.Car | VehicleInfo.VehicleType.Metro |
@@ -558,7 +558,7 @@ namespace TrafficManager.Manager.Impl {
             bool onHighway = Options.highwayRules && onOnewayHighway;
             bool applyHighwayRules = onHighway && nodeIsSimpleJunction;
             bool applyHighwayRulesAtJunction = applyHighwayRules && nodeIsRealJunction;
-            bool iterateViaGeometry = (applyHighwayRulesAtJunction || applyHighwayMergingRules) && prevLaneInfo.MatchesRoad();
+            bool iterateViaGeometry = (applyHighwayRulesAtJunction || applyHighwayMergingRules) && prevLaneInfo.MatchesRoutedRoad();
 
             // start with u-turns at highway junctions
             ushort nextSegmentId = iterateViaGeometry ? prevSegmentId : (ushort)0;
@@ -759,7 +759,7 @@ namespace TrafficManager.Manager.Impl {
                                     }
                                 }
 
-                                if (nextLaneInfo.MatchesRoad() && prevLaneInfo.MatchesRoad()) {
+                                if (nextLaneInfo.MatchesRoutedRoad() && prevLaneInfo.MatchesRoutedRoad()) {
                                     // routing road vehicles (car, SOS, bus, trolleybus, ...)
                                     // lane may be mixed car+tram
                                     ++incomingCarLanes;
@@ -905,7 +905,7 @@ namespace TrafficManager.Manager.Impl {
                                     nextLaneInfo = new { nextLaneInfo.m_finalDirection }, nextExpectedDirection });
 
                                 bool outgoing = (nextLaneInfo.m_finalDirection & NetInfo.InvertDirection(nextExpectedDirection)) != NetInfo.Direction.None;
-                                if (outgoing && nextLaneInfo.MatchesRoad()) {
+                                if (outgoing && nextLaneInfo.MatchesRoutedRoad()) {
                                     ++outgoingCarLanes;
 
                                     extendedLog?.Invoke(new { _ = "increasing number of outgoing lanes at ",

--- a/TLM/TLM/Util/TrackUtils.cs
+++ b/TLM/TLM/Util/TrackUtils.cs
@@ -17,14 +17,23 @@ namespace TrafficManager.Util {
             VehicleInfo.VehicleType.Monorail;
 
         internal const NetInfo.LaneType ROAD_LANE_TYPES = LaneArrowManager.LANE_TYPES;
+        internal const NetInfo.LaneType ROUTED_ROAD_LANE_TYPES = LaneArrowManager.LANE_TYPES | NetInfo.LaneType.CargoVehicle;
 
         internal const VehicleInfo.VehicleType ROAD_VEHICLE_TYPES = LaneArrowManager.VEHICLE_TYPES | VehicleInfo.VehicleType.Trolleybus;
 
         internal static bool MatchesTrack([NotNull] this NetInfo.Lane laneInfo) =>
             laneInfo.Matches(TRACK_LANE_TYPES, TRACK_VEHICLE_TYPES);
-    
+
         internal static bool MatchesRoad([NotNull] this NetInfo.Lane laneInfo) =>
             laneInfo.Matches(ROAD_LANE_TYPES, ROAD_VEHICLE_TYPES);
+
+        /// <summary>
+        /// Testing lane info if matches with predefined allowed road lane types and vehicle types
+        /// </summary>
+        /// <param name="laneInfo">Lane info instance to test</param>
+        /// <returns>True if matches, otherwise False</returns>
+        internal static bool MatchesRoutedRoad([NotNull] this NetInfo.Lane laneInfo) =>
+            laneInfo.Matches(ROUTED_ROAD_LANE_TYPES, ROAD_VEHICLE_TYPES);
 
         internal static bool Matches([NotNull] this NetInfo.Lane laneInfo , NetInfo.LaneType laneType, VehicleInfo.VehicleType vehicleType) {
             return (laneType & laneInfo.m_laneType) != 0 && (vehicleType & laneInfo.m_vehicleType) != 0;
@@ -32,7 +41,7 @@ namespace TrafficManager.Util {
 
         internal static bool IsTrackOnly(this NetInfo.Lane laneInfo) {
             return
-                laneInfo.MatchesTrack() && 
+                laneInfo.MatchesTrack() &&
                 !laneInfo.m_laneType.IsFlagSet(~TRACK_LANE_TYPES) &&
                 !laneInfo.m_vehicleType.IsFlagSet(~TRACK_VEHICLE_TYPES);
         }


### PR DESCRIPTION
Fixes #1701 

- fixes pathfinding issue when searching for cargo path with use of multiple types of cargo transport (train/plane/ship) 
- improves lane routing via `CargoVehicle` lanes which solves issues for buildings that suppose to allow for pass through vehicle paths like cargo terminals but also Airports DLC dual track Cargo Train Station 

### Note

I've swapped method for matching lanes for `RoutingManager`, because the original was already used by lane connection tool (and more) and I didn't want to increase complexity or scope of tests.
Additionally lanes with `CargoVehicles` are not available for configuration in game by any tools we support and at this state they are used internally only in form of invisible paths included in building assets and meant to be used as internal paths with certain limitations. 

More info about the problem and small test savegame you can find in the mentioned issue.

Build [ZIP](https://ci.appveyor.com/api/projects/krzychu124/tmpe/artifacts/TMPE.zip?branch=bugfix/1701-cargo-truck-transfer-mixed-path-issues)
