### PR TITLE
fixed LC raycasting for overlapping lanes

### DIFF
--- a/TLM/TLM/UI/SubTools/LaneConnectorTool.cs
+++ b/TLM/TLM/UI/SubTools/LaneConnectorTool.cs
@@ -537,6 +537,10 @@ namespace TrafficManager.UI.SubTools {
             }
 
             foreach (LaneEnd laneEnd in laneEnds) {
+                if((laneEnd.TransitionGroup & group_) == 0) {
+                    continue;
+                }
+
                 bool drawMarker = false;
                 bool acute = true;
                 bool sourceMode = GetSelectionMode() == SelectionMode.SelectSource;


### PR DESCRIPTION
fixes: https://discord.com/channels/545065285862948894/1049088238486294568
not possible to connect overlapping bus+tram lanes.

solution: don't try to intersect mouse ray for the wrong lanes.

[TMPE.zip](https://ci.appveyor.com/api/projects/krzychu124/tmpe/artifacts/TMPE.zip?branch=LC-raycast)