### PR TITLE
no parking signs on bus lanes.

### DIFF
--- a/TLM/TLM/Manager/Impl/ParkingRestrictionsManager.cs
+++ b/TLM/TLM/Manager/Impl/ParkingRestrictionsManager.cs
@@ -35,7 +35,8 @@ namespace TrafficManager.Manager.Impl {
 
         public bool MayHaveParkingRestriction(ushort segmentId, NetInfo.Direction finalDir) {
             ref NetSegment segment = ref segmentId.ToSegment();
-            bool right = (finalDir == NetInfo.Direction.Forward) != segment.m_flags.IsFlagSet(NetSegment.Flags.Invert);
+            var dir = Shortcuts.RHT ? finalDir : NetInfo.InvertDirection(finalDir);
+            bool right = dir == NetInfo.Direction.Forward != segment.m_flags.IsFlagSet(NetSegment.Flags.Invert);
             if (right) {
                 if (segment.m_flags.IsFlagSet(NetSegment.Flags.StopRight | NetSegment.Flags.StopRight2)) {
                     return false;

--- a/TLM/TLM/Manager/Impl/ParkingRestrictionsManager.cs
+++ b/TLM/TLM/Manager/Impl/ParkingRestrictionsManager.cs
@@ -25,13 +25,27 @@ namespace TrafficManager.Manager.Impl {
 
         public bool MayHaveParkingRestriction(ushort segmentId) {
             ref NetSegment segment = ref segmentId.ToSegment();
-            if ((segment.m_flags & NetSegment.Flags.Created) == NetSegment.Flags.None) {
-                return true;
+            if (!segment.IsValid()) {
+                return false;
             }
 
             ItemClass connectionClass = segment.Info.GetConnectionClass();
-
             return connectionClass.m_service == ItemClass.Service.Road && segment.Info.m_hasParkingSpaces;
+        }
+
+        public bool MayHaveParkingRestriction(ushort segmentId, NetInfo.Direction finalDir) {
+            ref NetSegment segment = ref segmentId.ToSegment();
+            bool right = (finalDir == NetInfo.Direction.Forward) != segment.m_flags.IsFlagSet(NetSegment.Flags.Invert);
+            if (right) {
+                if (segment.m_flags.IsFlagSet(NetSegment.Flags.StopRight | NetSegment.Flags.StopRight2)) {
+                    return false;
+                }
+            } else {
+                if (!right && segment.m_flags.IsFlagSet(NetSegment.Flags.StopLeft | NetSegment.Flags.StopLeft2)) {
+                    return false;
+                }
+            }
+            return MayHaveParkingRestriction(segmentId);
         }
 
         public bool IsParkingAllowed(ushort segmentId, NetInfo.Direction finalDir) {

--- a/TLM/TLM/Manager/Impl/ParkingRestrictionsManager.cs
+++ b/TLM/TLM/Manager/Impl/ParkingRestrictionsManager.cs
@@ -42,7 +42,7 @@ namespace TrafficManager.Manager.Impl {
                     return false;
                 }
             } else {
-                if (!right && segment.m_flags.IsFlagSet(NetSegment.Flags.StopLeft | NetSegment.Flags.StopLeft2)) {
+                if (segment.m_flags.IsFlagSet(NetSegment.Flags.StopLeft | NetSegment.Flags.StopLeft2)) {
                     return false;
                 }
             }

--- a/TLM/TLM/Manager/Impl/ParkingRestrictionsManager.cs
+++ b/TLM/TLM/Manager/Impl/ParkingRestrictionsManager.cs
@@ -36,7 +36,7 @@ namespace TrafficManager.Manager.Impl {
         public bool MayHaveParkingRestriction(ushort segmentId, NetInfo.Direction finalDir) {
             ref NetSegment segment = ref segmentId.ToSegment();
             var dir = Shortcuts.RHT ? finalDir : NetInfo.InvertDirection(finalDir);
-            bool right = dir == NetInfo.Direction.Forward != segment.m_flags.IsFlagSet(NetSegment.Flags.Invert);
+            bool right = (dir == NetInfo.Direction.Forward) != segment.m_flags.IsFlagSet(NetSegment.Flags.Invert);
             if (right) {
                 if (segment.m_flags.IsFlagSet(NetSegment.Flags.StopRight | NetSegment.Flags.StopRight2)) {
                     return false;

--- a/TLM/TLM/UI/SubTools/ParkingRestrictionsTool.cs
+++ b/TLM/TLM/UI/SubTools/ParkingRestrictionsTool.cs
@@ -274,13 +274,17 @@ namespace TrafficManager.UI.SubTools {
             }
 
             foreach (KeyValuePair<NetInfo.Direction, Vector3> e in segCenter) {
+                bool configurable = parkingManager.MayHaveParkingRestriction(segmentId, e.Key);
+                if (!configurable) {
+                    continue;
+                }
+
                 bool allowed = parkingManager.IsParkingAllowed(segmentId, e.Key);
                 if (allowed && viewOnly) {
                     continue;
                 }
 
                 bool visible = GeometryUtil.WorldToScreenPoint(e.Value, out Vector3 screenPos);
-
                 if (!visible) {
                     continue;
                 }


### PR DESCRIPTION
fixed: parking must not be configurable on bus lanes. 

[TMPE.zip](https://ci.appveyor.com/api/projects/krzychu124/tmpe/artifacts/TMPE.zip?branch=bus-parking-signs)

Before:
![image](https://user-images.githubusercontent.com/26344691/205787336-e2615126-8704-41ad-9330-177db2b4308b.png)
After:
![image](https://user-images.githubusercontent.com/26344691/205787163-7fe9d4e4-78ef-4b46-bcd9-0ca0019328a5.png)