### PR TITLE
save options in xml format

### DIFF
--- a/TLM/TLM/Custom/PathFinding/PathfinderUpdates.cs
+++ b/TLM/TLM/Custom/PathFinding/PathfinderUpdates.cs
@@ -27,6 +27,8 @@ namespace TrafficManager.Custom.PathFinding {
         [SuppressMessage("Usage", "RAS0002:Readonly field for a non-readonly struct", Justification = "Not performance critical.")]
         internal static readonly byte LatestPathfinderEdition = 1;
 
+        public static byte SavegamePathfinderEdition = LatestPathfinderEdition;
+
         /// <summary>
         /// Checks savegame pathfinder edition and, if necessary, despawns
         /// any vehicles that might have invalid paths due to bugs in the
@@ -38,13 +40,13 @@ namespace TrafficManager.Custom.PathFinding {
         public static ExtVehicleType DespawnVehiclesIfNecessary() {
             var filter = ExtVehicleType.None;
 
-            if (SavedGameOptions.Instance.SavegamePathfinderEdition == LatestPathfinderEdition) {
+            if (SavegamePathfinderEdition == LatestPathfinderEdition) {
                 return filter; // nothing to do, everything is fine
             }
 
-            Log.Info($"Pathfinder update from {SavedGameOptions.Instance.SavegamePathfinderEdition} to {LatestPathfinderEdition}.");
+            Log.Info($"Pathfinder update from {SavegamePathfinderEdition} to {LatestPathfinderEdition}.");
 
-            if (SavedGameOptions.Instance.SavegamePathfinderEdition < 1) {
+            if (SavegamePathfinderEdition < 1) {
                 filter |= ExtVehicleType.Plane; // #1338
             }
 
@@ -60,7 +62,7 @@ namespace TrafficManager.Custom.PathFinding {
             }
 
             // this will be stored in savegame
-            SavedGameOptions.Instance.SavegamePathfinderEdition = LatestPathfinderEdition;
+            SavegamePathfinderEdition = LatestPathfinderEdition;
 
             return filter;
         }

--- a/TLM/TLM/Lifecycle/SerializableDataExtension.cs
+++ b/TLM/TLM/Lifecycle/SerializableDataExtension.cs
@@ -11,7 +11,8 @@ namespace TrafficManager.Lifecycle {
     using TrafficManager.Manager.Impl;
     using TrafficManager.Manager.Impl.LaneConnection;
     using TrafficManager.State;
-    using Util;
+    using TrafficManager.Util;
+    using TrafficManager.Custom.PathFinding;
 
     [UsedImplicitly]
     public class SerializableDataExtension
@@ -215,6 +216,9 @@ namespace TrafficManager.Lifecycle {
                 Log.Warning("Configuration NULL, Couldn't load save data. Possibly a new game?");
                 return;
             }
+
+            // load Path Find Update
+            PathfinderUpdates.SavegamePathfinderEdition = _configuration.SavegamePathfinderEdition;
 
             // load ext. citizens
             if (_configuration.ExtCitizens != null) {

--- a/TLM/TLM/State/Configuration.cs
+++ b/TLM/TLM/State/Configuration.cs
@@ -8,7 +8,7 @@ namespace TrafficManager {
     using TrafficManager.Traffic;
     using System.Runtime.Serialization;
     using TrafficManager.Lifecycle;
-    using Util;
+    using TrafficManager.Custom.PathFinding;
     using LaneEndTransitionGroup = TrafficManager.API.Traffic.Enums.LaneEndTransitionGroup;
 
     [Serializable]
@@ -361,6 +361,8 @@ namespace TrafficManager {
         /// Parking restrictions
         /// </summary>
         public List<ParkingRestriction> ParkingRestrictions = new List<ParkingRestriction>();
+
+        public byte SavegamePathfinderEdition = PathfinderUpdates.LatestPathfinderEdition;
 
         [Obsolete]
         public string NodeTrafficLights = string.Empty;

--- a/TLM/TLM/State/SavedGameOptions.cs
+++ b/TLM/TLM/State/SavedGameOptions.cs
@@ -1,5 +1,7 @@
 namespace TrafficManager.State;
 using CSUtil.Commons;
+using System;
+using System.Text;
 using TrafficManager.API.Traffic.Enums;
 using TrafficManager.Custom.PathFinding;
 using TrafficManager.Util;
@@ -81,9 +83,6 @@ public class SavedGameOptions {
     public bool PriorityRoad_EnterBlockedYeild;
     public bool PriorityRoad_StopAtEntry;
 
-    // See PathfinderUpdates.cs
-    public byte SavegamePathfinderEdition = PathfinderUpdates.LatestPathfinderEdition;
-
     public bool showDefaultSpeedSubIcon;
 
     internal int getRecklessDriverModulo() => CalculateRecklessDriverModulo(recklessDrivers);
@@ -132,5 +131,29 @@ public class SavedGameOptions {
 
     private void Awake() {
         Log.Info("SavedGameOptions.Awake() called");
+    }
+
+    public byte[] Seraialize() {
+        try {
+            string xml = XMLUtil.Serialize(this);
+            return Encoding.ASCII.GetBytes(xml);
+        } catch (Exception ex) {
+            ex.LogException();
+            return null;
+        }
+    }
+
+    public static bool Deserialzie(byte[] data) {
+        try {
+            if (!data.IsNullOrEmpty()) {
+                string xml = Encoding.ASCII.GetString(data);
+                Instance = XMLUtil.Deserialize<SavedGameOptions>(xml);
+                Instance.Awake();
+                return true;
+            }
+        } catch (Exception ex) {
+            ex.LogException();
+        }
+        return false;
     }
 }

--- a/TLM/TLM/State/XMLUtil.cs
+++ b/TLM/TLM/State/XMLUtil.cs
@@ -1,0 +1,32 @@
+namespace TrafficManager.State {
+    using System.IO;
+    using System.Text;
+    using System.Xml.Serialization;
+    using System.Xml;
+
+    internal static class XMLUtil {
+        internal static XmlSerializerNamespaces NoNamespaces =>
+            new XmlSerializerNamespaces(new[] { XmlQualifiedName.Empty });
+
+        internal static string Serialize<T>(T obj) {
+            var serializer = new XmlSerializer(typeof(T));
+            StringBuilder sb = new();
+            using (TextWriter writer = new StringWriter(sb)) {
+                using (var xmlWriter = new XmlTextWriter(writer)) {
+                    serializer.Serialize(xmlWriter, obj, NoNamespaces);
+                }
+            }
+            return sb.ToString();
+        }
+
+        internal static T Deserialize<T>(string data) {
+            if (string.IsNullOrEmpty(data)) {
+                return default;
+            }
+            XmlSerializer ser = new XmlSerializer(typeof(T));
+            using (var stream = new StreamReader(data)) {
+                return (T)ser.Deserialize(stream);
+            }
+        }
+    }
+}

--- a/TLM/TLM/TLM.csproj
+++ b/TLM/TLM/TLM.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -180,6 +180,7 @@
     <Compile Include="State\OptionsTabs\MaintenanceTab_ToolsGroup.cs" />
     <Compile Include="State\TMPESettings.cs" />
     <Compile Include="State\VersionInfo.cs" />
+    <Compile Include="State\XMLUtil.cs" />
     <Compile Include="TrafficLight\Impl\ITrafficLightContainer.cs" />
     <Compile Include="TrafficLight\Impl\TrafficLightSimulation.cs" />
     <Compile Include="UI\AllowDespawn\AllowDespawnPanel.cs" />

--- a/TLM/TMPE.API/Manager/ICustomDataManager.cs
+++ b/TLM/TMPE.API/Manager/ICustomDataManager.cs
@@ -1,4 +1,4 @@
-﻿namespace TrafficManager.API.Manager {
+namespace TrafficManager.API.Manager {
     using JetBrains.Annotations;
 
     public interface ICustomDataManager<T> {
@@ -6,7 +6,6 @@
         /// </summary>
         /// <param name="data">Data comes from here.</param>
         /// <returns>Success.</returns>
-        [UsedImplicitly] // While this seems to be not called from anywhere, it is in fact called
         bool LoadData(T data);
 
         T SaveData(ref bool success);


### PR DESCRIPTION
saved game options are serialized as xml and then converted to byte[] data.

- paves the path for setting options as default for new games.
- Also moved out `SavedGamePathFinderEdition` because it will it does not belong there and would make it difficult to set options as default for new games.
- Kept legacy code for loading options but there is no need for the legacy save code.
- bumped  Config version

[TMPE.zip](https://ci.appveyor.com/api/projects/krzychu124/tmpe/artifacts/TMPE.zip?branch=options-XML3)