### PR TITLE
What's new 11.7.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,30 @@ This changelog includes all versions and major variants of the mod going all the
 
 > Date format: dd/mm/yyyy
 
+#### TM:PE V[11.7.4.0](https://github.com/CitiesSkylinesMods/TMPE/compare/11.7.3.0...11.7.3.1) STABLE, 22/03/2022
+
+- [Meta] Compatibility patch for the game update 1.16.1-f2
+- [New] Prevent the user from setting invalid Lane Arrows, update arrows if lane connections exist #368, #1724 (krzychu124)
+- [Fixed] Mouse wheel scroll is changing values if dropdown popup is closed #1733 (krzychu124)
+- [Fixed] Building Color change performance improvements #1725 (krzychu124)
+- [Fixed] Reduced memory pressure/garbage generation in simulation critical paths #1731 (krzychu124)
+- [Updated] Translation update for Arabic, Czech, English, French, Indonesian Italian, Korean, Polish, Portuguese, Romanian, Spanish, Thai, Turkish and Ukrainian
+- [Updated] Minor improvements in storing mod default values #1702 (kianzarrin)
+- [Mod] Improved compatibility with More Path Units
+- [Steam] [TM:PE v11 STABLE](https://steamcommunity.com/sharedfiles/filedetails/?id=1637663252)
+
+#### TM:PE V11.7.4.0 TEST, 22/03/2022
+
+- [Meta] Compatibility patch for the game update 1.16.1-f2
+- [New] Prevent the user from setting invalid Lane Arrows, update arrows if lane connections exist #368, #1724 (krzychu124)
+- [Fixed] Mouse wheel scroll is changing values if dropdown popup is closed #1733 (krzychu124)
+- [Fixed] Building Color change performance improvements #1725 (krzychu124)
+- [Fixed] Reduced memory pressure/garbage generation in simulation critical paths #1731 (krzychu124)
+- [Updated] Translation update for Arabic, Czech, English, French, Indonesian Italian, Korean, Polish, Portuguese, Romanian, Spanish, Thai, Turkish and Ukrainian
+- [Updated] Minor improvements in storing mod default values #1702 (kianzarrin)
+- [Mod] Improved compatibility with More Path Units
+- [Steam] [TM:PE v11 TEST](https://steamcommunity.com/sharedfiles/filedetails/?id=2489276785)
+
 #### TM:PE V[11.7.3.1](https://github.com/CitiesSkylinesMods/TMPE/compare/11.7.3.0...11.7.3.1) STABLE, 23/12/2022
 
 - [Fixed] Partial detection of Bank vans as service vehicles (krzychu124)

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
     <a href="https://github.com/CitiesSkylinesMods/TMPE/wiki/Report-a-Bug">Report a Bug</a><br />
 </p>
 <p align="center">
-    <a href="https://store.steampowered.com/app/255710/Cities_Skylines/"><img src="https://img.shields.io/static/v1?label=cities:%20skylines&message=v1.16.0-f3&color=01ABF8&logo=unity" /></a>
+    <a href="https://store.steampowered.com/app/255710/Cities_Skylines/"><img src="https://img.shields.io/static/v1?label=cities:%20skylines&message=v1.16.1-f2&color=01ABF8&logo=unity" /></a>
     <a href="https://steamcommunity.com/sharedfiles/filedetails/?id=1637663252"><img src="https://img.shields.io/github/v/release/CitiesSkylinesMods/TMPE?label=stable&color=7cc17b&logo=steam&logoColor=F5F5F5" /></a>
     <a href="https://steamcommunity.com/sharedfiles/filedetails/?id=2489276785"><img src="https://img.shields.io/github/v/release/CitiesSkylinesMods/TMPE?include_prereleases&label=test&color=f7b73c&logo=steam&logoColor=F5F5F5" /></a>
     <a href="https://github.com/CitiesSkylinesMods/TMPE/releases/latest"><img src="https://img.shields.io/github/v/release/CitiesSkylinesMods/TMPE?label=origin&color=F56C2D&logo=origin&logoColor=F56C2D" /></a>
@@ -29,6 +29,7 @@
 * Other problems? See: [Troubleshooting Guide](https://github.com/CitiesSkylinesMods/TMPE/wiki/Troubleshooting)
 
 ## Releases
+
 
 - [TM:PE v11 STABLE](https://steamcommunity.com/sharedfiles/filedetails/?id=1637663252) (fully tested releases)
 - [TM:PE v11 TEST](https://steamcommunity.com/sharedfiles/filedetails/?id=2489276785) (latest beta test releases)

--- a/TLM/SharedAssemblyInfo.cs
+++ b/TLM/SharedAssemblyInfo.cs
@@ -20,4 +20,4 @@ using System.Runtime.InteropServices;
 //      Minor Version
 //      Build Number
 //      Revision
-[assembly: AssemblyVersion("11.7.3.*")]
+[assembly: AssemblyVersion("11.7.4.*")]

--- a/TLM/TLM/Manager/Impl/AdvancedParkingManager.cs
+++ b/TLM/TLM/Manager/Impl/AdvancedParkingManager.cs
@@ -1952,6 +1952,7 @@ namespace TrafficManager.Manager.Impl {
                         false,
                         false,
                         GlobalConfig.Instance.ParkingAI.MaxBuildingToPedestrianLaneDistance,
+                        false,
                         out endPathPos)) {
                         calculateEndPos = false;
                     }

--- a/TLM/TLM/Manager/Impl/ExtCitizenInstanceManager.cs
+++ b/TLM/TLM/Manager/Impl/ExtCitizenInstanceManager.cs
@@ -927,6 +927,7 @@ namespace TrafficManager.Manager.Impl {
                     false,
                     false,
                     parkingAiConf.MaxBuildingToPedestrianLaneDistance,
+                    false,
                     out parkedVehiclePathPos);
             }
 
@@ -977,6 +978,7 @@ namespace TrafficManager.Manager.Impl {
                     allowUnderground,
                     false,
                     parkingAiConf.MaxBuildingToPedestrianLaneDistance,
+                    false,
                     out startPosA);
             } else {
                 foundStartPos = FindPathPosition(
@@ -1152,6 +1154,7 @@ namespace TrafficManager.Manager.Impl {
                     SavedGameOptions.Instance.parkingAI
                         ? GlobalConfig.Instance.ParkingAI.MaxBuildingToPedestrianLaneDistance
                         : 32f,
+                    false,
                     out PathUnit.Position posA,
                     out PathUnit.Position posB,
                     out float distA,
@@ -1171,6 +1174,7 @@ namespace TrafficManager.Manager.Impl {
                     SavedGameOptions.Instance.parkingAI
                         ? GlobalConfig.Instance.ParkingAI.MaxBuildingToPedestrianLaneDistance
                         : 32f,
+                    false,
                     out posA,
                     out posB,
                     out distA,
@@ -1191,6 +1195,7 @@ namespace TrafficManager.Manager.Impl {
                     SavedGameOptions.Instance.parkingAI
                         ? GlobalConfig.Instance.ParkingAI.MaxBuildingToPedestrianLaneDistance
                         : 32f,
+                    false,
                     out posA,
                     out posB,
                     out distA,

--- a/TLM/TLM/Manager/Impl/ExtPathManager.cs
+++ b/TLM/TLM/Manager/Impl/ExtPathManager.cs
@@ -58,6 +58,7 @@ namespace TrafficManager.Manager.Impl {
                     maxDistance: SavedGameOptions.Instance.parkingAI
                                      ? GlobalConfig.Instance.ParkingAI.MaxBuildingToPedestrianLaneDistance
                                      : 32f,
+                    excludeLaneWidth: false,
                     pathPosA: out PathUnit.Position posA,
                     pathPosB: out _,
                     distanceSqrA: out float distA,
@@ -78,6 +79,7 @@ namespace TrafficManager.Manager.Impl {
                     SavedGameOptions.Instance.parkingAI
                         ? GlobalConfig.Instance.ParkingAI.MaxBuildingToPedestrianLaneDistance
                         : 32f,
+                    false,
                     out posA,
                     out _,
                     out distA,
@@ -99,6 +101,7 @@ namespace TrafficManager.Manager.Impl {
                         ? GlobalConfig
                           .Instance.ParkingAI.MaxBuildingToPedestrianLaneDistance
                         : 32f,
+                    false,
                     out posA,
                     out _,
                     out distA,
@@ -118,6 +121,7 @@ namespace TrafficManager.Manager.Impl {
                                                    bool allowUnderground,
                                                    bool requireConnect,
                                                    float maxDistance,
+                                                   bool excludeLaneWidth,
                                                    out PathUnit.Position pathPos) {
             return FindPathPositionWithSpiralLoop(
                 position,
@@ -130,6 +134,7 @@ namespace TrafficManager.Manager.Impl {
                 allowUnderground,
                 requireConnect,
                 maxDistance,
+                excludeLaneWidth,
                 out pathPos);
         }
 
@@ -143,6 +148,7 @@ namespace TrafficManager.Manager.Impl {
                                                    bool allowUnderground,
                                                    bool requireConnect,
                                                    float maxDistance,
+                                                   bool excludeLaneWidth,
                                                    out PathUnit.Position pathPos) {
             return FindPathPositionWithSpiralLoop(
                 position,
@@ -156,6 +162,7 @@ namespace TrafficManager.Manager.Impl {
                 allowUnderground,
                 requireConnect,
                 maxDistance,
+                excludeLaneWidth,
                 out pathPos);
         }
 
@@ -169,6 +176,7 @@ namespace TrafficManager.Manager.Impl {
                                                    bool allowUnderground,
                                                    bool requireConnect,
                                                    float maxDistance,
+                                                   bool excludeLaneWidth,
                                                    out PathUnit.Position pathPos) {
             return FindPathPositionWithSpiralLoop(
                 position,
@@ -183,6 +191,7 @@ namespace TrafficManager.Manager.Impl {
                 allowUnderground,
                 requireConnect,
                 maxDistance,
+                excludeLaneWidth,
                 out pathPos,
                 out PathUnit.Position _,
                 out float _,
@@ -200,6 +209,7 @@ namespace TrafficManager.Manager.Impl {
                                                    bool allowUnderground,
                                                    bool requireConnect,
                                                    float maxDistance,
+                                                   bool excludeLaneWidth,
                                                    out PathUnit.Position pathPos
             ) {
             return FindPathPositionWithSpiralLoop(
@@ -215,6 +225,7 @@ namespace TrafficManager.Manager.Impl {
                 allowUnderground,
                 requireConnect,
                 maxDistance,
+                excludeLaneWidth,
                 out pathPos,
                 out PathUnit.Position _,
                 out float _,
@@ -230,6 +241,7 @@ namespace TrafficManager.Manager.Impl {
                                                    bool allowUnderground,
                                                    bool requireConnect,
                                                    float maxDistance,
+                                                   bool excludeLaneWidth,
                                                    out PathUnit.Position pathPosA,
                                                    out PathUnit.Position pathPosB,
                                                    out float distanceSqrA,
@@ -245,6 +257,7 @@ namespace TrafficManager.Manager.Impl {
                 allowUnderground,
                 requireConnect,
                 maxDistance,
+                excludeLaneWidth,
                 out pathPosA,
                 out pathPosB,
                 out distanceSqrA,
@@ -261,6 +274,7 @@ namespace TrafficManager.Manager.Impl {
                                                    bool allowUnderground,
                                                    bool requireConnect,
                                                    float maxDistance,
+                                                   bool excludeLaneWidth,
                                                    out PathUnit.Position pathPosA,
                                                    out PathUnit.Position pathPosB,
                                                    out float distanceSqrA,
@@ -278,6 +292,7 @@ namespace TrafficManager.Manager.Impl {
                 allowUnderground,
                 requireConnect,
                 maxDistance,
+                excludeLaneWidth,
                 out pathPosA,
                 out pathPosB,
                 out distanceSqrA,
@@ -294,6 +309,7 @@ namespace TrafficManager.Manager.Impl {
                                                    bool allowUnderground,
                                                    bool requireConnect,
                                                    float maxDistance,
+                                                   bool excludeLaneWidth,
                                                    out PathUnit.Position pathPosA,
                                                    out PathUnit.Position pathPosB,
                                                    out float distanceSqrA,
@@ -311,6 +327,7 @@ namespace TrafficManager.Manager.Impl {
                 allowUnderground,
                 requireConnect,
                 maxDistance,
+                excludeLaneWidth,
                 out pathPosA,
                 out pathPosB,
                 out distanceSqrA,
@@ -329,6 +346,7 @@ namespace TrafficManager.Manager.Impl {
                                                    bool allowUnderground,
                                                    bool requireConnect,
                                                    float maxDistance,
+                                                   bool excludeLaneWidth,
                                                    out PathUnit.Position pathPosA,
                                                    out PathUnit.Position pathPosB,
                                                    out float distanceSqrA,
@@ -456,6 +474,11 @@ namespace TrafficManager.Manager.Impl {
                                 out float laneOffsetB))
                             {
                                 float dist = Vector3.SqrMagnitude(position - posA);
+                                if (excludeLaneWidth)
+                                {
+                                    dist = Mathf.Max(0f, Mathf.Sqrt(dist) - segmentInfo.m_lanes[laneIndexA].m_width * 0.5f);
+                                    dist *= dist;
+                                }
                                 if (secondaryPosition.HasValue) {
                                     dist += Vector3.SqrMagnitude(secondaryPosition.Value - posA);
                                 }
@@ -473,6 +496,11 @@ namespace TrafficManager.Manager.Impl {
                                     myDistanceSqrA = dist;
 
                                     dist = Vector3.SqrMagnitude(position - posB);
+                                    if (excludeLaneWidth)
+                                    {
+                                        dist = Mathf.Max(0f, Mathf.Sqrt(dist) - segmentInfo.m_lanes[laneIndexA].m_width * 0.5f);
+                                        dist *= dist;
+                                    }
                                     if (secondaryPosition.HasValue) {
                                         dist += Vector3.SqrMagnitude(
                                             secondaryPosition.Value - posB);

--- a/TLM/TLM/Manager/Impl/LaneConnection/LaneConnectionSubManager.cs
+++ b/TLM/TLM/Manager/Impl/LaneConnection/LaneConnectionSubManager.cs
@@ -303,6 +303,9 @@ namespace TrafficManager.Manager.Impl.LaneConnection {
 
             for (int i = 0; i < 8; ++i) {
                 ushort segmentId = node.GetSegment(i);
+                if (segmentId == 0)
+                    continue;
+
                 RoutingManager.Instance.RequestRecalculation(segmentId);
                 if (TMPELifecycle.Instance.MayPublishSegmentChanges()) {
                     ExtSegmentManager.Instance.PublishSegmentChanges(segmentId);

--- a/TLM/TLM/Manager/Impl/VehicleBehaviorManager.cs
+++ b/TLM/TLM/Manager/Impl/VehicleBehaviorManager.cs
@@ -897,6 +897,7 @@ namespace TrafficManager.Manager.Impl {
                     allowUnderground,
                     false,
                     32f,
+                    false,
                     out startPosA,
                     out startPosB,
                     out sqrDistA,

--- a/TLM/TLM/Patch/_CitizenAI/_TouristAI/Connection/TouristAIConnection.cs
+++ b/TLM/TLM/Patch/_CitizenAI/_TouristAI/Connection/TouristAIConnection.cs
@@ -2,7 +2,7 @@ namespace TrafficManager.Patch._CitizenAI._TouristAI.Connection {
     using System;
     using UnityEngine;
 
-    public delegate int GetTaxiProbabilityDelegate(TouristAI instance);
+    public delegate int GetTaxiProbabilityDelegate(TouristAI instance, ushort instanceID, ref CitizenInstance citizenData);
     public delegate int GetBikeProbabilityDelegate(TouristAI instance);
     public delegate int GetCarProbabilityDelegate(TouristAI instance, Vector3 position);
     public delegate int GetElectricCarProbabilityDelegate(TouristAI instance, Citizen.Wealth wealth);

--- a/TLM/TLM/Patch/_CitizenAI/_TouristAI/GetVehicleInfoPatch.cs
+++ b/TLM/TLM/Patch/_CitizenAI/_TouristAI/GetVehicleInfoPatch.cs
@@ -95,7 +95,7 @@ namespace TrafficManager.Patch._CitizenAI._TouristAI {
             } else {
                 carProb = GetCarProbability(__instance, citizenData.m_frame1.m_position);
                 bikeProb = GetBikeProbability(__instance);
-                taxiProb = GetTaxiProbability(__instance);
+                taxiProb = GetTaxiProbability(__instance, instanceID, ref citizenData);
             }
 
             Randomizer randomizer = new Randomizer(citizenData.m_citizen);

--- a/TLM/TLM/Resources/whats_new.txt
+++ b/TLM/TLM/Resources/whats_new.txt
@@ -1,6 +1,13 @@
-[Version] 11.7.3.1
-[Released] Dec 23th 2022
-[Link] tmpe-v11731-stable-23122022
+[Version] 11.7.4.0
+[Released] Mar 22nd 2023
+[Link] tmpe-v11740-stable-22032023
 [Stable]
-[Fixed] Partial detection of Bank vans as service vehicle
+[Meta] Compatibility patch for the game update 1.16.1-f2
+[New] Prevent the user from setting invalid Lane Arrows, update arrows if lane connections exist #368 #1724 (krzychu124)
+[Fixed] Mouse wheel scroll is changing values if dropdown popup is closed #1733 (krzychu124)
+[Fixed] Building Color change performance improvements #1725 (krzychu124)
+[Fixed] Reduced memory pressure/garbage generation in simulation critical paths #1731 (krzychu124)
+[Updated] Translation update for Arabic, Czech, English, French, Indonesian Italian, Korean, Polish, Portuguese, Romanian, Spanish, Thai, Turkish and Ukrainian
+[Updated] Minor improvements in storing mod default values #1702 (kianzarrin)
+[Mod] Improved compatibility with More Path Units
 [/Version]

--- a/TLM/TLM/UI/WhatsNew/WhatsNew.cs
+++ b/TLM/TLM/UI/WhatsNew/WhatsNew.cs
@@ -11,7 +11,7 @@ namespace TrafficManager.UI.WhatsNew {
 
     public class WhatsNew {
         // bump and update what's new changelogs when new features added
-        public static readonly Version CurrentVersion = new Version(11,7,3,1);
+        public static readonly Version CurrentVersion = new Version(11,7,4,0);
 
         private const string WHATS_NEW_FILE = "whats_new.txt";
         private const string RESOURCES_PREFIX = "TrafficManager.Resources.";

--- a/TLM/TLM/Util/Extensions/NetSegmentExtensions.cs
+++ b/TLM/TLM/Util/Extensions/NetSegmentExtensions.cs
@@ -170,8 +170,8 @@ namespace TrafficManager.Util.Extensions {
             VehicleInfo.VehicleType vehicleType) {
 
 #if DEBUG
-            AssertNotNone(laneType, nameof(laneType));
-            AssertNotNone(vehicleType, nameof(vehicleType));
+            // AssertNotNone(laneType, nameof(laneType));
+            // AssertNotNone(vehicleType, nameof(vehicleType));
 #endif
 
             NetInfo segmentInfo = netSegment.Info;

--- a/TLM/TLM/Util/VersionUtil.cs
+++ b/TLM/TLM/Util/VersionUtil.cs
@@ -35,10 +35,10 @@ namespace TrafficManager.Util {
         // we could alternatively use BuildConfig.APPLICATION_VERSION because const values are evaluated at compile time.
         // but I have decided not to do this because I don't want this to happen automatically with a rebuild if
         // CS updates. these values should be changed manually so as to force us to acknowledge that they have changed.
-        public const uint EXPECTED_GAME_VERSION_U = 201450256U;
+        public const uint EXPECTED_GAME_VERSION_U = 201581072U;
 
         // see comments for EXPECTED_GAME_VERSION_U.
-        public static Version ExpectedGameVersion => new Version(1, 16, 0, 3);
+        public static Version ExpectedGameVersion => new Version(1, 16, 1, 2);
 
         public static string ExpectedGameVersionString => BuildConfig.VersionToString(EXPECTED_GAME_VERSION_U, false);
 

--- a/TLM/TMPE.API/Manager/IExtPathManager.cs
+++ b/TLM/TMPE.API/Manager/IExtPathManager.cs
@@ -16,6 +16,7 @@
                                             bool allowUnderground,
                                             bool requireConnect,
                                             float maxDistance,
+                                            bool excludeLaneWidth,
                                             out PathUnit.Position pathPos);
         bool FindPathPositionWithSpiralLoop(Vector3 position,
                                             ItemClass.Service service,
@@ -27,6 +28,7 @@
                                             bool allowUnderground,
                                             bool requireConnect,
                                             float maxDistance,
+                                            bool excludeLaneWidth,
                                             out PathUnit.Position pathPos);
 
         bool FindPathPositionWithSpiralLoop(Vector3 position,
@@ -39,6 +41,7 @@
                                             bool allowUnderground,
                                             bool requireConnect,
                                             float maxDistance,
+                                            bool excludeLaneWidth,
                                             out PathUnit.Position pathPos);
 
         bool FindPathPositionWithSpiralLoop(Vector3 position,
@@ -52,6 +55,7 @@
                                             bool allowUnderground,
                                             bool requireConnect,
                                             float maxDistance,
+                                            bool excludeLaneWidth,
                                             out PathUnit.Position pathPos);
 
         bool FindPathPositionWithSpiralLoop(Vector3 position,
@@ -63,6 +67,7 @@
                                             bool allowUnderground,
                                             bool requireConnect,
                                             float maxDistance,
+                                            bool excludeLaneWidth,
                                             out PathUnit.Position pathPosA,
                                             out PathUnit.Position pathPosB,
                                             out float distanceSqrA,
@@ -78,6 +83,7 @@
                                             bool allowUnderground,
                                             bool requireConnect,
                                             float maxDistance,
+                                            bool excludeLaneWidth,
                                             out PathUnit.Position pathPosA,
                                             out PathUnit.Position pathPosB,
                                             out float distanceSqrA,
@@ -93,6 +99,7 @@
                                             bool allowUnderground,
                                             bool requireConnect,
                                             float maxDistance,
+                                            bool excludeLaneWidth,
                                             out PathUnit.Position pathPosA,
                                             out PathUnit.Position pathPosB,
                                             out float distanceSqrA,
@@ -110,6 +117,7 @@
                                             bool allowUnderground,
                                             bool requireConnect,
                                             float maxDistance,
+                                            bool excludeLaneWidth,
                                             out PathUnit.Position pathPosA,
                                             out PathUnit.Position pathPosB,
                                             out float distanceSqrA,


### PR DESCRIPTION
**Compatibility patch for the game update 1.16.1-f2**

_New_
- Prevent the user from setting invalid Lane Arrows, update arrows if lane connections exist #368, #1724
- Mouse wheel scroll is changing values if dropdown popup is closed #1733

_Fixed_
- Building Color change performance improvements #1725
- Reduced memory pressure/garbage generation in simulation critical paths #1731

_Updated_
- Translation update for Arabic, Czech, English, French, Indonesian Italian, Korean, Polish, Portuguese, Romanian, Spanish, Thai, Turkish and Ukrainian
- Minor improvements in storing mod default values #1702

_Other_
- Improved compatibility with More Path Units


_Already released to the Steam Workshop_