### PR TITLE
Eliminate memory pressure/garbage generation in sim performance critical path

### DIFF
--- a/TLM/CSUtil.Commons/Log.cs
+++ b/TLM/CSUtil.Commons/Log.cs
@@ -26,7 +26,7 @@ namespace CSUtil.Commons {
     ///     Log.DebugFormat is optimized away, others are not, so is a good idea to wrap in if (boolValue)
     ///     ⚠ Expensive if not wrapped in a if () condition
     ///
-    /// Log.DebugIf, Log.WarningIf, ... - these first check a condition, and then call a lambda,
+    /// Log.DebugIf -- first check a condition, and then call a lambda,
     /// which provides a formatted string.
     ///     ✔ Lambda building is just as cheap as format args building
     ///     💲 The cost incurred: each captured value (pointer) is copied into lambda

--- a/TLM/CSUtil.Commons/Log.cs
+++ b/TLM/CSUtil.Commons/Log.cs
@@ -154,31 +154,12 @@ namespace CSUtil.Commons {
             LogToFile(string.Format(format, args), LogLevel.Warning);
         }
 
-        /// <summary>
-        /// Log a warning only if cond is true
-        /// NOTE: If a lambda contains values from `out` and `ref` scope args,
-        /// then you can not use a lambda, instead use `if (cond) { Log.Warning() }`
-        /// </summary>
-        /// <param name="cond">The condition</param>
-        /// <param name="formatFn">The function which returns text to log</param>
-        public static void WarningIf(bool cond, Func<string> formatFn) {
-            if (cond) {
-                LogToFile(formatFn(), LogLevel.Warning);
-            }
-        }
-
         public static void Error(string s) {
             LogToFile(s, LogLevel.Error);
         }
 
         public static void ErrorFormat(string format, params object[] args) {
             LogToFile(string.Format(format, args), LogLevel.Error);
-        }
-
-        public static void ErrorIf(bool cond, Func<string> formatFn) {
-            if (cond) {
-                LogToFile(formatFn(), LogLevel.Error);
-            }
         }
 
         /// <summary>Log error only in debug mode.</summary>

--- a/TLM/TLM/Manager/Impl/ParkingRestrictionsManager.cs
+++ b/TLM/TLM/Manager/Impl/ParkingRestrictionsManager.cs
@@ -94,8 +94,9 @@ namespace TrafficManager.Manager.Impl {
 
             if (!flag || !parkingAllowed[segmentId][1 - dirIndex]) {
                 // force relocation of illegally parked vehicles
+                ushort tempSegmentId = segmentId;
                 Singleton<SimulationManager>.instance.AddAction(
-                    () => segmentId.ToSegment().UpdateSegment(segmentId));
+                    () => tempSegmentId.ToSegment().UpdateSegment(tempSegmentId));
             }
             Notifier.Instance.OnSegmentModified(segmentId, this);
             return true;

--- a/TLM/TLM/Manager/Impl/TrafficPriorityManager.cs
+++ b/TLM/TLM/Manager/Impl/TrafficPriorityManager.cs
@@ -425,9 +425,10 @@ namespace TrafficManager.Manager.Impl {
             }
 
             if ((vehicle.m_flags & Vehicle.Flags.Spawned) == 0) {
-                Log.WarningIf(
-                    logPriority,
-                    () => $"TrafficPriorityManager.HasPriority({vehicleId}): Vehicle is not spawned.");
+                if (logPriority) {
+                    ushort vehicleIdCopy = vehicleId;
+                    Log.Warning($"TrafficPriorityManager.HasPriority({vehicleIdCopy}): Vehicle is not spawned.");
+                }
                 return true;
             }
 
@@ -636,10 +637,10 @@ namespace TrafficManager.Manager.Impl {
             }
 
             if ((incomingState.flags & ExtVehicleFlags.Spawned) == ExtVehicleFlags.None) {
-                Log.WarningIf(
-                    logPriority,
-                    () => $"TrafficPriorityManager.IsConflictingVehicle({vehicleId}, " +
-                    $"{incomingVehicleId}): Incoming vehicle is not spawned.");
+                if (logPriority) {
+                    Log.Warning($"TrafficPriorityManager.IsConflictingVehicle({vehicleId}, " +
+                              $"{incomingVehicleId}): Incoming vehicle is not spawned.");
+                }
                 return false;
             }
 
@@ -1204,12 +1205,12 @@ namespace TrafficManager.Manager.Impl {
                                 default: // (should not happen)
                                 {
                                     wouldCollide = false;
-                                    Log.WarningIf(
-                                        logPriority,
-                                        () => $"  TrafficPriorityManager.DetectCollision({vehicleId}, " +
-                                        $"{incomingVehicleId}): Target is going {targetToDir} and " +
-                                        $"incoming is coming from {incomingFromDir} (SHOULD NOT HAPPEN). " +
-                                        $"would collide? {wouldCollide}");
+                                    if (logPriority) {
+                                        Log.Warning($"  TrafficPriorityManager.DetectCollision({vehicleId}, " +
+                                                    $"{incomingVehicleId}): Target is going {targetToDir} and " +
+                                                    $"incoming is coming from {incomingFromDir} (SHOULD NOT HAPPEN). " +
+                                                    $"would collide? {wouldCollide}");
+                                    }
                                     break;
                                 }
                             }

--- a/TLM/TLM/Notifier.cs
+++ b/TLM/TLM/Notifier.cs
@@ -16,35 +16,45 @@ namespace TrafficManager
 
         public void OnLevelLoaded() => EventLevelLoaded?.Invoke();
 
-        public void OnModified(OnModifiedEventArgs args)
+        private void OnModified(OnModifiedEventArgs args)
         {
             SimulationManager.instance.AddAction(() =>
                 EventModified?.Invoke(args));
         }
 
         public void OnSegmentModified(ushort segmentId, object sender = null, object data = null) {
-            OnModified(new OnModifiedEventArgs {
-                InstanceID = new InstanceID { NetSegment = segmentId },
-                Sender = sender,
-                Data = data,
-            });
+            // skip if no listeners
+            if (EventModified != null) {
+                OnModified(
+                    new OnModifiedEventArgs {
+                        InstanceID = new InstanceID { NetSegment = segmentId },
+                        Sender = sender,
+                        Data = data,
+                    });
+            }
         }
 
         public void OnNodeModified(ushort nodeId, object sender = null, object data = null)
         {
-            OnModified(new OnModifiedEventArgs
-            {
-                InstanceID = new InstanceID { NetNode = nodeId },
-                Sender = sender,
-                Data = data,
-            });
+            // skip if no listeners
+            if (EventModified != null) {
+                OnModified(
+                    new OnModifiedEventArgs {
+                        InstanceID = new InstanceID { NetNode = nodeId },
+                        Sender = sender,
+                        Data = data,
+                    });
+            }
         }
 
         public void OnSegmentNodesModified(ushort segmentId, object sender = null, object data = null)
         {
-            ref NetSegment netSegment = ref segmentId.ToSegment();
-            OnNodeModified(netSegment.m_startNode, sender, data);
-            OnNodeModified(netSegment.m_endNode, sender, data);
+            // skip if no listeners
+            if (EventModified != null) {
+                ref NetSegment netSegment = ref segmentId.ToSegment();
+                OnNodeModified(netSegment.m_startNode, sender, data);
+                OnNodeModified(netSegment.m_endNode, sender, data);
+            }
         }
     }
 }

