### PR TITLE
Improve reliability of Custom Path Manager when patched by other mods

### DIFF
--- a/TLM/TLM/Custom/PathFinding/CustomPathFind.cs
+++ b/TLM/TLM/Custom/PathFinding/CustomPathFind.cs
@@ -217,6 +217,14 @@ namespace TrafficManager.Custom.PathFinding {
             }
         }
 
+        /// <summary>
+        /// Used internally to overwrite pathUnits array reference
+        /// </summary>
+        /// <param name="pathUnits"></param>
+        internal void SetPathUnits(Array32<PathUnit> pathUnits) {
+            pathUnits_ = pathUnits;
+        }
+
         public new bool CalculatePath(uint unit, bool skipQueue) {
             return ExtCalculatePath(unit, skipQueue);
         }

--- a/TLM/TLM/Custom/PathFinding/CustomPathFind.cs
+++ b/TLM/TLM/Custom/PathFinding/CustomPathFind.cs
@@ -199,6 +199,7 @@ namespace TrafficManager.Custom.PathFinding {
         }
 
         private void OnDestroy() {
+            Log.Info("Destroing CustomPathFind");
             lock (queueLock_) {
                 terminated_ = true;
                 Monitor.PulseAll(queueLock_);

--- a/TLM/TLM/Custom/PathFinding/CustomPathManager.cs
+++ b/TLM/TLM/Custom/PathFinding/CustomPathManager.cs
@@ -74,6 +74,37 @@ namespace TrafficManager.Custom.PathFinding {
             }
         }
 
+        /// <summary>
+        /// Either initializes the custom pathfinding or destroys already created and instantiates it again
+        /// The main use of this method is when other mods need to patch TM:PE pathfinding in some way
+        /// and ensure that the mod will use patched methods, and process of patching might be dependant on order of loading mods
+        /// </summary>
+        [UsedImplicitly]
+        public static void Reinitialize() {
+            try {
+                Log.Info("CustomPathManager.Reinitialize() called.");
+                var pathManager = PathManager.instance.gameObject.GetComponent<CustomPathManager>();
+                if (!pathManager) {
+                    Log.Info("CustomPathManager.Reinitialize() CustomPathManager not found, creating new instance.");
+                    PathManager.instance.gameObject.AddComponent<CustomPathManager>();
+                } else {
+                    Log.Warning("CustomPathManager.Reinitialize() CustomPathManager found, destroying old instance.");
+                    DestroyImmediate(pathManager);
+                    Log.Info("CustomPathManager.Reinitialize() Creating new instance...");
+                    PathManager.instance.gameObject.AddComponent<CustomPathManager>();
+                    Log.Info("CustomPathManager.Reinitialize() Reinitialization finished.");
+                }
+            } catch (Exception ex) {
+                string error =
+                    "Traffic Manager: President Edition failed to reinitialize custom pathfinding.\n" +
+                    "Traffic Manager will not work as expected.";
+                Log.Error(error);
+                Log.Error($"Path manager reinitialization error: {ex}");
+                UIView.library.ShowModal<ExceptionPanel>("ExceptionPanel")
+                      .SetMessage("TM:PE failed to load", error, true);
+            }
+        }
+
         [UsedImplicitly]
         protected override void Awake() {
             // On waking up, replace the stock pathfinders with the custom one
@@ -85,7 +116,8 @@ namespace TrafficManager.Custom.PathFinding {
 
             stockPathManager_ = PathManager.instance
                                 ?? throw new Exception("stockPathManager is null");
-            Log._Debug($"Got stock PathManager instance {stockPathManager_?.GetName()}");
+            Log._Debug($"Got stock PathManager instance: {stockPathManager_?.GetType().FullName}");
+
             PathManagerInstance.SetValue(null, this);
             Log._Debug("Should be custom: " + PathManager.instance.GetType());
 
@@ -117,7 +149,7 @@ namespace TrafficManager.Custom.PathFinding {
                                          : SystemInfo.processorCount - 4;
             simSleepMultiplier_ = CalculateBestSimSleepMultiplier(numCustomPathFinds);
 
-            Log._Debug("Creating " + numCustomPathFinds + " custom PathFind objects.");
+            Log._Debug("Creating " + numCustomPathFinds + " custom PathFind objects. Number of stock Pathfinds " +numOfStockPathFinds);
             _replacementPathFinds = new CustomPathFind[numCustomPathFinds];
             FieldInfo f_pathfinds = typeof(PathManager).GetField(
                                         "m_pathfinds",
@@ -132,12 +164,13 @@ namespace TrafficManager.Custom.PathFinding {
 
                 f_pathfinds?.SetValue(this, _replacementPathFinds);
 
+                Log._Debug("Destroying " + numOfStockPathFinds + " PathFind objects.");
                 for (int i = 0; i < numOfStockPathFinds; i++) {
-                    Log._Debug($"PF {i}: {stockPathFinds[i].m_queuedPathFindCount} queued path-finds");
+                    Log._Debug($"PF {i}: {stockPathFinds[i].m_queuedPathFindCount} queued path-finds. PF: {stockPathFinds[i]?.GetType().FullName ?? "<null>"} active: ({(bool)stockPathFinds[i]})");
 
                     // would cause deadlock since we have a lock on m_bufferLock
                     // stockPathFinds[i].WaitForAllPaths();
-                    Destroy(stockPathFinds[i]);
+                    DestroyImmediate(stockPathFinds[i]);
                 }
             }
         }
@@ -149,30 +182,29 @@ namespace TrafficManager.Custom.PathFinding {
 
             int n = _replacementPathFinds.Length;
 
-            Log._Debug("Creating " + n + " stock PathFind objects.");
-            PathFind[] stockPathFinds = new PathFind[n];
-
-            FieldInfo f_pathfinds = typeof(PathManager).GetField(
-                                        "m_pathfinds",
-                                        BindingFlags.NonPublic | BindingFlags.Instance)
-                                    ?? throw new Exception("f_pathFinds is null");
-
             // both stock and custom PathMangers use the same lock object
             lock (m_bufferLock) {
+                Log._Debug("Destroying " + n + " PathFind objects.");
                 for (int i = 0; i < n; i++) {
-                    Log._Debug($"PF {i}: {_replacementPathFinds[i].m_queuedPathFindCount} queued path-finds");
+                    Log._Debug($"PF {i}: {_replacementPathFinds[i].m_queuedPathFindCount} queued path-finds.  PF: {_replacementPathFinds[i]?.GetType().FullName ?? "<null>"} active: ({(bool)_replacementPathFinds[i]})");
 
                     // would cause deadlock since we have a lock on m_bufferLock
                     // customPathFinds[i].WaitForAllPaths();
-                    Destroy(_replacementPathFinds[i]);
+                    DestroyImmediate(_replacementPathFinds[i]);
                 }
 
                 // revert to vanilla number of threads
                 n = Mathf.Clamp(SystemInfo.processorCount / 2, 1, 4);
+                Log._Debug("Creating " + n + " stock PathFind objects.");
+                PathFind[] stockPathFinds = new PathFind[n];
                 for (int i = 0; i < n; i++) {
                     stockPathFinds[i] = gameObject.AddComponent<PathFind>();
                 }
 
+                FieldInfo f_pathfinds = typeof(PathManager).GetField(
+                                            "m_pathfinds",
+                                            BindingFlags.NonPublic | BindingFlags.Instance)
+                                        ?? throw new Exception("f_pathFinds is null");
                 f_pathfinds?.SetValue(stockPathManager, stockPathFinds);
             }
         }
@@ -463,7 +495,7 @@ namespace TrafficManager.Custom.PathFinding {
             Patcher.Uninstall(API.Harmony.HARMONY_ID_PATHFINDING);
 
             PathManagerInstance.SetValue(null, stockPathManager_);
-            Log._Debug("Should be stock: " + PathManager.instance.GetType());
+            Log.Info("Should be stock: " + PathManager.instance.GetType().FullName);
 
             UpdateOldPathManagerValues(stockPathManager_);
             var simManagers = GetSimulationManagers();
@@ -473,6 +505,7 @@ namespace TrafficManager.Custom.PathFinding {
             simManagers.Add(stockPathManager_);
             terminated_ = true;
             _instance = null;
+            Log._Debug("CustomPathManager: Destroyed");
         }
     }
 }

--- a/TLM/TLM/Lifecycle/Patcher.cs
+++ b/TLM/TLM/Lifecycle/Patcher.cs
@@ -26,6 +26,7 @@ namespace TrafficManager.Lifecycle {
             " - make sure harmony mod is deleted from the content folder\n" +
             " - resubscribe to harmony mod.\n" +
             " - run the game again.";
+        private static bool pathfindingPatchesInstalled;
 
         internal static void AssertCitiesHarmonyInstalled() {
             if (!HarmonyHelper.IsHarmonyInstalled) {
@@ -70,6 +71,7 @@ namespace TrafficManager.Lifecycle {
                     "continue playing but it's NOT recommended. Traffic Manager will " +
                     "not work as expected.");
             } else {
+                pathfindingPatchesInstalled = true;
                 Log.Info("TMPE Path-finding patches installed successfully");
             }
         }
@@ -136,6 +138,9 @@ namespace TrafficManager.Lifecycle {
         public static void Uninstall(string harmonyId) {
             try {
                 new Harmony(harmonyId).UnpatchAll(harmonyId);
+                if (harmonyId.Equals(API.Harmony.HARMONY_ID_PATHFINDING)) {
+                    pathfindingPatchesInstalled = false;
+                }
                 Log.Info($"TMPE patches in [{harmonyId}] uninstalled.");
             } catch(Exception ex) {
                 ex.LogException(true);


### PR DESCRIPTION
- implement `CustomPathManager` reinitialization,
- improve pathfind lifecycle logging

Build [zip](https://ci.appveyor.com/api/projects/krzychu124/tmpe/artifacts/TMPE.zip?branch=bugfix/reinitialize-pathmanager-compatibility)