### PR TITLE
What's new 11.7.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,28 @@ This changelog includes all versions and major variants of the mod going all the
 
 > Date format: dd/mm/yyyy
 
+#### TM:PE V[11.7.3.0](https://github.com/CitiesSkylinesMods/TMPE/compare/11.7.2.0...11.7.3.0) STABLE, 13/12/2022
+
+- [Meta] Compatibility patch for the game update 1.16.0-f3 (krzychu124)
+- [New] Improved bus/trolleybus stop path (pull to side earlier and use more of available space) #1688, #1690 (kianzarrin)
+- [Fixed] Cargo truck pathfinding via CargoVehicle networks (cargo stations/terminals) #1701, #1703 (krzychu124)
+- [Fixed] Lane connector on overlapping lanes #1706 (kianzarrin)
+- [Fixed] Parking signs on lanes with bus stop #1707 (kianzarrin)
+- [Updated] Minor changes in debug tools #1696, #1697 (kianzarrin)
+- [Updated] TMPE API Updates compatibility with other mods #1689 #1692 (kianzarrin)
+- [Steam] [TM:PE v11 STABLE](https://steamcommunity.com/sharedfiles/filedetails/?id=1637663252)
+
+#### TM:PE V11.7.3.0 TEST, 13/12/2022
+
+- [Meta] Compatibility patch for the game update 1.16.0-f3 (krzychu124)
+- [New] Improved bus/trolleybus stop path (pull to side earlier and use more of available space) #1688, #1690 (kianzarrin)
+- [Fixed] Cargo truck pathfinding via CargoVehicle networks (cargo stations/terminals) #1701, #1703 (krzychu124)
+- [Fixed] Lane connector on overlapping lanes #1706 (kianzarrin)
+- [Fixed] Parking signs on lanes with bus stop #1707 (kianzarrin)
+- [Updated] Minor changes in debug tools #1696, #1697 (kianzarrin)
+- [Updated] TMPE API Updates compatibility with other mods #1689 #1692 (kianzarrin)
+- [Steam] [TM:PE v11 TEST](https://steamcommunity.com/sharedfiles/filedetails/?id=2489276785)
+
 #### TM:PE V[11.7.2.0](https://github.com/CitiesSkylinesMods/TMPE/compare/11.7.1.2...11.7.2.0) STABLE, 15/11/2022
 
 - [Meta] Compatibility patch for the game update 1.15.1-f4 (krzychu124)

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
     <a href="https://github.com/CitiesSkylinesMods/TMPE/wiki/Report-a-Bug">Report a Bug</a><br />
 </p>
 <p align="center">
-    <a href="https://store.steampowered.com/app/255710/Cities_Skylines/"><img src="https://img.shields.io/static/v1?label=cities:%20skylines&message=v1.15.1-f4&color=01ABF8&logo=unity" /></a>
+    <a href="https://store.steampowered.com/app/255710/Cities_Skylines/"><img src="https://img.shields.io/static/v1?label=cities:%20skylines&message=v1.16.0-f3&color=01ABF8&logo=unity" /></a>
     <a href="https://steamcommunity.com/sharedfiles/filedetails/?id=1637663252"><img src="https://img.shields.io/github/v/release/CitiesSkylinesMods/TMPE?label=stable&color=7cc17b&logo=steam&logoColor=F5F5F5" /></a>
     <a href="https://steamcommunity.com/sharedfiles/filedetails/?id=2489276785"><img src="https://img.shields.io/github/v/release/CitiesSkylinesMods/TMPE?include_prereleases&label=test&color=f7b73c&logo=steam&logoColor=F5F5F5" /></a>
     <a href="https://github.com/CitiesSkylinesMods/TMPE/releases/latest"><img src="https://img.shields.io/github/v/release/CitiesSkylinesMods/TMPE?label=origin&color=F56C2D&logo=origin&logoColor=F56C2D" /></a>

--- a/TLM/SharedAssemblyInfo.cs
+++ b/TLM/SharedAssemblyInfo.cs
@@ -20,4 +20,4 @@ using System.Runtime.InteropServices;
 //      Minor Version
 //      Build Number
 //      Revision
-[assembly: AssemblyVersion("11.7.2.*")]
+[assembly: AssemblyVersion("11.7.3.*")]

--- a/TLM/TLM/Custom/PathFinding/CustomPathFind.cs
+++ b/TLM/TLM/Custom/PathFinding/CustomPathFind.cs
@@ -2642,12 +2642,6 @@ namespace TrafficManager.Custom.PathFinding {
                     $"\toffsetLength={offsetLength}");
             }
 #endif
-            if ((vehicleCategory_ & VehicleInfo.VehicleCategory.PublicTransportRoad) != 0 &&
-                (vehicleCategory_ & ~(VehicleInfo.VehicleCategory.Bus | VehicleInfo.VehicleCategory.Trolleybus | VehicleInfo.VehicleCategory.Taxi)) == 0)
-            {
-                offsetLength *= 0.75f;
-            }
-
             float baseLength = offsetLength / (prevLaneSpeed * maxLength_); // NON-STOCK CODE
             float comparisonValue = item.ComparisonValue; // NON-STOCK CODE
 #if ROUTING
@@ -3140,6 +3134,11 @@ namespace TrafficManager.Custom.PathFinding {
                                 nextLaneIndex,
                                 nextLaneId,
                                 $"ProcessItemCosts: Adding next item\n\tnextItem={nextItem}");
+                        }
+
+                        if ((nextLaneInfo.vehicleCategory & VehicleInfo.VehicleCategory.PublicTransportRoad) != 0 &&
+                            (nextLaneInfo.vehicleCategory & ~(VehicleInfo.VehicleCategory.Bus | VehicleInfo.VehicleCategory.Trolleybus | VehicleInfo.VehicleCategory.Taxi)) == 0) {
+                            nextItem.ComparisonValue -= baseLength * 0.25f;
                         }
 
                         AddBufferItem(

--- a/TLM/TLM/Resources/whats_new.txt
+++ b/TLM/TLM/Resources/whats_new.txt
@@ -1,10 +1,12 @@
-[Version] 11.7.2.0
-[Released] Nov 15th 2022
-[Link] tmpe-v11720-stable-15112022
+[Version] 11.7.3.0
+[Released] Dec 13th 2022
+[Link] tmpe-v11730-stable-13122022
 [Stable]
-[Meta] Compatibility patch for the game update 1.15.1-f4 (krzychu124)
-[New] Clear all TM:PE rules from selected node #692, #1668 (kianzarrin)
-[Fixed] Timed Traffic Lights wait = 0 issues #1497, #1674 (kianzarrin)
-[Updated] Minor changes to Timed Traffic Lights sensitivity slider #1670 (kianzarrin)
-[Updated] Pedestrian zone roads have now lower priority when setting up high priority road #1653 (kianzarrin)
+[Meta] Compatibility patch for the game update 1.16.0-f3 (krzychu124)
+[New] Improved bus/trolleybus stop path #1688, #1690 (kianzarrin)
+[Fixed] Cargo truck pathfinding via CargoVehicle networks (cargo stations/terminals) #1701, #1703 (krzychu124)
+[Fixed] Lane connector on overlapping lanes #1706 (kianzarrin)
+[Fixed] Parking signs on lanes with bus stop #1707 (kianzarrin)
+[Updated] Minor changes in debug tools #1696, #1697 (kianzarrin)
+[Updated] TMPE API Updates compatibility with other mods #1689 #1692 (kianzarrin)
 [/Version]

--- a/TLM/TLM/Resources/whats_new.txt
+++ b/TLM/TLM/Resources/whats_new.txt
@@ -3,7 +3,7 @@
 [Link] tmpe-v11730-stable-13122022
 [Stable]
 [Meta] Compatibility patch for the game update 1.16.0-f3 (krzychu124)
-[New] Improved bus/trolleybus stop path #1688, #1690 (kianzarrin)
+[New] Improved bus/trolleybus stop path (pull to side earlier and use more of available space) #1688, #1690 (kianzarrin)
 [Fixed] Cargo truck pathfinding via CargoVehicle networks (cargo stations/terminals) #1701, #1703 (krzychu124)
 [Fixed] Lane connector on overlapping lanes #1706 (kianzarrin)
 [Fixed] Parking signs on lanes with bus stop #1707 (kianzarrin)

--- a/TLM/TLM/UI/WhatsNew/WhatsNew.cs
+++ b/TLM/TLM/UI/WhatsNew/WhatsNew.cs
@@ -11,7 +11,7 @@ namespace TrafficManager.UI.WhatsNew {
 
     public class WhatsNew {
         // bump and update what's new changelogs when new features added
-        public static readonly Version CurrentVersion = new Version(11,7,2,0);
+        public static readonly Version CurrentVersion = new Version(11,7,3,0);
 
         private const string WHATS_NEW_FILE = "whats_new.txt";
         private const string RESOURCES_PREFIX = "TrafficManager.Resources.";

--- a/TLM/TLM/Util/Extensions/VehicleExtensions.cs
+++ b/TLM/TLM/Util/Extensions/VehicleExtensions.cs
@@ -118,7 +118,8 @@ namespace TrafficManager.Util.Extensions {
                                     VehicleInfo.VehicleCategory.MaintenanceTruck |
                                     VehicleInfo.VehicleCategory.ParkTruck |
                                     VehicleInfo.VehicleCategory.PostTruck |
-                                    VehicleInfo.VehicleCategory.SnowTruck)) != 0) {
+                                    VehicleInfo.VehicleCategory.SnowTruck |
+                                    VehicleInfo.VehicleCategory.BankTruck)) != 0) {
                 return ExtVehicleType.Service;
             } else if ((category & VehicleInfo.VehicleCategory.Bus) != 0) {
                 return ExtVehicleType.Bus;

--- a/TLM/TLM/Util/VersionUtil.cs
+++ b/TLM/TLM/Util/VersionUtil.cs
@@ -35,10 +35,10 @@ namespace TrafficManager.Util {
         // we could alternatively use BuildConfig.APPLICATION_VERSION because const values are evaluated at compile time.
         // but I have decided not to do this because I don't want this to happen automatically with a rebuild if
         // CS updates. these values should be changed manually so as to force us to acknowledge that they have changed.
-        public const uint EXPECTED_GAME_VERSION_U = 197387280U;
+        public const uint EXPECTED_GAME_VERSION_U = 201450256U;
 
         // see comments for EXPECTED_GAME_VERSION_U.
-        public static Version ExpectedGameVersion => new Version(1, 15, 1, 4);
+        public static Version ExpectedGameVersion => new Version(1, 16, 0, 3);
 
         public static string ExpectedGameVersionString => BuildConfig.VersionToString(EXPECTED_GAME_VERSION_U, false);
 


### PR DESCRIPTION
_New_
- Improved bus/trolleybus stop path #1688, #1690

_Fixed_
- Cargo truck pathfinding via `CargoVehicle` networks (cargo stations/terminals) #1701, #1703
- Lane connector on overlapping lanes #1706
- Parking signs on lanes with bus stop #1707

_Updated_
- Minor changes in debug tools #1696, #1697
- TMPE API Updates compatibility with other mods #1689 #1692