### PR TITLE
Improve segment end state detection and calculation accuracy in the leaving the segment decision making

### DIFF
--- a/TLM/TLM/Manager/Impl/VehicleBehaviorManager.cs
+++ b/TLM/TLM/Manager/Impl/VehicleBehaviorManager.cs
@@ -1197,7 +1197,10 @@ namespace TrafficManager.Manager.Impl {
                     return VehicleJunctionTransitState.Blocked;
                 }
 
-                return VehicleJunctionTransitState.Leave;
+                // allow for re-checking if vehicle still has priority (might be expensive)
+                if (SavedGameOptions.Instance.simulationAccuracy < SimulationAccuracy.VeryHigh) {
+                    return VehicleJunctionTransitState.Leave;
+                }
             }
 
             uint currentFrameIndex = Singleton<SimulationManager>.instance.m_currentFrameIndex;

--- a/TLM/TLM/Manager/Impl/VehicleBehaviorManager.cs
+++ b/TLM/TLM/Manager/Impl/VehicleBehaviorManager.cs
@@ -1609,8 +1609,7 @@ namespace TrafficManager.Manager.Impl {
                         }
 
                         if (sqrVelocity <= GlobalConfig.Instance.PriorityRules.MaxYieldVelocity
-                            * GlobalConfig.Instance.PriorityRules.MaxYieldVelocity ||
-                            SavedGameOptions.Instance.simulationAccuracy >= SimulationAccuracy.Medium) {
+                            * GlobalConfig.Instance.PriorityRules.MaxYieldVelocity) {
                             if (logPriority) {
                                 Log._DebugFormat(
                                     "VehicleBehaviorManager.MayChangeSegment({0}): {1} sign. waittime={2}",


### PR DESCRIPTION
Resolves #1229 by invalidating the feature request (no longer needed)

- solves the problem with detecting traffic light state when vehicle is approaching short segments with traffic lights
- solves the problem with very inaccurate priority detection when vehicle is approaching short segments (own or adjacent)
- applies only at **Very High** _Simulation Accuracy_ setting, since it may affect performance

Build [ZIP](https://ci.appveyor.com/api/projects/krzychu124/tmpe/artifacts/TMPE.zip?branch=bugfix/improve-segment-end-decision-accuracy)