--- a/TLM/TLM/Patch/_VehicleAI/UpdatePathTargetPositionsPatch.cs
+++ b/TLM/TLM/Patch/_VehicleAI/UpdatePathTargetPositionsPatch.cs
@@ -198,11 +198,12 @@ namespace TrafficManager.Patch._VehicleAI {
                                         Mathf.CeilToInt(distDiff * 256f / (curLaneId.ToLane().m_length + 1f)));
                                 }
 
-                                Log._DebugIf(
-                                    logLogic,
-                                    () => $"CustomVehicle.CustomUpdatePathTargetPositions({vehicleID}): " +
-                                    $"Calculated pathOffsetDelta={pathOffsetDelta}. distDiff={distDiff}, " +
-                                    $"targetPos={targetPos}, refPos={refPos}");
+                                if (logLogic) {
+                                    Log._Debug(
+                                            $"CustomVehicle.CustomUpdatePathTargetPositions({vehicleID}): " +
+                                            $"Calculated pathOffsetDelta={pathOffsetDelta}. distDiff={distDiff}, " +
+                                            $"targetPos={targetPos}, refPos={refPos}");
+                                }
 
                                 if (pathOffset > currentPosition.m_offset) {
                                     pathOffset = (byte)Mathf.Max(
@@ -719,10 +720,10 @@ namespace TrafficManager.Patch._VehicleAI {
                 // calculate next segment offset
                 byte nextSegOffset;
                 if ((vehicleData.m_flags & Vehicle.Flags.Flying) != 0) {
-                    Log._DebugIf(
-                        logLogic,
-                        () => $"CustomVehicle.CustomUpdatePathTargetPositions({vehicleID}): " +
-                        "Vehicle is flying");
+                    if (logLogic) {
+                        Log._Debug($"CustomVehicle.CustomUpdatePathTargetPositions({vehicleID}): " +
+                                  "Vehicle is flying");
+                    }
                     nextSegOffset = (byte)((nextPosition.m_offset < 128) ? 255 : 0);
                 } else if (curLaneId != nextLaneId &&
                            laneInfo.m_laneType != NetInfo.LaneType.CargoVehicle) {
@@ -750,13 +751,13 @@ namespace TrafficManager.Patch._VehicleAI {
                         }
                     }
 
-                    Log._DebugIf(
-                        logLogic,
-                        () => $"CustomVehicle.CustomUpdatePathTargetPositions({vehicleID}): " +
-                        "Calculated current segment position for regular vehicle. " +
-                        $"nextSegOffset={nextSegOffset}, bezier.a={bezier.a}, " +
-                        $"curSegDir={curSegDir}, maxSpeed={maxSpeed}, pathOffset={pathOffset}, " +
-                        $"calculateNextNextPos={calculateNextNextPos}");
+                    if (logLogic) {
+                        Log._Debug($"CustomVehicle.CustomUpdatePathTargetPositions({vehicleID}): " +
+                                  "Calculated current segment position for regular vehicle. " +
+                                  $"nextSegOffset={nextSegOffset}, bezier.a={bezier.a}, " +
+                                  $"curSegDir={curSegDir}, maxSpeed={maxSpeed}, pathOffset={pathOffset}, " +
+                                  $"calculateNextNextPos={calculateNextNextPos}");
+                    }
 
                     Vector3 nextSegDir;
                     float curMaxSpeed;
@@ -809,15 +810,15 @@ namespace TrafficManager.Patch._VehicleAI {
                             out nextSegDir,
                             out curMaxSpeed);
 
-                        Log._DebugIf(
-                            logLogic,
-                            () => $"CustomVehicle.CustomUpdatePathTargetPositions({vehicleID}): " +
-                            "Next next path position needs not to be calculated. Used regular " +
-                            $"calculation. IN: nextPosition=[seg={nextPosition.m_segment}, " +
-                            $"lane={nextPosition.m_lane}, off={nextPosition.m_offset}], " +
-                            $"nextLaneId={nextLaneId}, nextSegOffset={nextSegOffset}, " +
-                            $"OUT: bezier.d={bezier.d}, nextSegDir={nextSegDir}, " +
-                            $"curMaxSpeed={curMaxSpeed}");
+                        if (logLogic) {
+                            Log._Debug($"CustomVehicle.CustomUpdatePathTargetPositions({vehicleID}): " +
+                                       "Next next path position needs not to be calculated. Used regular " +
+                                       $"calculation. IN: nextPosition=[seg={nextPosition.m_segment}, " +
+                                       $"lane={nextPosition.m_lane}, off={nextPosition.m_offset}], " +
+                                       $"nextLaneId={nextLaneId}, nextSegOffset={nextSegOffset}, " +
+                                       $"OUT: bezier.d={bezier.d}, nextSegDir={nextSegDir}, " +
+                                       $"curMaxSpeed={curMaxSpeed}");
+                        }
                     }
 
                     if (curMaxSpeed < 0.01f
@@ -850,20 +851,21 @@ namespace TrafficManager.Patch._VehicleAI {
 
                     if (currentPosition.m_offset == 0) {
                         curSegDir = -curSegDir;
-                        Log._DebugIf(
-                            logLogic,
-                            () => $"CustomVehicle.CustomUpdatePathTargetPositions({vehicleID}): " +
-                            $"currentPosition.m_offset == 0: inverted curSegDir={curSegDir}");
+                        if (logLogic) {
+                            Log._Debug(
+                                $"CustomVehicle.CustomUpdatePathTargetPositions({vehicleID}): " +
+                                $"currentPosition.m_offset == 0: inverted curSegDir={curSegDir}");
+                        }
                     }
 
                     if (nextSegOffset < nextPosition.m_offset) {
                         nextSegDir = -nextSegDir;
-                        Log._DebugIf(
-                            logLogic,
-                            () => $"CustomVehicle.CustomUpdatePathTargetPositions({vehicleID}): " +
-                            $"nextSegOffset={nextSegOffset} < " +
-                            $"nextPosition.m_offset={nextPosition.m_offset}: inverted " +
-                            $"nextSegDir={nextSegDir}");
+                        if (logLogic) {
+                            Log._Debug($"CustomVehicle.CustomUpdatePathTargetPositions({vehicleID}): " +
+                                       $"nextSegOffset={nextSegOffset} < " +
+                                       $"nextPosition.m_offset={nextPosition.m_offset}: inverted " +
+                                       $"nextSegDir={nextSegDir}");
+                        }
                     }
 
                     curSegDir.Normalize();
@@ -925,11 +927,11 @@ namespace TrafficManager.Patch._VehicleAI {
                             curMaxSpeed,
                             CalculateTargetSpeed(__instance, vehicleID, ref vehicleData, 1000f, curve));
 
-                        Log._DebugIf(
-                            logLogic,
-                            () => $"CustomVehicle.CustomUpdatePathTargetPositions({vehicleID}): " +
-                            $"dist > 1f. nextNodeId={nextNodeId}, curve={curve}, " +
-                            $"curMaxSpeed={curMaxSpeed}, pathOffset={pathOffset}");
+                        if (logLogic) {
+                            Log._Debug($"CustomVehicle.CustomUpdatePathTargetPositions({vehicleID}): " +
+                                       $"dist > 1f. nextNodeId={nextNodeId}, curve={curve}, " +
+                                       $"curMaxSpeed={curMaxSpeed}, pathOffset={pathOffset}");
+                        }
 
                         // update node target positions
                         while (pathOffset < 255) {
@@ -941,12 +943,12 @@ namespace TrafficManager.Patch._VehicleAI {
                                 pathOffsetDelta = 8 + Mathf.Max(0, Mathf.CeilToInt(distDiff * 256f / (dist + 1f)));
                             }
 
-                            Log._DebugIf(
-                                logLogic,
-                                () => $"CustomVehicle.CustomUpdatePathTargetPositions({vehicleID}): " +
-                                "Preparing to update node target positions (1). " +
-                                $"pathOffset={pathOffset}, distDiff={distDiff}, " +
-                                $"pathOffsetDelta={pathOffsetDelta}");
+                            if (logLogic) {
+                                Log._Debug($"CustomVehicle.CustomUpdatePathTargetPositions({vehicleID}): " +
+                                           "Preparing to update node target positions (1). " +
+                                           $"pathOffset={pathOffset}, distDiff={distDiff}, " +
+                                           $"pathOffsetDelta={pathOffsetDelta}");
+                            }
 
                             byte previousPathOffset = pathOffset;
                             byte stopOffset;
@@ -977,21 +979,23 @@ namespace TrafficManager.Patch._VehicleAI {
                                 Mathf.Min(targetPos.w, curMaxSpeed));
                             float sqrMagnitude2 = (bezierPos - refPos).sqrMagnitude;
 
-                            Log._DebugIf(
-                                logLogic,
-                                () => $"CustomVehicle.CustomUpdatePathTargetPositions({vehicleID}): " +
-                                "Preparing to update node target positions (2). " +
-                                $"pathOffset={pathOffset}, bezierPos={bezierPos}, " +
-                                $"targetPos={targetPos}, sqrMagnitude2={sqrMagnitude2}");
+                            if (logLogic) {
+                                Log._Debug(
+                                    $"CustomVehicle.CustomUpdatePathTargetPositions({vehicleID}): " +
+                                    "Preparing to update node target positions (2). " +
+                                    $"pathOffset={pathOffset}, bezierPos={bezierPos}, " +
+                                    $"targetPos={targetPos}, sqrMagnitude2={sqrMagnitude2}");
+                            }
 
                             if (!(sqrMagnitude2 >= minSqrDistA) && !needStopAtNode) {
                                 continue;
                             }
 
-                            Log._DebugIf(
-                                logLogic,
-                                () => $"CustomVehicle.CustomUpdatePathTargetPositions({vehicleID}): " +
-                                $"sqrMagnitude2={sqrMagnitude2} >= minSqrDistA={minSqrDistA} and no need to stop at node");
+                            if (logLogic) {
+                                Log._Debug(
+                                    $"CustomVehicle.CustomUpdatePathTargetPositions({vehicleID}): " +
+                                    $"sqrMagnitude2={sqrMagnitude2} >= minSqrDistA={minSqrDistA} and no need to stop at node");
+                            }
 
                             if (index <= 0) {
                                 vehicleData.m_lastPathOffset = pathOffset;
@@ -1037,30 +1041,34 @@ namespace TrafficManager.Patch._VehicleAI {
                             minSqrDistA = minSqrDistanceB;
                             refPos = targetPos;
                             targetPos.w = 1000f;
-                            Log._DebugIf(
-                                logLogic,
-                                () => $"CustomVehicle.CustomUpdatePathTargetPositions({vehicleID}): " +
-                                $"After updating node target positions. minSqrDistA={minSqrDistA}, " +
-                                $"refPos={refPos}");
+
+                            if (logLogic) {
+                                Log._Debug(
+                                    $"CustomVehicle.CustomUpdatePathTargetPositions({vehicleID}): " +
+                                    $"After updating node target positions. minSqrDistA={minSqrDistA}, " +
+                                    $"refPos={refPos}");
+                            }
 
                             if (index == max) {
-                                Log._DebugIf(
-                                    logLogic,
-                                    () => $"CustomVehicle.CustomUpdatePathTargetPositions({vehicleID}): " +
-                                    $"index == max ({max}). " +
-                                    "FINISH.");
+                                if (logLogic) {
+                                    Log._Debug(
+                                        $"CustomVehicle.CustomUpdatePathTargetPositions({vehicleID}): " +
+                                        $"index == max ({max}). " +
+                                        "FINISH.");
+                                }
                                 return false;
                             }
                         }
                     }
                 } else {
                     PathUnit.CalculatePathPositionOffset(nextLaneId, targetPos, out nextSegOffset);
-                    Log._DebugIf(
-                        logLogic,
-                        () => $"CustomVehicle.CustomUpdatePathTargetPositions({vehicleID}): " +
-                        $"Same lane or cargo lane. curLaneId={curLaneId}, nextLaneId={nextLaneId}, " +
-                        $"laneInfo.m_laneType={laneInfo.m_laneType}, targetPos={targetPos}, " +
-                        $"nextSegOffset={nextSegOffset}");
+                    if (logLogic) {
+                        Log._Debug(
+                            $"CustomVehicle.CustomUpdatePathTargetPositions({vehicleID}): " +
+                            $"Same lane or cargo lane. curLaneId={curLaneId}, nextLaneId={nextLaneId}, " +
+                            $"laneInfo.m_laneType={laneInfo.m_laneType}, targetPos={targetPos}, " +
+                            $"nextSegOffset={nextSegOffset}");
+                    }
                 }
 
                 // check for arrival
@@ -1146,12 +1154,13 @@ namespace TrafficManager.Patch._VehicleAI {
                 laneInfo = nextLaneInfo;
                 firstIter = false; // NON-STOCK CODE
 
-                Log._DebugIf(
-                    logLogic,
-                    () => $"CustomVehicle.CustomUpdatePathTargetPositions({vehicleID}): " +
-                    "Prepared next main loop iteration. currentPosition" +
-                    $"=[seg={currentPosition.m_segment}, lane={currentPosition.m_lane}, " +
-                    $"off={currentPosition.m_offset}], curLaneId={curLaneId}");
+                if (logLogic) {
+                    Log._Debug(
+                        $"CustomVehicle.CustomUpdatePathTargetPositions({vehicleID}): " +
+                        "Prepared next main loop iteration. currentPosition" +
+                        $"=[seg={currentPosition.m_segment}, lane={currentPosition.m_lane}, " +
+                        $"off={currentPosition.m_offset}], curLaneId={curLaneId}");
+                }
             } // end while true
 
             // Unreachable

--- a/TLM/TLM/Patch/_VehicleAI/UpdatePathTargetPositionsPatch.cs
+++ b/TLM/TLM/Patch/_VehicleAI/UpdatePathTargetPositionsPatch.cs
@@ -899,13 +899,7 @@ namespace TrafficManager.Patch._VehicleAI {
                     // STOCK CODE END
 
                     if (debugOverlay) {
-                        Segment3 arrow1 = new(bezier.a, bezier.a + curSegDir);
-                        Segment3 arrow2 = new(bezier.d, bezier.d + nextSegDir);
-                        DebugOverlay.Actions[0] = () => bezier.RenderDebugOverlay(Color.yellow);
-                        Color color = Color.cyan;
-                        Color color2 = Color.Lerp(color, Color.black, 0.2f);
-                        DebugOverlay.Actions[1] = () => arrow1.RenderDebugArrowOverlay(color);
-                        DebugOverlay.Actions[2] = () => arrow2.RenderDebugArrowOverlay(color2);
+                        DebugArrowOverlay(bezier, curSegDir, nextSegDir);
                     }
 
                     if (dist > 1f) {
@@ -1164,6 +1158,16 @@ namespace TrafficManager.Patch._VehicleAI {
             } // end while true
 
             // Unreachable
+        }
+
+        private static void DebugArrowOverlay(Bezier3 bezier, Vector3 curSegDir, Vector3 nextSegDir) {
+            Segment3 arrow1 = new(bezier.a, bezier.a + curSegDir);
+            Segment3 arrow2 = new(bezier.d, bezier.d + nextSegDir);
+            DebugOverlay.Actions[0] = () => bezier.RenderDebugOverlay(Color.yellow);
+            Color color = Color.cyan;
+            Color color2 = Color.Lerp(color, Color.black, 0.2f);
+            DebugOverlay.Actions[1] = () => arrow1.RenderDebugArrowOverlay(color);
+            DebugOverlay.Actions[2] = () => arrow2.RenderDebugArrowOverlay(color2);
         }
     }
 }

--- a/TLM/TLM/Patch/_VehicleAI/UpdatePathTargetPositionsPatch.cs
+++ b/TLM/TLM/Patch/_VehicleAI/UpdatePathTargetPositionsPatch.cs
@@ -198,12 +198,12 @@ namespace TrafficManager.Patch._VehicleAI {
                                         Mathf.CeilToInt(distDiff * 256f / (curLaneId.ToLane().m_length + 1f)));
                                 }
 
-                                if (logLogic) {
-                                    Log._Debug(
-                                            $"CustomVehicle.CustomUpdatePathTargetPositions({vehicleID}): " +
-                                            $"Calculated pathOffsetDelta={pathOffsetDelta}. distDiff={distDiff}, " +
-                                            $"targetPos={targetPos}, refPos={refPos}");
-                                }
+                                Log._DebugIf(
+                                    logLogic,
+                                    () =>
+                                        $"CustomVehicle.CustomUpdatePathTargetPositions({vehicleID}): " +
+                                        $"Calculated pathOffsetDelta={pathOffsetDelta}. distDiff={distDiff}, " +
+                                        $"targetPos={targetPos}, refPos={refPos}");
 
                                 if (pathOffset > currentPosition.m_offset) {
                                     pathOffset = (byte)Mathf.Max(
@@ -720,10 +720,7 @@ namespace TrafficManager.Patch._VehicleAI {
                 // calculate next segment offset
                 byte nextSegOffset;
                 if ((vehicleData.m_flags & Vehicle.Flags.Flying) != 0) {
-                    if (logLogic) {
-                        Log._Debug($"CustomVehicle.CustomUpdatePathTargetPositions({vehicleID}): " +
-                                  "Vehicle is flying");
-                    }
+                    Log._DebugIf(logLogic, () => $"CustomVehicle.CustomUpdatePathTargetPositions({vehicleID}): Vehicle is flying");
                     nextSegOffset = (byte)((nextPosition.m_offset < 128) ? 255 : 0);
                 } else if (curLaneId != nextLaneId &&
                            laneInfo.m_laneType != NetInfo.LaneType.CargoVehicle) {
@@ -751,13 +748,13 @@ namespace TrafficManager.Patch._VehicleAI {
                         }
                     }
 
-                    if (logLogic) {
-                        Log._Debug($"CustomVehicle.CustomUpdatePathTargetPositions({vehicleID}): " +
-                                  "Calculated current segment position for regular vehicle. " +
-                                  $"nextSegOffset={nextSegOffset}, bezier.a={bezier.a}, " +
-                                  $"curSegDir={curSegDir}, maxSpeed={maxSpeed}, pathOffset={pathOffset}, " +
-                                  $"calculateNextNextPos={calculateNextNextPos}");
-                    }
+                    Log._DebugIf(
+                        logLogic,
+                        () => $"CustomVehicle.CustomUpdatePathTargetPositions({vehicleID}): " +
+                              "Calculated current segment position for regular vehicle. " +
+                              $"nextSegOffset={nextSegOffset}, bezier.a={bezier.a}, " +
+                              $"curSegDir={curSegDir}, maxSpeed={maxSpeed}, pathOffset={pathOffset}, " +
+                              $"calculateNextNextPos={calculateNextNextPos}");
 
                     Vector3 nextSegDir;
                     float curMaxSpeed;
@@ -810,15 +807,15 @@ namespace TrafficManager.Patch._VehicleAI {
                             out nextSegDir,
                             out curMaxSpeed);
 
-                        if (logLogic) {
-                            Log._Debug($"CustomVehicle.CustomUpdatePathTargetPositions({vehicleID}): " +
-                                       "Next next path position needs not to be calculated. Used regular " +
-                                       $"calculation. IN: nextPosition=[seg={nextPosition.m_segment}, " +
-                                       $"lane={nextPosition.m_lane}, off={nextPosition.m_offset}], " +
-                                       $"nextLaneId={nextLaneId}, nextSegOffset={nextSegOffset}, " +
-                                       $"OUT: bezier.d={bezier.d}, nextSegDir={nextSegDir}, " +
-                                       $"curMaxSpeed={curMaxSpeed}");
-                        }
+                        Log._DebugIf(
+                            logLogic,
+                            () => $"CustomVehicle.CustomUpdatePathTargetPositions({vehicleID}): " +
+                                  "Next next path position needs not to be calculated. Used regular " +
+                                  $"calculation. IN: nextPosition=[seg={nextPosition.m_segment}, " +
+                                  $"lane={nextPosition.m_lane}, off={nextPosition.m_offset}], " +
+                                  $"nextLaneId={nextLaneId}, nextSegOffset={nextSegOffset}, " +
+                                  $"OUT: bezier.d={bezier.d}, nextSegDir={nextSegDir}, " +
+                                  $"curMaxSpeed={curMaxSpeed}");
                     }
 
                     if (curMaxSpeed < 0.01f
@@ -851,21 +848,21 @@ namespace TrafficManager.Patch._VehicleAI {
 
                     if (currentPosition.m_offset == 0) {
                         curSegDir = -curSegDir;
-                        if (logLogic) {
-                            Log._Debug(
+                        Log._DebugIf(
+                            logLogic,
+                            () =>
                                 $"CustomVehicle.CustomUpdatePathTargetPositions({vehicleID}): " +
                                 $"currentPosition.m_offset == 0: inverted curSegDir={curSegDir}");
-                        }
                     }
 
                     if (nextSegOffset < nextPosition.m_offset) {
                         nextSegDir = -nextSegDir;
-                        if (logLogic) {
-                            Log._Debug($"CustomVehicle.CustomUpdatePathTargetPositions({vehicleID}): " +
-                                       $"nextSegOffset={nextSegOffset} < " +
-                                       $"nextPosition.m_offset={nextPosition.m_offset}: inverted " +
-                                       $"nextSegDir={nextSegDir}");
-                        }
+                        Log._DebugIf(
+                            logLogic,
+                            () => $"CustomVehicle.CustomUpdatePathTargetPositions({vehicleID}): " +
+                                  $"nextSegOffset={nextSegOffset} < " +
+                                  $"nextPosition.m_offset={nextPosition.m_offset}: inverted " +
+                                  $"nextSegDir={nextSegDir}");
                     }
 
                     curSegDir.Normalize();
@@ -921,11 +918,11 @@ namespace TrafficManager.Patch._VehicleAI {
                             curMaxSpeed,
                             CalculateTargetSpeed(__instance, vehicleID, ref vehicleData, 1000f, curve));
 
-                        if (logLogic) {
-                            Log._Debug($"CustomVehicle.CustomUpdatePathTargetPositions({vehicleID}): " +
-                                       $"dist > 1f. nextNodeId={nextNodeId}, curve={curve}, " +
-                                       $"curMaxSpeed={curMaxSpeed}, pathOffset={pathOffset}");
-                        }
+                        Log._DebugIf(
+                            logLogic,
+                            () => $"CustomVehicle.CustomUpdatePathTargetPositions({vehicleID}): " +
+                                  $"dist > 1f. nextNodeId={nextNodeId}, curve={curve}, " +
+                                  $"curMaxSpeed={curMaxSpeed}, pathOffset={pathOffset}");
 
                         // update node target positions
                         while (pathOffset < 255) {
@@ -937,12 +934,13 @@ namespace TrafficManager.Patch._VehicleAI {
                                 pathOffsetDelta = 8 + Mathf.Max(0, Mathf.CeilToInt(distDiff * 256f / (dist + 1f)));
                             }
 
-                            if (logLogic) {
-                                Log._Debug($"CustomVehicle.CustomUpdatePathTargetPositions({vehicleID}): " +
-                                           "Preparing to update node target positions (1). " +
-                                           $"pathOffset={pathOffset}, distDiff={distDiff}, " +
-                                           $"pathOffsetDelta={pathOffsetDelta}");
-                            }
+                            Log._DebugIf(
+                                logLogic,
+                                () =>
+                                    $"CustomVehicle.CustomUpdatePathTargetPositions({vehicleID}): " +
+                                    "Preparing to update node target positions (1). " +
+                                    $"pathOffset={pathOffset}, distDiff={distDiff}, " +
+                                    $"pathOffsetDelta={pathOffsetDelta}");
 
                             byte previousPathOffset = pathOffset;
                             byte stopOffset;
@@ -973,23 +971,19 @@ namespace TrafficManager.Patch._VehicleAI {
                                 Mathf.Min(targetPos.w, curMaxSpeed));
                             float sqrMagnitude2 = (bezierPos - refPos).sqrMagnitude;
 
-                            if (logLogic) {
-                                Log._Debug(
-                                    $"CustomVehicle.CustomUpdatePathTargetPositions({vehicleID}): " +
-                                    "Preparing to update node target positions (2). " +
-                                    $"pathOffset={pathOffset}, bezierPos={bezierPos}, " +
-                                    $"targetPos={targetPos}, sqrMagnitude2={sqrMagnitude2}");
-                            }
+                            Log._Debug(
+                                $"CustomVehicle.CustomUpdatePathTargetPositions({vehicleID}): " +
+                                "Preparing to update node target positions (2). " +
+                                $"pathOffset={pathOffset}, bezierPos={bezierPos}, " +
+                                $"targetPos={targetPos}, sqrMagnitude2={sqrMagnitude2}");
 
                             if (!(sqrMagnitude2 >= minSqrDistA) && !needStopAtNode) {
                                 continue;
                             }
 
-                            if (logLogic) {
-                                Log._Debug(
-                                    $"CustomVehicle.CustomUpdatePathTargetPositions({vehicleID}): " +
-                                    $"sqrMagnitude2={sqrMagnitude2} >= minSqrDistA={minSqrDistA} and no need to stop at node");
-                            }
+                            Log._Debug(
+                                $"CustomVehicle.CustomUpdatePathTargetPositions({vehicleID}): " +
+                                $"sqrMagnitude2={sqrMagnitude2} >= minSqrDistA={minSqrDistA} and no need to stop at node");
 
                             if (index <= 0) {
                                 vehicleData.m_lastPathOffset = pathOffset;
@@ -1036,33 +1030,27 @@ namespace TrafficManager.Patch._VehicleAI {
                             refPos = targetPos;
                             targetPos.w = 1000f;
 
-                            if (logLogic) {
-                                Log._Debug(
-                                    $"CustomVehicle.CustomUpdatePathTargetPositions({vehicleID}): " +
-                                    $"After updating node target positions. minSqrDistA={minSqrDistA}, " +
-                                    $"refPos={refPos}");
-                            }
+                            Log._Debug(
+                                $"CustomVehicle.CustomUpdatePathTargetPositions({vehicleID}): " +
+                                $"After updating node target positions. minSqrDistA={minSqrDistA}, " +
+                                $"refPos={refPos}");
 
                             if (index == max) {
-                                if (logLogic) {
-                                    Log._Debug(
-                                        $"CustomVehicle.CustomUpdatePathTargetPositions({vehicleID}): " +
-                                        $"index == max ({max}). " +
-                                        "FINISH.");
-                                }
+                                Log._Debug(
+                                    $"CustomVehicle.CustomUpdatePathTargetPositions({vehicleID}): " +
+                                    $"index == max ({max}). " +
+                                    "FINISH.");
                                 return false;
                             }
                         }
                     }
                 } else {
                     PathUnit.CalculatePathPositionOffset(nextLaneId, targetPos, out nextSegOffset);
-                    if (logLogic) {
-                        Log._Debug(
-                            $"CustomVehicle.CustomUpdatePathTargetPositions({vehicleID}): " +
-                            $"Same lane or cargo lane. curLaneId={curLaneId}, nextLaneId={nextLaneId}, " +
-                            $"laneInfo.m_laneType={laneInfo.m_laneType}, targetPos={targetPos}, " +
-                            $"nextSegOffset={nextSegOffset}");
-                    }
+                    Log._Debug(
+                        $"CustomVehicle.CustomUpdatePathTargetPositions({vehicleID}): " +
+                        $"Same lane or cargo lane. curLaneId={curLaneId}, nextLaneId={nextLaneId}, " +
+                        $"laneInfo.m_laneType={laneInfo.m_laneType}, targetPos={targetPos}, " +
+                        $"nextSegOffset={nextSegOffset}");
                 }
 
                 // check for arrival
@@ -1148,13 +1136,11 @@ namespace TrafficManager.Patch._VehicleAI {
                 laneInfo = nextLaneInfo;
                 firstIter = false; // NON-STOCK CODE
 
-                if (logLogic) {
-                    Log._Debug(
-                        $"CustomVehicle.CustomUpdatePathTargetPositions({vehicleID}): " +
-                        "Prepared next main loop iteration. currentPosition" +
-                        $"=[seg={currentPosition.m_segment}, lane={currentPosition.m_lane}, " +
-                        $"off={currentPosition.m_offset}], curLaneId={curLaneId}");
-                }
+                Log._Debug(
+                    $"CustomVehicle.CustomUpdatePathTargetPositions({vehicleID}): " +
+                    "Prepared next main loop iteration. currentPosition" +
+                    $"=[seg={currentPosition.m_segment}, lane={currentPosition.m_lane}, " +
+                    $"off={currentPosition.m_offset}], curLaneId={curLaneId}");
             } // end while true
 
             // Unreachable

--- a/TLM/TLM/TrafficLight/Impl/TimedTrafficLights.cs
+++ b/TLM/TLM/TrafficLight/Impl/TimedTrafficLights.cs
@@ -1030,10 +1030,11 @@ namespace TrafficManager.TrafficLight.Impl {
                             $"{segmentId} to node {NodeId} without reusing old segment");
 
                         if (!step.AddSegment(segmentId, startNode, true)) {
-                            Log.WarningIf(
-                                logTrafficLights,
-                                () => "TimedTrafficLights.HandleNewSegments: Failed to add segment " +
-                                $"{segmentId} @ start {startNode} to node {NodeId}");
+                            if (logTrafficLights) {
+                                Log.Warning(
+                                    "TimedTrafficLights.HandleNewSegments: Failed to add segment " +
+                                    $"{segmentId} @ start {startNode} to node {NodeId}");
+                            }
                         }
                     } else {
                         // reuse old lights
@@ -1085,9 +1086,9 @@ namespace TrafficManager.TrafficLight.Impl {
             ref NetSegment netSegment = ref segmentId.ToSegment();
 
             if (!netSegment.IsValid()) {
-                Log.ErrorIf(
-                    cond: logTrafficLights,
-                    formatFn: () => $"TimedTrafficLights.ChangeLightMode: Segment {segmentId} is invalid");
+                if (logTrafficLights) {
+                    Log.Error($"TimedTrafficLights.ChangeLightMode: Segment {segmentId} is invalid");
+                }
 
                 return;
             }
@@ -1317,10 +1318,11 @@ namespace TrafficManager.TrafficLight.Impl {
                 if (end != null) {
                     segmentEndIds.Add(end);
                 } else {
-                    Log.WarningIf(
-                        logTrafficLights,
-                        () => "TimedTrafficLights.UpdateSegmentEnds: Failed to add segment end " +
+                    if (logTrafficLights) {
+                    Log.Warning(
+                        "TimedTrafficLights.UpdateSegmentEnds: Failed to add segment end " +
                         $"{segmentId} @ {startNode} to node {NodeId}: GetOrAddSegmentEnd returned null.");
+                    }
                 }
             }
 

--- a/TLM/TLM/TrafficLight/Impl/TimedTrafficLightsStep.cs
+++ b/TLM/TLM/TrafficLight/Impl/TimedTrafficLightsStep.cs
@@ -391,10 +391,10 @@ namespace TrafficManager.TrafficLight.Impl {
                     if (!nextStep.CustomSegmentLights.TryGetValue(
                             segmentId,
                             out CustomSegmentLights nextStepSegmentLights)) {
-                        Log.WarningIf(
-                            logTrafficLights,
-                            () => "TimedTrafficLightsStep: nextStep does not contain lights for " +
-                            $"segment {segmentId}!");
+                        if (logTrafficLights) {
+                            Log.Warning("TimedTrafficLightsStep: nextStep does not contain lights for " +
+                                    $"segment {segmentId}!");
+                        }
                         continue;
                     }
 
@@ -770,9 +770,9 @@ namespace TrafficManager.TrafficLight.Impl {
 #else
             const bool logTrafficLights = false;
 #endif
-            Log.WarningIf(
-                logTrafficLights,
-                () => $"calcWaitFlow: called for node {timedNode.NodeId} @ step {stepRefIndex}");
+            if (logTrafficLights) {
+                Log.Warning($"calcWaitFlow: called for node {timedNode.NodeId} @ step {stepRefIndex}");
+            }
 
             // TODO checking against getCurrentFrame() is only valid if this is the current step
             // during start phase all vehicles on "green" segments are counted as flowing

--- a/TLM/TLM/U/Autosize/UResizerConfig.cs
+++ b/TLM/TLM/U/Autosize/UResizerConfig.cs
@@ -91,9 +91,9 @@ namespace TrafficManager.U.Autosize {
                         resizerConfig.onResize_(resizer);
                     }
                     catch (Exception e) {
-                        Log.ErrorIf(
-                            cond: logUEvents,
-                            formatFn: () => $"While calling OnResize on {control.name}: {e}");
+                        if (logUEvents) {
+                            Log.Error($"While calling OnResize on {control.name}: {e}");
+                        }
                     }
                 }
 

--- a/TLM/TLM/UI/TrafficManagerTool.cs
+++ b/TLM/TLM/UI/TrafficManagerTool.cs
@@ -719,15 +719,7 @@ namespace TrafficManager.UI {
                         RoadSelectionUtil.SetRoad(HoveredSegmentId, segmentList);
                     }
 
-                    InstanceID instanceID = new InstanceID {
-                        NetSegment = HoveredSegmentId,
-                    };
-
-                    SimulationManager.instance.m_ThreadingWrapper.QueueMainThread(() => {
-                        OpenWorldInfoPanel(
-                            instanceID,
-                            HitPos);
-                    });
+                    OpenWorldInfoPanel(new InstanceID { NetSegment = HoveredSegmentId }, HitPos);
                 }
             } else if (SelectedNodeId != 0 && KeybindSettingsBase.RestoreDefaultsKey.KeyDown(e)) {
                 ushort nodeId = SelectedNodeId;

--- a/TLM/TLM/Util/Shortcuts.cs
+++ b/TLM/TLM/Util/Shortcuts.cs
@@ -116,13 +116,13 @@ namespace TrafficManager.Util {
         internal static string ToSTR(this List<LanePos> laneList) =>
             (from lanePos in laneList select lanePos.laneId).ToSTR();
 
-        internal static void AssertEq<T>(T a, T b, string m = "") where T : IComparable {
+        internal static void AssertEq<T>(T a, T b, string m = "") where T : IComparable<T> {
             if (a.CompareTo(b) != 0) {
                 Log.Error($"Assertion failed. Expected {a} == {b} | " + m);
             }
         }
 
-        internal static void AssertNEq<T>(T a, T b, string m = "") where T : IComparable {
+        internal static void AssertNEq<T>(T a, T b, string m = "") where T : IComparable<T> {
             if (a.CompareTo(b) == 0) {
                 Log.Error($"Assertion failed. Expected {a} != {b} | " + m);
             }
@@ -146,7 +146,7 @@ namespace TrafficManager.Util {
         /// <exception cref="ArgumentException">
         /// Thrown if <typeparamref name="T"/> is not some kind of <see cref="Enum"/>.
         /// </exception>
-        internal static void AssertNotNone<T>(T value, string m = "") {
+        internal static void AssertNotNone<T>(T value, string m = "") where T: IEquatable<T> {
             if (!typeof(T).IsEnum)
                 throw new ArgumentException($"Type '{typeof(T).FullName}' is not an enum");
 
@@ -163,10 +163,12 @@ namespace TrafficManager.Util {
         }
 
         internal static void LogException(this Exception ex, bool showInPanel = false) {
-            if (ex is null)
+            if (ex is null) {
                 Log.Error("null argument ex was passed to Log.Exception()");
+                return;
+            }
             try {
-                Log.Error(ex.ToString() + "\n\t===================="); // stack trace is printed after this.
+                Log.Error(ex + "\n\t===================="); // stack trace is printed after this.
                 UnityEngine.Debug.LogException(ex);
                 if (showInPanel)
                     UIView.ForwardException(ex);


### PR DESCRIPTION

- delete `Release` conditional Log methods that create garbage regardless of condition
- replace garbage generating calls with garbage free alternatives, use `PoolList<T>` where applicable
- refactor delegates capturing method variables either by removing delegate or forcing delegate instantiation to last moment
- correct `Assertion` type to avoid boxing, fix possible `NullReferenceException` while logging an `Exception` 😂 
- skip queuing notify actions if there's no listeners in the `Notifier` class. Avoids creating useless `Simulation Action` and also eliminates garbage that would be generated by instantiating objects args and `Action` delegate itself 

### Important note after checking compiled code in `Release` target
Debug guarded calls with lambdas or delegates capturing local variable (`debugOverlay` in `UpdatePathTargetPositionsPatch.cs` captures Bezier3 variable) can still trigger generation of `<>DisplayClass` helper classes, and most importantly use the instance of helper class to move captured variable around **even if debug guarded code is not used explicitly anywhere in the method**.

### Other notes
Lambda/Delegate capturing **local variable** generates `<>DisplayClass` which instance in most cases is created in the first line of the method, regardless of where it be actually used, so compiler will generate instantiation code just for passing captured value around, even if you guard the explicit call with multiple conditions, including `const`.

### TODO for the future PR
_Redesign `SegmentTraverser` and `SegmentLaneTraverser`_ since currently they are multi-level garbage generators with lambdas capturing other lambdas, capturing local variables, not to mention that one runs recursively.
Used on the main thread, mostly for displaying mod overlays like clickable Speed limits signs handles, Parking restrictions etc.

Build [ZIP](https://ci.appveyor.com/api/projects/krzychu124/tmpe/artifacts/TMPE.zip?branch=bugfix/eliminate-memory-pressure-hot-path)