### PR TITLE
What's new 11.9.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,11 +32,23 @@ This changelog includes all versions and major variants of the mod going all the
 #### TM:PE V[11.9.2.0](https://github.com/CitiesSkylinesMods/TMPE/compare/11.9.1.0...11.9.2.0) STABLE, 24/09/2025
 
 - [Meta] Internal version check compatible with 1.20.1-f1
+- [Meta] Short segment detection improvements are available only at Very High Simulation Accuracy setting, since they may affect performance #1759, #1730, #1229
+- [Fixed] Detecting traffic light state when vehicle is approaching short segments with traffic lights #1759, #1730, #1229
+- [Fixed] Very inaccurate priority detection when vehicle is approaching short segments (current or adjacent) #1730, #1229
+- [Fixed] Slightly reduced memory footprint of API structs #1732
+- [Updated] Changed location of despawn button in vehicle info popup #1781
+- [Updated] Changed mod log file location on macOS to avoid TargetInvocationException. Mod log (TMPE.log) is saved in the same location as the game log (Player.log) #1780, #1776, #1741
 - [Steam] [TM:PE v11 STABLE](https://steamcommunity.com/sharedfiles/filedetails/?id=1637663252)
 
 #### TM:PE V11.9.2.0 TEST, 24/09/2025
 
 - [Meta] Internal version check compatible with 1.20.1-f1
+- [Meta] Short segment detection improvements are available only at Very High Simulation Accuracy setting, since they may affect performance #1759, #1730, #1229
+- [Fixed] Detecting traffic light state when vehicle is approaching short segments with traffic lights #1759, #1730, #1229
+- [Fixed] Very inaccurate priority detection when vehicle is approaching short segments (current or adjacent) #1730, #1229
+- [Fixed] Slightly reduced memory footprint of API structs #1732
+- [Updated] Changed location of despawn button in vehicle info popup #1781
+- [Updated] Changed mod log file location on macOS to avoid TargetInvocationException. Mod log (TMPE.log) is saved in the same location as the game log (Player.log) #1780, #1776, #1741
 - [Steam] [TM:PE v11 TEST](https://steamcommunity.com/sharedfiles/filedetails/?id=2489276785)
 
 #### TM:PE V[11.9.1.0](https://github.com/CitiesSkylinesMods/TMPE/compare/11.9.0.0...11.9.1.0) STABLE, 25/03/2025

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,16 @@ This changelog includes all versions and major variants of the mod going all the
 
 > Date format: dd/mm/yyyy
 
+#### TM:PE V[11.9.2.0](https://github.com/CitiesSkylinesMods/TMPE/compare/11.9.1.0...11.9.2.0) STABLE, 24/09/2025
+
+- [Meta] Internal version check compatible with 1.20.1-f1
+- [Steam] [TM:PE v11 STABLE](https://steamcommunity.com/sharedfiles/filedetails/?id=1637663252)
+
+#### TM:PE V11.9.2.0 TEST, 24/09/2025
+
+- [Meta] Internal version check compatible with 1.20.1-f1
+- [Steam] [TM:PE v11 TEST](https://steamcommunity.com/sharedfiles/filedetails/?id=2489276785)
+
 #### TM:PE V[11.9.1.0](https://github.com/CitiesSkylinesMods/TMPE/compare/11.9.0.0...11.9.1.0) STABLE, 25/03/2025
 
 - [Meta] Internal version check compatible with 1.19.2-f3

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
     <a href="https://github.com/CitiesSkylinesMods/TMPE/wiki/Report-a-Bug">Report a Bug</a><br />
 </p>
 <p align="center">
-    <a href="https://store.steampowered.com/app/255710/Cities_Skylines/"><img src="https://img.shields.io/static/v1?label=cities:%20skylines&message=v1.19.2-f3&color=01ABF8&logo=unity" /></a>
+    <a href="https://store.steampowered.com/app/255710/Cities_Skylines/"><img src="https://img.shields.io/static/v1?label=cities:%20skylines&message=v1.20.1-f1&color=01ABF8&logo=unity" /></a>
     <a href="https://steamcommunity.com/sharedfiles/filedetails/?id=1637663252"><img src="https://img.shields.io/github/v/release/CitiesSkylinesMods/TMPE?label=stable&color=7cc17b&logo=steam&logoColor=F5F5F5" /></a>
     <a href="https://steamcommunity.com/sharedfiles/filedetails/?id=2489276785"><img src="https://img.shields.io/github/v/release/CitiesSkylinesMods/TMPE?include_prereleases&label=test&color=f7b73c&logo=steam&logoColor=F5F5F5" /></a>
     <a href="https://github.com/CitiesSkylinesMods/TMPE/releases/latest"><img src="https://img.shields.io/github/v/release/CitiesSkylinesMods/TMPE?label=origin&color=F56C2D&logo=origin&logoColor=F56C2D" /></a>

--- a/TLM/CSUtil.Commons/Log.cs
+++ b/TLM/CSUtil.Commons/Log.cs
@@ -55,7 +55,19 @@ namespace CSUtil.Commons {
 
         static Log() {
             try {
-                string dir = Application.dataPath;
+                string dir;
+                if (Application.platform != RuntimePlatform.OSXPlayer) {
+                    dir = Application.dataPath;
+                } else {
+                    dir = Path.Combine(
+                        Path.Combine(
+                            Path.Combine(
+                                Environment.GetFolderPath(Environment.SpecialFolder.Personal),
+                                "Library"),
+                            "Logs"),
+                        "Unity");
+                }
+
                 LogFilePath = Path.Combine(dir, LOG_FILE_NAME);
                 if (File.Exists(LogFilePath)) {
                     File.Delete(LogFilePath); // delete old file to avoid confusion.

--- a/TLM/SharedAssemblyInfo.cs
+++ b/TLM/SharedAssemblyInfo.cs
@@ -20,4 +20,4 @@ using System.Runtime.InteropServices;
 //      Minor Version
 //      Build Number
 //      Revision
-[assembly: AssemblyVersion("11.9.1.*")]
+[assembly: AssemblyVersion("11.9.2.*")]

--- a/TLM/TLM/Resources/whats_new.txt
+++ b/TLM/TLM/Resources/whats_new.txt
@@ -1,6 +1,6 @@
-[Version] 11.9.1.0
-[Released] Mar 25th 2025
-[Link] tmpe-v11910-stable-25032025
+[Version] 11.9.2.0
+[Released] Sep 24th 2025
+[Link] tmpe-v11920-stable-24092025
 [Stable]
-[Meta] Internal version check compatible with 1.19.2-f3
+[Meta] Internal version check compatible with 1.20.1-f1
 [/Version]

--- a/TLM/TLM/Resources/whats_new.txt
+++ b/TLM/TLM/Resources/whats_new.txt
@@ -2,7 +2,11 @@
 [Released] Sep 24th 2025
 [Link] tmpe-v11920-stable-24092025
 [Stable]
+[Updated] Changed location of despawn button in vehicle info popup #1781
+[Updated] Changed mod log file location on macOS to avoid TargetInvocationException. Mod log (TMPE.log) is saved in the same location as the game log (Player.log) #1780, #1776, #1741
+[Fixed] Detecting traffic light state when vehicle is approaching short segments with traffic lights #1759, #1730, #1229
+[Fixed] Very inaccurate priority detection when vehicle is approaching short segments (current or adjacent) #1730, #1229
+[Fixed] Slightly reduced memory footprint of API structs #1732
 [Meta] Internal version check compatible with 1.20.1-f1
-[Updated] Changed location of despawn button in vehicle info popup
-[Updated] Changed mod log file location on macOS to avoid TargetInvocationException
+[Meta] Short segment detection improvements are available only at Very High Simulation Accuracy setting, since they may affect performance #1759, #1730, #1229
 [/Version]

--- a/TLM/TLM/Resources/whats_new.txt
+++ b/TLM/TLM/Resources/whats_new.txt
@@ -4,4 +4,5 @@
 [Stable]
 [Meta] Internal version check compatible with 1.20.1-f1
 [Updated] Changed location of despawn button in vehicle info popup
+[Updated] Changed mod log file location on macOS to avoid TargetInvocationException
 [/Version]

--- a/TLM/TLM/Resources/whats_new.txt
+++ b/TLM/TLM/Resources/whats_new.txt
@@ -3,4 +3,5 @@
 [Link] tmpe-v11920-stable-24092025
 [Stable]
 [Meta] Internal version check compatible with 1.20.1-f1
+[Updated] Changed location of despawn button in vehicle info popup
 [/Version]

--- a/TLM/TLM/UI/RemoveVehicleButtonExtender.cs
+++ b/TLM/TLM/UI/RemoveVehicleButtonExtender.cs
@@ -52,9 +52,15 @@ namespace TrafficManager.UI {
         protected UIButton AddRemoveVehicleButton(WorldInfoPanel panel) {
             UIButton button = new GameObject("RemoveVehicleInstanceButton")
                 .AddComponent<RemoveVehicleButton>();
+            UITextField textField = panel.Find<UITextField>("VehicleName");
+            if (textField && textField.size.x > 220f) {
+                // resize and move VehicleName text field to fit the mod despawn button in the row
+                textField.relativePosition += new Vector3(-12, 0);
+                textField.size += new Vector2(-20, 0);
+            }
 
             button.AlignTo(panel.component, UIAlignAnchor.TopRight);
-            button.relativePosition += new Vector3(-button.width - 55f, 50f);
+            button.relativePosition += new Vector3(-button.width - (4 * 33f), 5f);
 
             Log._Debug($"Added {button} to {panel}");
             return button;
@@ -80,7 +86,7 @@ namespace TrafficManager.UI {
                 this.atlas = futureAtlas.CreateAtlas();
 
                 UpdateButtonSkinAndTooltip();
-                width = height = 30f;
+                width = height = 28f;
             }
 
             public override void HandleClick(UIMouseEventParameter p) {

--- a/TLM/TLM/UI/WhatsNew/WhatsNew.cs
+++ b/TLM/TLM/UI/WhatsNew/WhatsNew.cs
@@ -11,7 +11,7 @@ namespace TrafficManager.UI.WhatsNew {
 
     public class WhatsNew {
         // bump and update what's new changelogs when new features added
-        public static readonly Version CurrentVersion = new Version(11,9,1,0);
+        public static readonly Version CurrentVersion = new Version(11, 9, 2, 0);
 
         private const string WHATS_NEW_FILE = "whats_new.txt";
         private const string RESOURCES_PREFIX = "TrafficManager.Resources.";

--- a/TLM/TLM/Util/VersionUtil.cs
+++ b/TLM/TLM/Util/VersionUtil.cs
@@ -35,10 +35,10 @@ namespace TrafficManager.Util {
         // we could alternatively use BuildConfig.APPLICATION_VERSION because const values are evaluated at compile time.
         // but I have decided not to do this because I don't want this to happen automatically with a rebuild if
         // CS updates. these values should be changed manually so as to force us to acknowledge that they have changed.
-        public const uint EXPECTED_GAME_VERSION_U = 214295312U;
+        public const uint EXPECTED_GAME_VERSION_U = 218358032u;
 
         // see comments for EXPECTED_GAME_VERSION_U.
-        public static Version ExpectedGameVersion => new Version(1, 19, 2, 3);
+        public static Version ExpectedGameVersion => new Version(1, 20, 1, 1);
 
         public static string ExpectedGameVersionString => BuildConfig.VersionToString(EXPECTED_GAME_VERSION_U, false);
 


### PR DESCRIPTION
**Minor fixes and improvements, internal version check compatible with 1.20.1-f1**

_Fixed_
- Detecting traffic light state when vehicle is approaching short segments with traffic lights #1759, #1730, #1229
- Very inaccurate priority detection when vehicle is approaching short segments (current or adjacent) #1730, #1229
- Slightly reduced memory footprint of API structs #1732

_Updated_
- Changed location of despawn button in vehicle info popup #1781
- Changed mod log file location on macOS to avoid `TargetInvocationException`. Mod log (TMPE.log) is saved in the same location as the game log (Player.log) #1780, #1776, #1741

Closes #1781 #1780 #1776 #1741 
