### PR TITLE
Incorrect citizen influx on the City Statistics window

### DIFF
--- a/TLM/TLM/Patch/_CitizenAI/_HumanAI/SimulationStepPatch.cs
+++ b/TLM/TLM/Patch/_CitizenAI/_HumanAI/SimulationStepPatch.cs
@@ -141,18 +141,6 @@ namespace TrafficManager.Patch._CitizenAI._HumanAI {
                                                   | CitizenInstance.Flags.SittingDown
                                                   | CitizenInstance.Flags.Cheering);
 
-                        // NON-STOCK CODE START (transferred from ResidentAI.PathfindSuccess)
-                        const Citizen.Flags CTZ_MASK = Citizen.Flags.Tourist
-                                                       | Citizen.Flags.MovingIn
-                                                       | Citizen.Flags.DummyTraffic;
-                        if (citizenId != 0 && (citizen.m_flags & CTZ_MASK) == Citizen.Flags.MovingIn)
-                        {
-                            StatisticBase statisticBase = Singleton<StatisticsManager>
-                                                .instance.Acquire<StatisticInt32>(StatisticType.MoveRate);
-                            statisticBase.Add(1);
-                        }
-
-                        // NON-STOCK CODE END
                         PathfindSuccess(__instance, instanceID, ref data);
                         break;
                     }


### PR DESCRIPTION

Removed code is not necessary and shouldn't be there since below `PathfindSuccess` call will do exactly the same for `ResidentAI` which ends up on a duplicate of `Moving-in` citizens displayed on the City Statistics window.

**It doesn't affect any simulation data or behavior, generates incorrect plot for `Influx` category**

Build [ZIP](https://ci.appveyor.com/api/projects/krzychu124/tmpe/artifacts/TMPE.zip?branch=bugfix/incorrect-infux-stats)