### PR TITLE
Prevent the user from setting invalid Lane Arrows, update if lane connections exist

### DIFF
--- a/TLM/TLM/Manager/Impl/LaneArrowManager.cs
+++ b/TLM/TLM/Manager/Impl/LaneArrowManager.cs
@@ -227,6 +227,12 @@ namespace TrafficManager.Manager.Impl {
             }
         }
 
+        private void ValidateCustomLaneArrows() {
+            for (uint laneId = 0; laneId < NetManager.MAX_LANE_COUNT; ++laneId) {
+                Flags.ValidateLaneCustomArrows(laneId);
+            }
+        }
+
         public override void OnLevelLoading() {
             base.OnLevelLoading();
             if (SavedGameOptions.Instance.DedicatedTurningLanes) {
@@ -243,6 +249,7 @@ namespace TrafficManager.Manager.Impl {
         public override void OnAfterLoadData() {
             base.OnAfterLoadData();
             Flags.ClearHighwayLaneArrows();
+            ValidateCustomLaneArrows();
             ApplyFlags();
         }
 

--- a/TLM/TLM/Patch/_RoadBaseAI/SegmentSimulationStepPatch.cs
+++ b/TLM/TLM/Patch/_RoadBaseAI/SegmentSimulationStepPatch.cs
@@ -27,20 +27,6 @@ namespace TrafficManager.Patch._RoadBaseAI {
         /// </summary>
         [UsedImplicitly]
         public static void Prefix(RoadBaseAI __instance, ushort segmentID, ref NetSegment data) {
-            // TODO check if this is required *START*
-            uint curLaneId = data.m_lanes;
-            int numLanes = data.Info.m_lanes.Length;
-            uint laneIndex = 0;
-
-            while (laneIndex < numLanes && curLaneId != 0u) {
-                Flags.ApplyLaneArrowFlags(curLaneId);
-
-                laneIndex++;
-                curLaneId = Singleton<NetManager>.instance.m_lanes.m_buffer[curLaneId].m_nextLane;
-            }
-
-            // ↑↑↑↑
-            // TODO check if this is required *END*
             if (segmentID < lastSimulatedSegmentId) {
                 // segment simulation restart
                 ++trafficMeasurementMod;

--- a/TLM/TLM/State/Flags.cs
+++ b/TLM/TLM/State/Flags.cs
@@ -630,7 +630,7 @@ namespace TrafficManager.State {
 
             LaneArrows? outgoingAvailableLaneArrows = ExtSegmentEndManager.Instance.GetOutgoingAvailableLaneArrows(laneId);
             if (!outgoingAvailableLaneArrows.HasValue) {
-                ResetLaneArrowFlags(laneId);
+                LaneArrowManager.Instance.ResetLaneArrows(laneId);
                 return;
             }
 
@@ -639,7 +639,7 @@ namespace TrafficManager.State {
 #if DEBUGFLAGS
                 Log._Debug($"Invalid custom Lane Arrows. Resetting for lane {laneId}! Available: {outgoingAvailableLaneArrows.Value} Custom: {laneArrowFlag.Value}");
 #endif
-                ResetLaneArrowFlags(laneId);
+                LaneArrowManager.Instance.ResetLaneArrows(laneId);
             }
         }
 

--- a/TLM/TLM/State/Flags.cs
+++ b/TLM/TLM/State/Flags.cs
@@ -146,12 +146,12 @@ namespace TrafficManager.State {
             NetNode.Flags flags = node.m_flags | NetNode.Flags.CustomTrafficLights;
             if (flag) {
 #if DEBUGFLAGS
-                Log._Debug($"Adding traffic light @ node {nId}");
+                Log._Debug($"Adding traffic light @ node {nodeId}");
 #endif
                 flags |= NetNode.Flags.TrafficLights;
             } else {
 #if DEBUGFLAGS
-                Log._Debug($"Removing traffic light @ node {nId}");
+                Log._Debug($"Removing traffic light @ node {nodeId}");
 #endif
                 flags &= ~NetNode.Flags.TrafficLights;
             }
@@ -316,7 +316,12 @@ namespace TrafficManager.State {
             Log._Debug($"Flags.resetLaneArrowFlags: Resetting lane arrows of lane {laneId}.");
 #endif
             if (LaneConnectionManager.Instance.Road.HasOutgoingConnections(laneId)) {
-                return false;
+                LaneArrows? arrows = LaneConnectionManager.Instance.Road.GetArrowsForOutgoingConnections(laneId);
+#if DEBUGFLAGS
+                Log._Debug($"Flags.resetLaneArrowFlags: Lane {laneId} has outgoing connections. Calculated Arrows: {(arrows.HasValue ? arrows.Value : "<none>")}");
+#endif
+                laneArrowFlags[laneId] = arrows.HasValue ? arrows.Value : null;
+                return true;
             }
 
             laneArrowFlags[laneId] = null;
@@ -615,6 +620,26 @@ namespace TrafficManager.State {
             // uint laneFlags = netLane.m_flags;
             if (((NetLane.Flags)netLane.m_flags & (NetLane.Flags.Created | NetLane.Flags.Deleted)) == NetLane.Flags.Created) {
                 netLane.m_flags &= (ushort)~lfr;
+            }
+        }
+
+        public static void ValidateLaneCustomArrows(uint laneId) {
+            LaneArrows? laneArrowFlag = laneArrowFlags[laneId];
+            if (!laneArrowFlag.HasValue)
+                return;
+
+            LaneArrows? outgoingAvailableLaneArrows = ExtSegmentEndManager.Instance.GetOutgoingAvailableLaneArrows(laneId);
+            if (!outgoingAvailableLaneArrows.HasValue) {
+                ResetLaneArrowFlags(laneId);
+                return;
+            }
+
+            // check is laneArrowFlag is any different than available
+            if ((laneArrowFlag.Value & ~outgoingAvailableLaneArrows.Value) != LaneArrows.None) {
+#if DEBUGFLAGS
+                Log._Debug($"Invalid custom Lane Arrows. Resetting for lane {laneId}! Available: {outgoingAvailableLaneArrows.Value} Custom: {laneArrowFlag.Value}");
+#endif
+                ResetLaneArrowFlags(laneId);
             }
         }
 

--- a/TLM/TLM/UI/SubTools/LaneArrows/LaneArrowTool.cs
+++ b/TLM/TLM/UI/SubTools/LaneArrows/LaneArrowTool.cs
@@ -172,8 +172,10 @@ namespace TrafficManager.UI.SubTools.LaneArrows {
                 reverse: true);
 
             CreateLaneArrowsWindow(sortedLanes.Count);
+            ref ExtSegmentEnd segmentEnd = ref ExtSegmentEndManager.Instance.GetEnd(SelectedSegmentId, startNode.Value);
             SetupLaneArrowsWindowButtons(laneList: sortedLanes,
-                                         startNode: startNode.Value);
+                                         startNode: startNode.Value,
+                                         segmentEnd.laneArrows);
             MainTool.RequestOnscreenDisplayUpdate();
         }
 
@@ -203,7 +205,7 @@ namespace TrafficManager.UI.SubTools.LaneArrows {
         /// Given the tool window already created with its buttons set up,
         /// go through them and assign click events, disable some, activate some etc.
         /// </summary>
-        private void SetupLaneArrowsWindowButtons(IList<LanePos> laneList, bool startNode) {
+        private void SetupLaneArrowsWindowButtons(IList<LanePos> laneList, bool startNode, LaneArrows availableArrows) {
             // For all lanes, go through our buttons and update their onClick, etc.
             for (var i = 0; i < laneList.Count; i++) {
                 uint laneId = laneList[i].laneId;
@@ -215,6 +217,9 @@ namespace TrafficManager.UI.SubTools.LaneArrows {
                 buttonLeft.ToggleFlag = API.Traffic.Enums.LaneArrows.Left;
                 buttonLeft.UpdateButtonSkinAndTooltip();
                 buttonLeft.ParentTool = this; // to access error reporting function on click
+                bool leftAllowed =  (availableArrows & LaneArrows.Left) != 0;
+                buttonLeft.isEnabled = leftAllowed;
+                buttonLeft.tooltip = !leftAllowed ? T("LaneArrow: Direction not available") : string.Empty;
 
                 LaneArrowButton buttonForward = ToolWindow.Buttons[(i * 3) + 1];
                 buttonForward.LaneId = laneId;
@@ -223,6 +228,9 @@ namespace TrafficManager.UI.SubTools.LaneArrows {
                 buttonForward.ToggleFlag = API.Traffic.Enums.LaneArrows.Forward;
                 buttonForward.UpdateButtonSkinAndTooltip();
                 buttonForward.ParentTool = this; // to access error reporting function on click
+                bool forwardAllowed =  (availableArrows & LaneArrows.Forward) != 0;
+                buttonForward.isEnabled = forwardAllowed;
+                buttonForward.tooltip = !forwardAllowed ? T("LaneArrow: Direction not available") : string.Empty;
 
                 LaneArrowButton buttonRight = ToolWindow.Buttons[(i * 3) + 2];
                 buttonRight.LaneId = laneId;
@@ -231,6 +239,9 @@ namespace TrafficManager.UI.SubTools.LaneArrows {
                 buttonRight.ToggleFlag = API.Traffic.Enums.LaneArrows.Right;
                 buttonRight.UpdateButtonSkinAndTooltip();
                 buttonRight.ParentTool = this; // to access error reporting function on click
+                bool rightAllowed =  (availableArrows & LaneArrows.Right) != 0;
+                buttonRight.isEnabled = rightAllowed;
+                buttonRight.tooltip = !rightAllowed ? T("LaneArrow: Direction not available") : string.Empty;
             }
         }
 

--- a/TLM/TLM/UI/TrafficManagerTool.cs
+++ b/TLM/TLM/UI/TrafficManagerTool.cs
@@ -1176,13 +1176,14 @@ namespace TrafficManager.UI {
                 labelSb.AppendFormat(", flags: {0}", netSegment.m_flags);
                 labelSb.AppendFormat("\nsvc: {0}, sub: {1}", service, subService);
 
-                uint startVehicles = endMan.GetRegisteredVehicleCount(
-                    ref endMan.ExtSegmentEnds[endMan.GetIndex((ushort)segmentId, true)]);
+                ref ExtSegmentEnd startSegmentEnd = ref endMan.ExtSegmentEnds[endMan.GetIndex((ushort)segmentId, true)];
+                uint startVehicles = endMan.GetRegisteredVehicleCount(ref startSegmentEnd);
 
-                uint endVehicles = endMan.GetRegisteredVehicleCount(
-                    ref endMan.ExtSegmentEnds[endMan.GetIndex((ushort)segmentId, false)]);
+                ref ExtSegmentEnd endSegmentEnd = ref endMan.ExtSegmentEnds[endMan.GetIndex((ushort)segmentId, false)];
+                uint endVehicles = endMan.GetRegisteredVehicleCount(ref endSegmentEnd);
 
                 labelSb.AppendFormat( "\nstart veh.: {0}, end veh.: {1}", startVehicles, endVehicles);
+                labelSb.AppendFormat( "\nstart arrows: {0}, end arrows: {1}", startSegmentEnd.laneArrows, endSegmentEnd.laneArrows);
 #endif
                 labelSb.AppendFormat("\nTraffic: {0} %", netSegment.m_trafficDensity);
 

--- a/TLM/TMPE.API/Traffic/Data/ExtSegmentEnd.cs
+++ b/TLM/TMPE.API/Traffic/Data/ExtSegmentEnd.cs
@@ -1,6 +1,8 @@
 namespace TrafficManager.API.Traffic.Data
 {
     using System;
+    using CSUtil.Commons;
+    using TrafficManager.API.Traffic.Enums;
     using UnityEngine;
 
     public struct ExtSegmentEnd : IEquatable<ExtSegmentEnd>
@@ -36,6 +38,11 @@ namespace TrafficManager.API.Traffic.Data
         public Vector3 RightCornerDir;
 
         /// <summary>
+        /// All available Lane Arrows describing possible outgoing directions via this segment end
+        /// </summary>
+        public LaneArrows laneArrows;
+
+        /// <summary>
         /// First registered vehicle id on this segment end
         /// </summary>
         public ushort firstVehicleId;
@@ -51,6 +58,7 @@ namespace TrafficManager.API.Traffic.Data
             LeftCornerDir = Vector3.zero;
             RightCorner = Vector3.zero;
             RightCornerDir = Vector3.zero;
+            laneArrows = LaneArrows.None;
         }
 
         public override string ToString()
@@ -58,7 +66,8 @@ namespace TrafficManager.API.Traffic.Data
             return string.Format(
                 "[ExtSegmentEnd {0}\n\tsegmentId={1}\n\tstartNode={2}\n\tnodeId={3}\n" +
                 "\toutgoing={4}\n\tincoming={5}\n\tfirstVehicleId={6}\n" +
-                "\tLeftCorner={7}\n\tLeftCornerDir={8}\n\tRightCorner={9}\n\tRightCornerDir={10}" +
+                "\tLeftCorner={7}\n\tLeftCornerDir={8}\n\tRightCorner={9}\n\tRightCornerDir={10}\n" +
+                "\tLaneArrows={11}" +
                 "\nExtSegmentEnd]",
                 base.ToString(),
                 segmentId,
@@ -70,7 +79,8 @@ namespace TrafficManager.API.Traffic.Data
                 LeftCorner,
                 LeftCornerDir,
                 RightCorner,
-                RightCornerDir);
+                RightCornerDir,
+                laneArrows);
         }
 
         public bool Equals(ExtSegmentEnd otherSegEnd)


### PR DESCRIPTION
Fixes #368 

Enhancements in this PR:
- validate `Lane Arrows` on load
- calculate and refresh set of allowed lane arrows for `SegmentEnd`
- reset custom lane arrows when after segment or node update the set of available lane arrows is significantly different (segment supports more or less arrow directions than before)
- block invalid `Lane Arrows` in the Tool UI, shows a tooltip for disabled arrows
- update `Lane Arrows` if the lane has any `Lane Connection(s)`, to match direction of the lane connection
- [performance] after doing many tests I decided to remove code for updating lane arrows from `_RoadBaseAI/SegmentSimulationStepPatch` since it does not provide any value other than wasting CPU time

Provided enhancements will solve a lot of mysterious issues reported by users in the past few years. Sometimes, for some reason (most likely segment update or bug in other feature) custom lane arrows became invalid, effectively causing huge pathfinding issues (including infamous "no cims coming from outside" when the users started a new city), since invalid arrows either don't create any lane transitions or only those of type "relaxed" which come with significant penalty for pathfinding when selected for regular vehicles.


Build [ZIP](https://ci.appveyor.com/api/projects/krzychu124/tmpe/artifacts/TMPE.zip?branch=bugfix/invalid-arrow-directions-not-allowed)