### PR TITLE
Incomplete Bank vans detection 

### DIFF
--- a/TLM/TLM/Manager/Impl/ExtVehicleManager.cs
+++ b/TLM/TLM/Manager/Impl/ExtVehicleManager.cs
@@ -936,6 +936,7 @@ namespace TrafficManager.Manager.Impl {
                         case PassengerCarAI _:
                             return ExtVehicleType.PassengerCar;
                         case AmbulanceAI _:
+                        case BankVanAI _:
                         case FireTruckAI _:
                         case PoliceCarAI _:
                         case HearseAI _:

--- a/TLM/TLM/Patch/_VehicleAI/_BankVanAI/StartPathFindPatch.cs
+++ b/TLM/TLM/Patch/_VehicleAI/_BankVanAI/StartPathFindPatch.cs
@@ -1,0 +1,29 @@
+namespace TrafficManager.Patch._VehicleAI._BankVanAI {
+    using System.Collections.Generic;
+    using System.Reflection;
+    using System.Reflection.Emit;
+    using HarmonyLib;
+    using JetBrains.Annotations;
+    using TrafficManager.API.Traffic.Enums;
+    using TrafficManager.Patch._PathManager;
+
+    [HarmonyPatch]
+    public class StartPathFindPatch {
+
+        [UsedImplicitly]
+        public static MethodBase TargetMethod() => StartPathFindCommons.TargetMethod<BankVanAI>();
+
+        [UsedImplicitly]
+        public static void Prefix(ushort vehicleID, ref Vehicle vehicleData) {
+            CreatePathPatch.ExtPathType = ExtPathType.None;
+            CreatePathPatch.ExtVehicleType = ExtVehicleType.Service;
+            CreatePathPatch.VehicleID = vehicleID;
+        }
+
+        [UsedImplicitly]
+        [HarmonyPriority(Priority.Low)] // so that if this code is redundant, it would result in warning log.
+        public static IEnumerable<CodeInstruction> Transpiler(ILGenerator il, IEnumerable<CodeInstruction> instructions) {
+            return StartPathFindCommons.ReplaceMaxPosTranspiler(instructions);
+        }
+    }
+}

--- a/TLM/TLM/TLM.csproj
+++ b/TLM/TLM/TLM.csproj
@@ -161,6 +161,7 @@
     <Compile Include="Patch\_NetLane\CalculateStopPositionAndDirection.cs" />
     <Compile Include="Patch\_PedestrianZoneRoadAI\BollardSimulationStepPatch.cs" />
     <Compile Include="Patch\_VehicleAI\InvalidPathPatch.cs" />
+    <Compile Include="Patch\_VehicleAI\_BankVanAI\StartPathFindPatch.cs" />
     <Compile Include="Patch\_VehicleAI\_BusAI\CalculateSegmentPositionPatch.cs" />
     <Compile Include="State\OptionsTabs\GameplayTab_AIGroups.cs" />
     <Compile Include="State\OptionsTabs\GeneralTab_CompatibilityGroup.cs" />


### PR DESCRIPTION
Add missing `BankVanAI` to correctly determine vehicle type. Affects vehicle restrictions and junction restrictions features - was detected as not eligible to use turn on red feature or not following Service Vehicles restriction