### PR TITLE
set options as default for new game

### DIFF
--- a/TLM/TLM/State/GlobalConfig.cs
+++ b/TLM/TLM/State/GlobalConfig.cs
@@ -8,9 +8,7 @@ namespace TrafficManager.State {
     using TrafficManager.Util;
     using TrafficManager.Lifecycle;
 
-    [XmlRootAttribute(
-        "GlobalConfig",
-        IsNullable = false)]
+    [XmlRoot("GlobalConfig", IsNullable = false)]
     public class GlobalConfig : GenericObservable<GlobalConfig> {
         public const string FILENAME = "TMPE_GlobalConfig.xml";
         public const string BACKUP_FILENAME = FILENAME + ".bak";
@@ -79,17 +77,25 @@ namespace TrafficManager.State {
 
         public ConfigData.TimedTrafficLights TimedTrafficLights = new();
 
+        [XmlElement("DefaultsForNewGame")]
+        public SavedGameOptions SavedGameOptions = null;
+
         internal static void WriteConfig() {
             ModifiedTime = WriteConfig(Instance);
         }
 
+        /// <summary>
+        /// Replaces global config file with default config.
+        /// </summary>
+        /// <param name="oldConfig">if null, all is reset, otherwise old config is migrated to new config.</param>
+        /// <param name="modifiedTime">time of the file created</param>
+        /// <returns>the new default config</returns>
         private static GlobalConfig WriteDefaultConfig(GlobalConfig oldConfig,
-                                                       bool resetAll,
                                                        out DateTime modifiedTime) {
             Log._Debug($"Writing default config...");
             GlobalConfig conf = new GlobalConfig();
 
-            if (!resetAll && oldConfig != null) {
+            if (oldConfig != null) {
                 conf.Main.MainMenuButtonX = oldConfig.Main.MainMenuButtonX;
                 conf.Main.MainMenuButtonY = oldConfig.Main.MainMenuButtonY;
 
@@ -190,7 +196,7 @@ namespace TrafficManager.State {
             }
             catch (Exception e) {
                 Log.Warning($"Could not load global config: {e} Generating default config.");
-                return WriteDefaultConfig(null, false, out modifiedTime);
+                return WriteDefaultConfig(null, out modifiedTime);
             }
         }
 
@@ -214,17 +220,17 @@ namespace TrafficManager.State {
                         $"Error occurred while saving backup config to '{filename}': {e.ToString()}");
                 }
 
-                Reset(conf);
+                Reset(oldConfig: conf);
             } else {
                 Instance = conf;
                 ModifiedTime = WriteConfig(Instance);
             }
         }
 
-        public static void Reset(GlobalConfig oldConfig, bool resetAll = false) {
+        public static void Reset(GlobalConfig oldConfig) {
             Log.Info($"Resetting global config.");
             DateTime modifiedTime;
-            Instance = WriteDefaultConfig(oldConfig, resetAll, out modifiedTime);
+            Instance = WriteDefaultConfig(oldConfig, out modifiedTime);
             ModifiedTime = modifiedTime;
         }
 

--- a/TLM/TLM/State/OptionsTabs/MaintenanceTab_ConfigGroup.cs
+++ b/TLM/TLM/State/OptionsTabs/MaintenanceTab_ConfigGroup.cs
@@ -13,8 +13,13 @@ namespace TrafficManager.State {
             Handler = OnReloadGlobalConfigClicked,
         };
         public static ActionButton ResetGlobalConfig = new() {
-            Label = "Maintenance.Button:Reset global configuration",
+            Label = "Maintenance.Button:Reset all configuration",
             Handler = OnResetGlobalConfigClicked,
+        };
+
+        public static ActionButton SetAsDefaultForNewGames = new() {
+            Label = "Maintenance.Button:Set as default for new games",
+            Handler = OnSetAsDefaultForNewGamesClicked,
         };
 
 #if DEBUG
@@ -33,6 +38,7 @@ namespace TrafficManager.State {
 #if DEBUG
             DebugSwiches.AddUI(group);
 #endif
+            SetAsDefaultForNewGames.AddUI(group);
         }
 
         private static string T(string key) => Translation.Options.Get(key);
@@ -41,6 +47,10 @@ namespace TrafficManager.State {
             => GlobalConfig.Reload();
 
         private static void OnResetGlobalConfigClicked()
-            => GlobalConfig.Reset(oldConfig: null, resetAll: true);
+            => GlobalConfig.Reset(oldConfig: null);
+        private static void OnSetAsDefaultForNewGamesClicked() {
+            GlobalConfig.Instance.SavedGameOptions = SavedGameOptions.Instance;
+            GlobalConfig.WriteConfig();
+        }
     }
 }

--- a/TLM/TLM/State/SavedGameOptions.cs
+++ b/TLM/TLM/State/SavedGameOptions.cs
@@ -3,7 +3,7 @@ using CSUtil.Commons;
 using System;
 using System.Text;
 using TrafficManager.API.Traffic.Enums;
-using TrafficManager.Custom.PathFinding;
+using TrafficManager.Lifecycle;
 using TrafficManager.Util;
 
 public class SavedGameOptions {
@@ -112,10 +112,19 @@ public class SavedGameOptions {
     public static bool Available { get; set; } = false;
 
     public static SavedGameOptions Instance { get; private set; }
+
+    /// <summary>
+    /// ensures SavedGameOptions exists.
+    /// if not then it is set to global default or built-in default (if global default does not exist).
+    /// </summary>
     public static void Ensure() {
         Log.Info("SavedGameOptions.Ensure() called");
         if (Instance == null) {
-            Create();
+            if (GlobalConfig.Instance?.SavedGameOptions != null) {
+                Instance = GlobalConfig.Instance.SavedGameOptions;
+            } else {
+                Create();
+            }
         }
     }
     private static void Create() {
@@ -142,7 +151,6 @@ public class SavedGameOptions {
             return null;
         }
     }
-
     public static bool Deserialzie(byte[] data) {
         try {
             if (!data.IsNullOrEmpty()) {

--- a/TLM/TLM/UI/Helpers/CheckboxOption.cs
+++ b/TLM/TLM/UI/Helpers/CheckboxOption.cs
@@ -112,22 +112,15 @@ namespace TrafficManager.UI.Helpers {
         protected override void UpdateTooltip() {
             if (!HasUI) return;
 
-            _ui.tooltip = IsInScope
-                ? string.IsNullOrEmpty(_tooltip)
-                    ? string.Empty // avoid invalidating UI if already no tooltip
-                    : Translate(_tooltip)
-                : Translate(INGAME_ONLY_SETTING);
+            _ui.tooltip = Tooltip;
         }
 
         protected override void UpdateReadOnly() {
             if (!HasUI) return;
+            Log._Debug($"CheckboxOption.UpdateReadOnly() - `{FieldName}` is {(ReadOnly ? "read-only" : "writeable")}");
 
-            var readOnly = !IsInScope || _readOnly;
-
-            Log._Debug($"CheckboxOption.UpdateReadOnly() - `{FieldName}` is {(readOnly ? "read-only" : "writeable")}");
-
-            _ui.readOnly = readOnly;
-            _ui.opacity = readOnly ? 0.3f : 1f;
+            _ui.readOnly = ReadOnly;
+            _ui.opacity = ReadOnly ? 0.3f : 1f;
         }
 
         /* UI helper methods */

--- a/TLM/TLM/UI/Helpers/DLCRestrictedCheckboxOption.cs
+++ b/TLM/TLM/UI/Helpers/DLCRestrictedCheckboxOption.cs
@@ -15,7 +15,7 @@ public class DLCRestrictedCheckboxOption : CheckboxOption {
                                        SteamHelper.DLC requiredDLC,
                                        Scope scope = Scope.Savegame) : base(fieldName, scope) {
         _requiredDLC = requiredDLC;
-        _readOnly = !SteamHelper.IsDLCOwned(_requiredDLC);
+        ReadOnly = !SteamHelper.IsDLCOwned(_requiredDLC);
     }
 
     public override CheckboxOption AddUI(UIHelperBase container) {
@@ -36,7 +36,7 @@ public class DLCRestrictedCheckboxOption : CheckboxOption {
         innerPanel.autoFitChildrenVertically = true;
         innerPanel.autoLayout = true;
 
-        if (_readOnly) {
+        if (ReadOnly) {
             icon.tooltip = Locale.Get("CONTENT_REQUIRED", _requiredDLC.ToString());
             _ui.tooltip = Translate("Checkbox:DLC is required to change this option and see effects in game");
         }

--- a/TLM/TLM/UI/Helpers/DropDownOption.cs
+++ b/TLM/TLM/UI/Helpers/DropDownOption.cs
@@ -94,25 +94,18 @@ namespace TrafficManager.UI.Helpers {
         }
 
         protected override void UpdateTooltip() {
-            if (!HasUI) return;
-
-            //UIDropDown parent(UIPanel) handles tooltip
-            _ui.parent.tooltip = IsInScope
-                ? $"{_tooltip}"
-                : Translate(INGAME_ONLY_SETTING);
+            if (HasUI) {
+                _ui.parent.tooltip = Tooltip;
+            }
         }
 
         protected override void UpdateReadOnly() {
             if (!HasUI) return;
+            Log._Debug($"DropDownOption.UpdateReadOnly() - `{FieldName}` is {(ReadOnly ? "read-only" : "writeable")}");
 
-            var readOnly = !IsInScope || _readOnly;
-
-            Log._Debug($"DropDownOption.UpdateReadOnly() - `{FieldName}` is {(readOnly ? "read-only" : "writeable")}");
-
-            _ui.isInteractive = !readOnly;
-            _ui.opacity = readOnly ? 0.3f : 1f;
-            // parent is UIPanel containing text label and dropdown
-            _dropdownLabel.opacity = readOnly ? 0.3f : 1f;
+            _ui.isInteractive = !ReadOnly;
+            _ui.opacity = ReadOnly ? 0.3f : 1f;
+            _dropdownLabel.opacity = ReadOnly ? 0.3f : 1f;
         }
     }
 }

--- a/TLM/TLM/UI/Helpers/SerializableUIOptionBase.cs
+++ b/TLM/TLM/UI/Helpers/SerializableUIOptionBase.cs
@@ -39,8 +39,6 @@ namespace TrafficManager.UI.Helpers {
         /// </summary>
         public ValidatorDelegate Validator { get; set; }
 
-        protected Scope _scope;
-
         [CanBeNull]
         private FieldInfo _fieldInfo;
 
@@ -52,7 +50,6 @@ namespace TrafficManager.UI.Helpers {
         public SerializableUIOptionBase(string fieldName, Scope scope) {
 
             _fieldName = fieldName;
-            _scope = scope;
             if (scope.IsFlagSet(Scope.Savegame)) {
                 _fieldInfo = typeof(SavedGameOptions).GetField(fieldName);
 
@@ -98,16 +95,6 @@ namespace TrafficManager.UI.Helpers {
 
         public string FieldName => _fieldInfo?.Name ?? _fieldName;
 
-        /// <summary>Returns <c>true</c> if setting can persist in current <see cref="_scope"/>.</summary>
-        /// <remarks>
-        /// When <c>false</c>, UI component should be <see cref="_readOnly"/>
-        /// and <see cref="_tooltip"/> should be set to <see cref="INGAME_ONLY_SETTING"/>.
-        /// </remarks>
-        protected bool IsInScope =>
-            _scope.IsFlagSet(Scope.Global) ||
-            (_scope.IsFlagSet(Scope.Savegame) && TMPELifecycle.AppMode != null) ||
-            _scope == Scope.None;
-
         public static implicit operator TVal(SerializableUIOptionBase<TVal, TUI, TComponent> a) => a.Value;
 
         public void DefaultOnValueChanged(TVal newVal) {
@@ -126,10 +113,10 @@ namespace TrafficManager.UI.Helpers {
         public bool HasUI => _ui != null;
         protected TUI _ui;
 
-        protected string _label;
-        protected string _tooltip;
+        private string _label;
+        private string _tooltip;
 
-        protected bool _readOnly;
+        private bool _readOnly;
 
         private TranslatorDelegate _translator;
         public delegate string TranslatorDelegate(string key);
@@ -161,7 +148,7 @@ namespace TrafficManager.UI.Helpers {
         }
 
         public string Tooltip {
-            get => _tooltip;
+            get => _tooltip ?? string.Empty;
             set {
                 _tooltip = value;
                 UpdateTooltip();
@@ -171,7 +158,7 @@ namespace TrafficManager.UI.Helpers {
         public bool ReadOnly {
             get => _readOnly;
             set {
-                _readOnly = !IsInScope || value;
+                _readOnly = value;
                 UpdateReadOnly();
             }
         }

--- a/TLM/TLM/UI/Helpers/SliderOption.cs
+++ b/TLM/TLM/UI/Helpers/SliderOption.cs
@@ -110,7 +110,7 @@ namespace TrafficManager.UI.Helpers {
         protected override void UpdateLabel() {
             if (!HasUI) return;
 
-            string tooltip = IsInScope ? $"{Value}{_tooltip}" : Translate(INGAME_ONLY_SETTING);
+            string tooltip = $"{Value}{Tooltip}";
             string label = Translate(Label);
             _sliderLabel.text = label + ": " + tooltip;
         }
@@ -119,16 +119,12 @@ namespace TrafficManager.UI.Helpers {
 
         protected override void UpdateReadOnly() {
             if (!HasUI) return;
+            Log._Debug($"SliderOption.UpdateReadOnly() - `{FieldName}` is {(ReadOnly ? "read-only" : "writeable")}");
 
-            var readOnly = !IsInScope || _readOnly;
-
-            Log._Debug($"SliderOption.UpdateReadOnly() - `{FieldName}` is {(readOnly ? "read-only" : "writeable")}");
-
-            _ui.isInteractive = !readOnly;
-            _ui.thumbObject.isInteractive = !readOnly;
-            _ui.thumbObject.opacity = readOnly ? 0.3f : 1f;
-            // parent is UIPanel containing text label and slider
-            _sliderLabel.opacity = readOnly ? 0.3f : 1f;
+            _ui.isInteractive = !ReadOnly;
+            _ui.thumbObject.isInteractive = !ReadOnly;
+            _ui.thumbObject.opacity = ReadOnly ? 0.3f : 1f;
+            _sliderLabel.opacity = ReadOnly ? 0.3f : 1f;
         }
     }
 }

--- a/TLM/TLM/UI/Helpers/TriStateCheckboxOption.cs
+++ b/TLM/TLM/UI/Helpers/TriStateCheckboxOption.cs
@@ -101,24 +101,18 @@ namespace TrafficManager.UI.Helpers {
         }
 
         protected override void UpdateTooltip() {
-            if (!HasUI) return;
-
-            _ui.tooltip = IsInScope
-                ? string.IsNullOrEmpty(_tooltip)
-                    ? string.Empty // avoid invalidating UI if already no tooltip
-                    : Translate(_tooltip)
-                : Translate(INGAME_ONLY_SETTING);
+            if (HasUI) {
+                _ui.tooltip = Tooltip;
+            }
         }
 
         protected override void UpdateReadOnly() {
             if (!HasUI) return;
 
-            var readOnly = !IsInScope || _readOnly;
+            Log._Debug($"TriStateCheckboxOption.UpdateReadOnly() - `{FieldName}` is {(ReadOnly ? "read-only" : "writeable")}");
 
-            Log._Debug($"TriStateCheckboxOption.UpdateReadOnly() - `{FieldName}` is {(readOnly ? "read-only" : "writeable")}");
-
-            _ui.readOnly = readOnly;
-            _ui.opacity = readOnly ? 0.3f : 1f;
+            _ui.readOnly = ReadOnly;
+            _ui.opacity = ReadOnly ? 0.3f : 1f;
         }
 
         /* UI helper methods */


### PR DESCRIPTION
[TMPE.zip](https://ci.appveyor.com/api/projects/krzychu124/tmpe/artifacts/TMPE.zip?branch=set-default-options)
fixes #363

- `Resetting all config` resets global config + sets default options for new games to built-in defaults
- `Set as default for new games` option was added. this can be pressed both in main menu and in game.
- all options can always be modified in main menu, game, or asset editor (except dynamic lane changing cannot be modified in asset editor).

Bonus:
- moved some duplicate code to base class `SerializableUIOptionBase`
- the `resetAll` parameter when resetting global was redundant - even misleading. so I dropped it. if the `oldConfig` parameter is null it is all reset (as it was the case before).
